### PR TITLE
Fix to dataproxy backend to allow viewing files with duplicate column title names

### DIFF
--- a/src/backend/dataproxy.js
+++ b/src/backend/dataproxy.js
@@ -56,6 +56,19 @@ this.recline.Backend.DataProxy = this.recline.Backend.DataProxy || {};
         if (results.error) {
           dfd.reject(results.error);
         }
+
+        // Rename duplicate fieldIds as each field name needs to be
+        // unique.
+        var seen = {};
+        _.map(results.fields, function(fieldId, index) {
+          if (fieldId in seen) {
+            seen[fieldId] += 1;
+            results.fields[index] = fieldId + "("+seen[fieldId]+")";
+          } else {
+            seen[fieldId] = 1;
+          }
+        });
+
         dataset.fields.reset(_.map(results.fields, function(fieldId) {
           return {id: fieldId};
           })


### PR DESCRIPTION
By renaming duplicate column names, allow the dataproxy backend
to be used for viewing files where
the column names are not unique.  This occurs, for example, when
more than 1 column has not been given a column title at all.

Prior to this commit, when encountering such a file, the dataproxy
backend would error-out leaving the user without any feedback as
to what went wrong.

Eg, this change allows [1] to be viewed with recline.  Although this
example is a CSV in a non-standard format with field-descriptions
at the head of the file, and so normal recline features may not be
as applicable; I think it's still useful to be able to view the contents
of the file rather than a javascript error being encountered.

[1] http://data.defra.gov.uk/env/wrfg23_wrmsannual_t1_201011.csv
