### PR TITLE
Ability to extend graph options.

### DIFF
--- a/src/view.graph.js
+++ b/src/view.graph.js
@@ -247,7 +247,14 @@ my.Graph = Backbone.View.extend({
       },
       grid: { hoverable: true, clickable: true }
     };
-    return optionsPerGraphType[typeId];
+    
+    if ("graphOptions" in self.state.attributes){
+      return _.extend(optionsPerGraphType[typeId],
+        self.state.attributes.graphOptions  
+      )
+    }else{
+      return optionsPerGraphType[typeId];
+    }
   },
 
   createSeries: function() {


### PR DESCRIPTION
Hi, I was working on a histogram graph, and found no other way to adjust the bad width automatically or some other way, to I added this extend line, which allows to over ride any other graph options that are passed on to flotr2 draw().
