### PR TITLE
[#264] Fix for #264 from ckan-updates branch.

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -499,11 +499,7 @@ my.Query = Backbone.Model.extend({
     var ourfilter = JSON.parse(JSON.stringify(filter));
     // not fully specified so use template and over-write
     if (_.keys(filter).length <= 3) {
-      ourfilter = _.extend(
-        // crude deep copy
-        JSON.parse(JSON.stringify(this._filterTemplates[filter.type])),
-        ourfilter
-      );
+      ourfilter = _.defaults(ourfilter, this._filterTemplates[filter.type]);
     }
     var filters = this.get('filters');
     filters.push(ourfilter);


### PR DESCRIPTION
Uses _.defaults rather than performing an explicit
deep copy.
