### PR TITLE
Bug fix: call view.show after determining sidebar visibility

### DIFF
--- a/src/view.multiview.js
+++ b/src/view.multiview.js
@@ -299,15 +299,13 @@ my.MultiView = Backbone.View.extend({
     this.el.find('.navigation a').removeClass('active');
     var $el = this.el.find('.navigation a[data-view="' + pageName + '"]');
     $el.addClass('active');
-    // show the specific page
+
+    // add/remove sidebars and hide inactive views
     _.each(this.pageViews, function(view, idx) {
       if (view.id === pageName) {
         view.view.el.show();
         if (view.view.elSidebar) {
           view.view.elSidebar.show();
-        }
-        if (view.view.show) {
-          view.view.show();
         }
       } else {
         view.view.el.hide();
@@ -316,6 +314,18 @@ my.MultiView = Backbone.View.extend({
         }
         if (view.view.hide) {
           view.view.hide();
+        }
+      }
+    });
+
+    this._showHideSidebar();
+
+    // call view.view.show after sidebar visibility has been determined so
+    // that views can correctly calculate their maximum width
+    _.each(this.pageViews, function(view, idx) {
+      if (view.id === pageName) {
+        if (view.view.show) {
+          view.view.show();
         }
       }
     });
@@ -333,7 +343,6 @@ my.MultiView = Backbone.View.extend({
     var viewName = $(e.target).attr('data-view');
     this.updateNav(viewName);
     this.state.set({currentView: viewName});
-    this._showHideSidebar();
   },
 
   // create a state object for this view and do the job of


### PR DESCRIPTION
Makes sure that views that need to know their
maximum width before redrawing don't draw over
the sidebar.
