### PR TITLE
Fix issue of tick labels with null in field array (Issue #286)

### DIFF
--- a/src/view.flot.js
+++ b/src/view.flot.js
@@ -191,7 +191,7 @@ my.Flot = Backbone.View.extend({
       // convert x to a string and make sure that it is not too long or the
       // tick labels will overlap
       // TODO: find a more accurate way of calculating the size of tick labels
-      var label = self._xaxisLabel(x);
+      var label = self._xaxisLabel(x) || "";
 
       if (typeof label !== 'string') {
         label = label.toString();


### PR DESCRIPTION
Trying to run label.toString() on null value in tickFormatter results
in error.
