### PR TITLE
Fixes a bug in querystate handling.

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -16,6 +16,7 @@ my.Dataset = Backbone.Model.extend({
 
   // ### initialize
   initialize: function() {
+    var self = this;
     _.bindAll(this, 'query');
     this.backend = null;
     if (this.get('backend')) {
@@ -35,8 +36,9 @@ my.Dataset = Backbone.Model.extend({
     this.facets = new my.FacetList();
     this.recordCount = null;
     this.queryState = new my.Query();
-    this.queryState.bind('change', this.query);
-    this.queryState.bind('facet:add', this.query);
+    this.queryState.bind('change facet:add', function () {
+      self.query(); // We want to call query() without any arguments.
+    });
     // store is what we query and save against
     // store will either be the backend or be a memory store if Backend fetch
     // tells us to use memory store


### PR DESCRIPTION
If dataset.query() receives an argument it expects it to be a querystate object, which is a simple javascript object describing the query parameters. 

However, we were using this function as a callback whenever a `change` event gets fired on the Query object (which is a Model subclass). The first parameter passed to the callback in this case was the changed Query object. The query() method then tried to update the Query using itself, e.g. query.set(query, {silent: true}). This creates a strange recursive object which is hard to serialize!

The solution, I think, is to have an anonymous callback call query() without any parameters.

Fixes okfn/dataexplorer#120.
