### PR TITLE
add method to replace a filter

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -570,7 +570,30 @@ my.Query = Backbone.Model.extend({
     };
     this.set({facets: facets}, {silent: true});
     this.trigger('facet:add', this);
+  },
+  removeFacet: function(fieldId) {
+    var facets = this.get('facets');
+    // Assume id and fieldId should be the same (TODO: this need not be true if we want to add two different type of facets on same field)
+    if (!_.contains(_.keys(facets), fieldId)) {
+      return;
+    }
+    delete facets[fieldId];
+    this.set({facets: facets}, {silent: true});
+    this.trigger('facet:remove', this);
+  },
+  clearFacets: function() {
+    var facets = this.get('facets');
+    _.each(_.keys(facets), function(fieldId) {
+      delete facets[fieldId];
+    });
+    this.trigger('facet:remove', this);
+  },
+  // trigger a facet add; use this to trigger a single event after adding
+  // multiple facets
+  refreshFacets: function() {
+    this.trigger('facet:add', this);
   }
+
 });
 
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -353,6 +353,24 @@ test('Query.addFacet', function () {
   deepEqual({terms: {field: 'xyz', "size": 25}}, query.get('facets')['xyz']);
 });
 
+test('Query.removeFacet', function () {
+  var query = new recline.Model.Query();
+  query.addFacet('xyz');
+  deepEqual({terms: {field: 'xyz'}}, query.get('facets')['xyz']);
+  query.removeFacet('xyz');
+  equal(undefined, query.get('facets')['xyz']);
+});
+
+test('Query.clearFacets', function () {
+  var query = new recline.Model.Query();
+  query.addFacet('abc');
+  query.addFacet('xyz');
+  deepEqual({terms: {field: 'xyz'}}, query.get('facets')['xyz']);
+  deepEqual({terms: {field: 'abc'}}, query.get('facets')['abc']);
+  query.clearFacets();
+  deepEqual({}, query.get('facets'));
+});
+
 test('Query.addFilter', function () {
   var query = new recline.Model.Query();
   query.addFilter({type: 'term', field: 'xyz'});


### PR DESCRIPTION
I've added a replaceFilter method.  I'm using it when I want to change the value of the filter and re-run a query.  If you do a remove and then an add, you get two change events, and two re-queries; I want just one.  

An example of how I'm using it is with a Leaflet map; when the user zooms or moves the map, the bounding box changes so I want to redo a query.  Everything about the query is the same except for the bounding box, so I do this:

```
this.model.queryState.replaceFilter({
  type: "geo_bounding_box",
  field: "location.coord",
  top_left: { "lat" : nw[0], "lon" : nw[1] },
  bottom_right: { "lat" : se[0], "lon" : se[1] },
});
```
