### PR TITLE
Update widget.queryeditor.js

### DIFF
--- a/src/widget.queryeditor.js
+++ b/src/widget.queryeditor.js
@@ -12,7 +12,7 @@ my.QueryEditor = Backbone.View.extend({
     <form action="" method="GET" class="form-inline"> \
       <div class="input-prepend text-query"> \
         <span class="add-on"><i class="icon-search"></i></span> \
-        <input type="text" name="q" value="{{q}}" class="span2" placeholder="Search data ..." class="search-query" /> \
+        <label>Search</label><input type="text" name="q" value="{{q}}" class="span2" placeholder="Search data ..." class="search-query" /> \
       </div> \
       <button type="submit" class="btn">Go &raquo;</button> \
     </form> \


### PR DESCRIPTION
To be 508 compliant all form input fields need to have a label, it can be hidden by css in -> recline/css/multiview.css -> .header .recline-query-editor label { display:none; }
Reference: http://wac.osu.edu/tutorials/section508/forms.htm
