### PR TITLE
Update widget.pager.js

### DIFF
--- a/src/widget.pager.js
+++ b/src/widget.pager.js
@@ -12,7 +12,7 @@ my.Pager = Backbone.View.extend({
     <div class="pagination"> \
       <ul> \
         <li class="prev action-pagination-update"><a href="">&laquo;</a></li> \
-        <li class="active"><a><input name="from" type="text" value="{{from}}" /> &ndash; <input name="to" type="text" value="{{to}}" /> </a></li> \
+        <li class="active"><label for="from">From</label><a><input name="from" type="text" value="{{from}}" /> &ndash; <label for="to">To</label><input name="to" type="text" value="{{to}}" /> </a></li> \
         <li class="next action-pagination-update"><a href="">&raquo;</a></li> \
       </ul> \
     </div> \


### PR DESCRIPTION
To be 508 compliant all form input fields need to have a label, they can be hidden by css in -> recline/css/multiview.css -> .header .recline-pager .pagination label { display:none; }
Reference: http://wac.osu.edu/tutorials/section508/forms.htm
