### PR TITLE
Update widget.queryeditor.js and widget.queryeditor.js

### DIFF
--- a/css/multiview.css
+++ b/css/multiview.css
@@ -67,6 +67,10 @@
   vertical-align: top;
 }
 
+.header .recline-query-editor label {
+  display:none;
+}
+
 /**********************************************************
   * Pager
   *********************************************************/
@@ -76,6 +80,10 @@
   margin: auto;
   display: block;
   margin-left: 20px;
+}
+
+.header .recline-pager .pagination label {
+  display:none;
 }
 
 .header .recline-pager .pagination input {

--- a/dist/recline.css
+++ b/dist/recline.css
@@ -316,6 +316,10 @@ div.data-table-cell-content-numeric > a.data-table-cell-edit {
   vertical-align: top;
 }
 
+.header .recline-query-editor label {
+  display:none;
+}
+
 /**********************************************************
   * Pager
   *********************************************************/
@@ -325,6 +329,10 @@ div.data-table-cell-content-numeric > a.data-table-cell-edit {
   margin: auto;
   display: block;
   margin-left: 20px;
+}
+
+.header .recline-pager .pagination label {
+  display:none;
 }
 
 .header .recline-pager .pagination input {

--- a/dist/recline.js
+++ b/dist/recline.js
@@ -4393,7 +4393,7 @@ my.Pager = Backbone.View.extend({
     <div class="pagination"> \
       <ul> \
         <li class="prev action-pagination-update"><a href="">&laquo;</a></li> \
-        <li class="active"><a><input name="from" type="text" value="{{from}}" /> &ndash; <input name="to" type="text" value="{{to}}" /> </a></li> \
+        <li class="active"><label for="from">From</label><a><input id="from" name="from" type="text" value="{{from}}" /> &ndash; <label for="to">To</label><input id="to" name="to" type="text" value="{{to}}" /> </a></li> \
         <li class="next action-pagination-update"><a href="">&raquo;</a></li> \
       </ul> \
     </div> \
@@ -4467,7 +4467,7 @@ my.QueryEditor = Backbone.View.extend({
     <form action="" method="GET" class="form-inline"> \
       <div class="input-prepend text-query"> \
         <span class="add-on"><i class="icon-search"></i></span> \
-        <input type="text" name="q" value="{{q}}" class="span2" placeholder="Search data ..." class="search-query" /> \
+        <label for="search">Search</label><input id="search" type="text" name="q" value="{{q}}" class="span2" placeholder="Search data ..." class="search-query" /> \
       </div> \
       <button type="submit" class="btn">Go &raquo;</button> \
     </form> \

--- a/src/widget.pager.js
+++ b/src/widget.pager.js
@@ -12,7 +12,7 @@ my.Pager = Backbone.View.extend({
     <div class="pagination"> \
       <ul> \
         <li class="prev action-pagination-update"><a href="">&laquo;</a></li> \
-        <li class="active"><a><input name="from" type="text" value="{{from}}" /> &ndash; <input name="to" type="text" value="{{to}}" /> </a></li> \
+        <li class="active"><label for="from">From</label><a><input id="from" name="from" type="text" value="{{from}}" /> &ndash; <label for="to">To</label><input id="to" name="to" type="text" value="{{to}}" /> </a></li> \
         <li class="next action-pagination-update"><a href="">&raquo;</a></li> \
       </ul> \
     </div> \

--- a/src/widget.queryeditor.js
+++ b/src/widget.queryeditor.js
@@ -12,7 +12,7 @@ my.QueryEditor = Backbone.View.extend({
     <form action="" method="GET" class="form-inline"> \
       <div class="input-prepend text-query"> \
         <span class="add-on"><i class="icon-search"></i></span> \
-        <input type="text" name="q" value="{{q}}" class="span2" placeholder="Search data ..." class="search-query" /> \
+        <label for="search">Search</label><input id="search" type="text" name="q" value="{{q}}" class="span2" placeholder="Search data ..." class="search-query" /> \
       </div> \
       <button type="submit" class="btn">Go &raquo;</button> \
     </form> \


### PR DESCRIPTION
To be 508 compliant all form input fields need to have a label.
Reference: http://wac.osu.edu/tutorials/section508/forms.htm

Added css modification as well for the labels to remain hidden.

Fixing input labels and input ids to be 508 compliant
