### PR TITLE
[#425] Fix Dataset.query() when called with Query model

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -191,7 +191,11 @@ my.Dataset = Backbone.Model.extend({
     this.trigger('query:start');
 
     if (queryObj) {
-      this.queryState.set(queryObj, {silent: true});
+      var attributes = queryObj;
+      if (queryObj instanceof my.Query) {
+        attributes = queryObj.toJSON();
+      }
+      this.queryState.set(attributes, {silent: true});
     }
     var actualQuery = this.queryState.toJSON();
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -177,6 +177,31 @@ test('Dataset getFieldsSummary', function () {
   });
 });
 
+test('query with Query model', function () {
+  var dataset = new recline.Model.Dataset({
+    records: [{country: 'UK'}, {country: 'DE'}]
+  });
+  var query = new recline.Model.Query();
+  query.addFilter({type: 'term', field: 'country', term: 'DE'});
+
+  dataset.query(query).done(function (results) {
+    deepEqual(results.length, 1);
+    deepEqual(results.models[0].toJSON(), {country: 'DE'});
+  });
+});
+
+test('query with plain object', function () {
+  var dataset = new recline.Model.Dataset({
+    records: [{country: 'UK'}, {country: 'DE'}]
+  });
+  var query = {q: 'DE'};
+
+  dataset.query(query).done(function (results) {
+    deepEqual(results.length, 1);
+    deepEqual(results.models[0].toJSON(), {country: 'DE'});
+  });
+});
+
 test('fetch without and with explicit fields', function () {
   var dataset = new recline.Model.Dataset({
     backend: 'csv',


### PR DESCRIPTION
The problem is that Backbone >= 0.9.9 doesn't accept updating models with:

```
model.set(otherModel);
```

That needs to be changed to:

```
model.set(otherModel.attributes);
```

Dataset.query() accepts both regular JS objects and Query models, so we need to
check the parameter type to support both.
