### PR TITLE
OpenSpending - Berlin ERDF spendings data-driven story

### DIFF
--- a/examples/openspending/content/stories/where-does-berlin-spends-its-erdf-benefits.mdx
+++ b/examples/openspending/content/stories/where-does-berlin-spends-its-erdf-benefits.mdx
@@ -1,0 +1,105 @@
+---
+title: Where does Berlin spends its ERDF benefits?
+date: 2023-06-12
+authors: ['João Demenech']
+---
+
+In this data-driven story, let's analyze how the city of Berlin has benefited from ERDF from 2008 to 2015.
+
+## What is ERDF?
+
+If you're not familiar with ERDF, it's the European Regional Development Fund. According to its [official website](https://ec.europa.eu/regional_policy/funding/erdf_en):
+
+> The European Regional Development Fund (ERDF) aims to strengthen economic, social and territorial cohesion in the European Union by correcting imbalances between its regions. In 2021-2027 it will enable investments in a smarter, greener, more connected and more social Europe that is closer to its citizens.
+
+## A look into the data
+
+The dataset that will be used is this one: https://www.openspending.org/@os-data/de3-berlin-2007-2013-erdf (if you're looking for ERDF data for other cities/regions, take a look at the data catalog).
+
+Here's a sample of this data:
+
+<FlatUiTable url="https://storage.openspending.org/de3-berlin-2007-2013-erdf/concat.csv" />
+
+Note that we will only use the rows where the "amount_kind" column is set to "total_amount".
+
+## How has the total amount changed over the years?
+
+The line chart below shows the sum of the total amount of EUR that was approved for each year:
+
+<LineChart data="https://storage.openspending.org/de3-berlin-2007-2013-erdf/berlin-erdf-2007-2013-total-amount-apporved-per-year.csv" xAxis="approval_year" yAxis="total_amount" />
+
+As you can see, the total only increased from 2007 to 2010, fluctuating between €7 million and €9 million per year.
+
+## Who were the top beneficiaries for each year?
+
+Now, let's try to understand who were the top beneficiaries each year. To do that, let's filter the data to show only the two top beneficiaries for each year:
+
+<FlatUiTable url="https://storage.openspending.org/de3-berlin-2007-2013-erdf/berlin-erdf-2007-2013-total-amount-approved-per-year-per-beneficiary--top-2.csv" />
+
+Since there are many years in this range, let's split this analysis into two ranges: one for 2008-2010 and the other for 2011-2015.
+
+<VegaLite spec={{
+  "data": { "url": "https://storage.openspending.org/de3-berlin-2007-2013-erdf/berlin-erdf-2007-2013-total-amount-approved-per-year-per-beneficiary--top-2.csv"},
+  "transform": [
+    {"filter": "datum.approval_year <= 2010"},
+  ],
+  "title": "Total Amount (EUR) x Approval Year (2007-2010)",
+  "width": "container",
+  "mark": {"type": "bar", "tooltip": true },
+  "encoding": {
+    "y": {
+      "aggregate": "sum",
+      "field": "total_amount",
+      "title": "Total Amount (EUR)",
+      "stack": null
+    },
+    "x": {"field": "approval_year", "title": "Approval Year"},
+    "color": {
+      "type": "nominal",
+      "field": "beneficiary_name",
+    }
+  }
+}} />
+
+<VegaLite spec={{
+  "title": "Total Amount (EUR) x Approval Year (2011-2013)",
+  "data": { "url": "https://storage.openspending.org/de3-berlin-2007-2013-erdf/berlin-erdf-2007-2013-total-amount-approved-per-year-per-beneficiary--top-2.csv"},
+  "transform": [
+    {"filter": "datum.approval_year > 2010"},
+  ],
+  "width": "container",
+  "mark": {"type": "bar", "tooltip": true },
+  "encoding": {
+    "y": {
+      "aggregate": "sum",
+      "field": "total_amount",
+      "title": "Total Amount (EUR)",
+      "stack": null
+    },
+    "x": {"field": "approval_year", "title": "Approval Year"},
+    "color": {
+      "type": "nominal",
+      "field": "beneficiary_name",
+    }
+  }
+}} />
+
+It's easy to spot some repeating colors. Now, let's see to which sector the top beneficiaries belong to:
+
+<Table csv="
+Beneficiary,Sector
+D & B,Education
+Stiftung Sozialpädagogisches Institut Berlin (SPI),Education/Social work
+IB e.V.,Social work
+gsub-Projektegesellschaft mbH,Consulting
+BBW Berufsvorbereitungs-u.Ausbildungsgesellschaft,Education
+Arbeit und Bildung e.V.,Consulting
+Gesellschaft für soziale Unternehmensberatung  GSUB,Consulting
+SPI Consult GmbH,Consulting
+Beuth Hochschule für Technik Berlin,Education
+TU Berlin, Fakultät II,Education
+Hochschule für Technik und Wirtschaft Berlin,Education
+WeTeK gGmbH,Education
+" />
+
+Based on the sectors of the top beneficiaries, it's clear that education and professional training have been a major focus of ERDF investment in Berlin during that period of time.

--- a/examples/openspending/content/stories/where-does-berlin-spends-its-erdf-benefits.mdx
+++ b/examples/openspending/content/stories/where-does-berlin-spends-its-erdf-benefits.mdx
@@ -28,7 +28,7 @@ The line chart below shows the sum of the total amount of EUR that was approved 
 
 <LineChart data="https://storage.openspending.org/de3-berlin-2007-2013-erdf/berlin-erdf-2007-2013-total-amount-apporved-per-year.csv" xAxis="approval_year" yAxis="total_amount" />
 
-As you can see, the total only increased from 2007 to 2010, fluctuating between €7 million and €9 million per year.
+As you can see, the total increased significantly from 2007 to 2010, later fluctuating between €7 million and €9 million per year.
 
 ## Who were the top beneficiaries for each year?
 


### PR DESCRIPTION
This PR adds a new data-driven story to OpenSpending re ERDF spendings in Berlin