### PR TITLE
Fix issues with css styles on Openspending

### DIFF
--- a/examples/openspending/pages/_app.tsx
+++ b/examples/openspending/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { AppProps } from 'next/app';
+import '@portaljs/components/styles.css';
 import './styles.css';
 import { NextSeo } from 'next-seo';
 


### PR DESCRIPTION
There was an issue due to the import order of the CSS files.