### PR TITLE
Fix wiki-link regexp to match non-Latin characters

### DIFF
--- a/packages/remark-wiki-link/src/lib/fromMarkdown.ts
+++ b/packages/remark-wiki-link/src/lib/fromMarkdown.ts
@@ -79,7 +79,7 @@ function fromMarkdown(opts: FromMarkdownOptions = {}) {
       data: { isEmbed, target, alias },
     } = wikiLink;
     // eslint-disable-next-line no-useless-escape
-    const wikiLinkWithHeadingPattern = /([\w\s\/\.-]*)(#.*)?/;
+    const wikiLinkWithHeadingPattern = /([\p{Letter}\d\s\/\.-_]*)(#.*)?/u;
     const [, path, heading = ""] = target.match(wikiLinkWithHeadingPattern);
 
     const possibleWikiLinkPermalinks = wikiLinkResolver(path);


### PR DESCRIPTION
Fixes https://github.com/datopian/flowershow/issues/537.

In a nutshell, it's possible to match a letter from any alphabet using [Unicode character class escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape). According to MDN the feature should work in Node.js 10+:

![image](https://github.com/igoradamenko/portaljs/assets/6537798/cfb7a359-41bd-4c38-96a5-41be2250671e)

I've tested the solution on a small vault.

Here's how the package worked with Flowershow prior to this PR:

![doesnotwork](https://github.com/datopian/portaljs/assets/6537798/d067eb02-13c7-4b27-8256-0851589ac867)

This is how it works now:

![works](https://github.com/datopian/portaljs/assets/6537798/652f4aab-d726-45ea-a685-d6e1334802a2)
