### PR TITLE
[remark-wiki-link]: Parse note embeds as regular wiki links

### DIFF
--- a/.changeset/thick-worms-peel.md
+++ b/.changeset/thick-worms-peel.md
@@ -1,0 +1,5 @@
+---
+'@portaljs/remark-wiki-link': minor
+---
+
+Parse note embeds as regular wiki links (until we add proper support for note embeds).

--- a/packages/remark-wiki-link/src/lib/fromMarkdown.ts
+++ b/packages/remark-wiki-link/src/lib/fromMarkdown.ts
@@ -15,9 +15,9 @@ const defaultWikiLinkResolver = (target: string) => {
 
 export interface FromMarkdownOptions {
   pathFormat?:
-    | "raw" // default; use for regular relative or absolute paths
-    | "obsidian-absolute" // use for Obsidian-style absolute paths (with no leading slash)
-    | "obsidian-short"; // use for Obsidian-style shortened paths (shortest path possible)
+  | "raw" // default; use for regular relative or absolute paths
+  | "obsidian-absolute" // use for Obsidian-style absolute paths (with no leading slash)
+  | "obsidian-short"; // use for Obsidian-style shortened paths (shortest path possible)
   permalinks?: string[]; // list of permalinks to match possible permalinks of a wiki link against
   wikiLinkResolver?: (name: string) => string[]; // function to resolve wiki links to an array of possible permalinks
   newClassName?: string; // class name to add to links that don't have a matching permalink
@@ -125,13 +125,24 @@ function fromMarkdown(opts: FromMarkdownOptions = {}) {
     if (isEmbed) {
       const [isSupportedFormat, format] = isSupportedFileFormat(target);
       if (!isSupportedFormat) {
-        wikiLink.data.hName = "p";
-        wikiLink.data.hChildren = [
-          {
-            type: "text",
-            value: `![[${target}]]`,
-          },
-        ];
+        // Temporarily render note transclusion as a regular wiki link
+        if (!format) {
+          wikiLink.data.hName = "a";
+          wikiLink.data.hProperties = {
+            className: classNames + " " + "transclusion",
+            href: hrefTemplate(link) + headingId,
+          };
+          wikiLink.data.hChildren = [{ type: "text", value: displayName }];
+
+        } else {
+          wikiLink.data.hName = "p";
+          wikiLink.data.hChildren = [
+            {
+              type: "text",
+              value: `![[${target}]]`,
+            },
+          ];
+        }
       } else if (format === "pdf") {
         wikiLink.data.hName = "iframe";
         wikiLink.data.hProperties = {

--- a/packages/remark-wiki-link/src/lib/html.ts
+++ b/packages/remark-wiki-link/src/lib/html.ts
@@ -15,9 +15,9 @@ const defaultWikiLinkResolver = (target: string) => {
 
 export interface HtmlOptions {
   pathFormat?:
-    | "raw" // default; use for regular relative or absolute paths
-    | "obsidian-absolute" // use for Obsidian-style absolute paths (with no leading slash)
-    | "obsidian-short"; // use for Obsidian-style shortened paths (shortest path possible)
+  | "raw" // default; use for regular relative or absolute paths
+  | "obsidian-absolute" // use for Obsidian-style absolute paths (with no leading slash)
+  | "obsidian-short"; // use for Obsidian-style shortened paths (shortest path possible)
   permalinks?: string[]; // list of permalinks to match possible permalinks of a wiki link against
   wikiLinkResolver?: (name: string) => string[]; // function to resolve wiki links to an array of possible permalinks
   newClassName?: string; // class name to add to links that don't have a matching permalink
@@ -108,7 +108,16 @@ function html(opts: HtmlOptions = {}) {
     if (isEmbed) {
       const [isSupportedFormat, format] = isSupportedFileFormat(target);
       if (!isSupportedFormat) {
-        this.raw(`![[${target}]]`);
+        // Temporarily render note transclusion as a regular wiki link
+        if (!format) {
+          this.tag(
+            `<a href="${hrefTemplate(link + headingId)}" class="${classNames} transclusion">`
+          );
+          this.raw(displayName);
+          this.tag("</a>");
+        } else {
+          this.raw(`![[${target}]]`);
+        }
       } else if (format === "pdf") {
         this.tag(
           `<iframe width="100%" src="${hrefTemplate(

--- a/packages/remark-wiki-link/test/micromarkExtensionWikiLink.spec.ts
+++ b/packages/remark-wiki-link/test/micromarkExtensionWikiLink.spec.ts
@@ -309,4 +309,16 @@ describe("micromark-extension-wiki-link", () => {
       expect(serialized).toBe('<p><a href="/" class="internal">/index</a></p>');
     });
   });
+
+  describe("transclusions", () => {
+    test("parsers a transclusion as a regular wiki link", () => {
+      const serialized = micromark("![[Some Page]]", "ascii", {
+        extensions: [syntax()],
+        htmlExtensions: [html() as any], // TODO type fix
+      });
+      expect(serialized).toBe(
+        '<p><a href="Some Page" class="internal new transclusion">Some Page</a></p>'
+      );
+    });
+  });
 });

--- a/packages/remark-wiki-link/test/remarkWikiLink.spec.ts
+++ b/packages/remark-wiki-link/test/remarkWikiLink.spec.ts
@@ -535,4 +535,28 @@ describe("remark-wiki-link", () => {
       });
     });
   });
+
+  describe("transclusions", () => {
+    test("replaces a transclusion with a regular wiki link", () => {
+      const processor = unified().use(markdown).use(wikiLinkPlugin);
+
+      let ast = processor.parse("![[Some Page]]");
+      ast = processor.runSync(ast);
+
+      expect(select("wikiLink", ast)).not.toEqual(null);
+
+      visit(ast, "wikiLink", (node: Node) => {
+        expect(node.data?.isEmbed).toEqual(true);
+        expect(node.data?.exists).toEqual(false);
+        expect(node.data?.permalink).toEqual("Some Page");
+        expect(node.data?.alias).toEqual(null);
+        expect(node.data?.hName).toEqual("a");
+        expect((node.data?.hProperties as any).className).toEqual(
+          "internal new transclusion"
+        );
+        expect((node.data?.hProperties as any).href).toEqual("Some Page");
+        expect((node.data?.hChildren as any)[0].value).toEqual("Some Page");
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #1005 

Temporary solution before we have a proper note embed support.