### PR TITLE
Fixed bug on filter by startDate

### DIFF
--- a/.changeset/thin-worms-build.md
+++ b/.changeset/thin-worms-build.md
@@ -1,0 +1,5 @@
+---
+'@portaljs/components': patch
+---
+
+Fixed filter by startDate error

--- a/packages/components/src/components/BucketViewer.tsx
+++ b/packages/components/src/components/BucketViewer.tsx
@@ -93,7 +93,7 @@ export function BucketViewer({
   useEffect(() => {
       if(!filterState) return;
 
-      if(filterState.startDate && filterState.startDate) {
+      if (filterState.startDate && filterState.endDate) {
         setFilteredData(bucketFiles.filter(({ dateProps }) => 
           dateProps 
             ? 


### PR DESCRIPTION
## Changes

- Changed condition that was validating the startDate twice instead of validate the endDate