### PR TITLE
Fixed problem presenting the download component in the first load of …

### DIFF
--- a/.changeset/funny-horses-smash.md
+++ b/.changeset/funny-horses-smash.md
@@ -1,0 +1,5 @@
+---
+'@portaljs/components': patch
+---
+
+Fixed problem presenting the download component in the first load of the bucket viewer

--- a/packages/components/src/components/BucketViewer.tsx
+++ b/packages/components/src/components/BucketViewer.tsx
@@ -47,7 +47,7 @@ export function BucketViewer({
   downloadComponent = downloadComponent ?? <></>;
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [showDownloadComponentOnLine, setShowDownloadComponentOnLine] = useState(0);
+  const [showDownloadComponentOnLine, setShowDownloadComponentOnLine] = useState(-1);
   const [currentPage, setCurrentPage] = useState<number>(0);
   const [lastPage, setLastPage] = useState<number>(0);
   const [bucketFiles, setBucketFiles] = useState<BucketViewerData[]>([]);


### PR DESCRIPTION
## Changes

- Added -1 on the initial state of the BucketViewer's download button component