### PR TITLE
Fix gtag function not available error on /welcome page

### DIFF
--- a/site/pages/welcome.tsx
+++ b/site/pages/welcome.tsx
@@ -7,18 +7,36 @@ export default function Welcome() {
   const router = useRouter()
 
   useEffect(() => {
-    // Track the visit to the welcome page
-    if (siteConfig.analytics && typeof window.gtag === 'function') {
-      gtag.event({
-        action: 'welcome_page_visit',
-        category: 'Engagement',
-        label: 'Cold Email Campaign',
-        value: 1,
-      })
+    const trackAndRedirect = () => {
+      // Track the visit to the welcome page
+      if (siteConfig.analytics && typeof window.gtag === 'function') {
+        gtag.event({
+          action: 'welcome_page_visit',
+          category: 'Engagement',
+          label: 'Cold Email Campaign',
+          value: 1,
+        })
+      }
+
+      // Redirect to home page after tracking
+      router.replace('/')
     }
 
-    // Redirect to home page after tracking
-    router.replace('/')
+    // Wait for gtag to be available
+    if (siteConfig.analytics) {
+      const checkGtag = () => {
+        if (typeof window.gtag === 'function') {
+          trackAndRedirect()
+        } else {
+          // Check again after a short delay
+          setTimeout(checkGtag, 100)
+        }
+      }
+      checkGtag()
+    } else {
+      // No analytics configured, just redirect
+      router.replace('/')
+    }
   }, [router])
 
   return null


### PR DESCRIPTION
Wait for gtag to load before tracking welcome page visit to prevent console warning and ensure proper analytics tracking.

🤖 Generated with [Claude Code](https://claude.ai/code)