### PR TITLE
Add conversion tracking for all CTA buttons

### DIFF
--- a/site/components/ButtonLink.tsx
+++ b/site/components/ButtonLink.tsx
@@ -1,4 +1,6 @@
 import { AnchorHTMLAttributes } from "react";
+import * as gtag from '@/lib/gtag';
+import siteConfig from '@/config/siteConfig';
 
 type ButtonLinkProps = {
   style?: "primary" | "secondary" | "tertiary";
@@ -6,6 +8,7 @@ type ButtonLinkProps = {
   className?: string;
   title?: string;
   href?: string;
+  trackConversion?: boolean;
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "style">;
 
 export default function ButtonLink({
@@ -14,6 +17,7 @@ export default function ButtonLink({
   className = "",
   href = "https://cloud.portaljs.com/",
   title = "Get started with PortalJS Cloud",
+  trackConversion = false,
   ...rest
 }: ButtonLinkProps) {
   let _className: string =
@@ -30,11 +34,23 @@ export default function ButtonLink({
 
   _className += ` ${className}`;
 
+  const handleClick = () => {
+    if (trackConversion && siteConfig.analytics && typeof window.gtag === 'function') {
+      gtag.event({
+        action: 'get_started_click',
+        category: 'Conversion',
+        label: 'CTA Button',
+        value: 1,
+      });
+    }
+  };
+
   return (
     <a
       href={href}
       title={title}
       className={_className}
+      onClick={handleClick}
       {...rest}
     >
       {children}

--- a/site/components/ButtonLink.tsx
+++ b/site/components/ButtonLink.tsx
@@ -18,6 +18,7 @@ export default function ButtonLink({
   href = "https://cloud.portaljs.com/",
   title = "Get started with PortalJS Cloud",
   trackConversion = false,
+  onClick,
   ...rest
 }: ButtonLinkProps) {
   let _className: string =
@@ -34,14 +35,24 @@ export default function ButtonLink({
 
   _className += ` ${className}`;
 
-  const handleClick = () => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    // Execute parent onClick handler first if provided
+    if (onClick) {
+      onClick(event);
+    }
+
+    // Track conversion if enabled
     if (trackConversion && siteConfig.analytics && typeof window.gtag === 'function') {
-      gtag.event({
-        action: 'get_started_click',
-        category: 'Conversion',
-        label: 'CTA Button',
-        value: 1,
-      });
+      try {
+        gtag.event({
+          action: 'get_started_click',
+          category: 'Conversion',
+          label: 'CTA Button',
+          value: 1,
+        });
+      } catch (error) {
+        console.warn('Failed to track conversion event:', error);
+      }
     }
   };
 
@@ -50,8 +61,8 @@ export default function ButtonLink({
       href={href}
       title={title}
       className={_className}
-      onClick={handleClick}
       {...rest}
+      onClick={handleClick}
     >
       {children}
     </a>

--- a/site/components/Nav.tsx
+++ b/site/components/Nav.tsx
@@ -145,6 +145,7 @@ export default function Nav() {
             href="https://cloud.portaljs.com/auth/signup"
             title="Get started with PortalJS Cloud"
             className="text-sm !py-2 hidden lg:block"
+            trackConversion={true}
           >
             Get started free
           </ButtonLink>

--- a/site/components/PricingPlans.tsx
+++ b/site/components/PricingPlans.tsx
@@ -377,6 +377,7 @@ export default function PricingPlans() {
                   aria-describedby={tier.id}
                   title={`${tier.title} - ${tier.cta}`}
                   style={tier.featured ? 'primary' : 'secondary'}
+                  trackConversion={tier.href === 'https://cloud.portaljs.com/auth/signup'}
                 >
                   {index !== 0 && index !== 3 && buy ? 'Buy now' : tier.cta}
                 </ButtonLink>

--- a/site/components/ckan/Hero.tsx
+++ b/site/components/ckan/Hero.tsx
@@ -28,6 +28,7 @@ export default function Hero() {
               style="secondary"
               className="mt-8 text-sm"
               href="https://cloud.portaljs.com/auth/signup"
+              trackConversion={true}
             >
               Deploy with PortalJS Cloud
             </ButtonLink>

--- a/site/components/home/Hero.tsx
+++ b/site/components/home/Hero.tsx
@@ -89,6 +89,7 @@ export default function Hero() {
                   href="https://cloud.portaljs.com/auth/signup"
                   title="Get started with PortalJS Cloud"
                   className="text-sm"
+                  trackConversion={true}
                 >
                   Get started free
                 </ButtonLink>

--- a/site/pages/compare/index.tsx
+++ b/site/pages/compare/index.tsx
@@ -135,7 +135,7 @@ export default function CompareIndex() {
                 <ButtonLink href={calendarLink} title="Book a demo">
                   Book a demo
                 </ButtonLink>
-                <ButtonLink href="https://cloud.portaljs.com/auth/signup" title="Sign up for free" style="secondary">
+                <ButtonLink href="https://cloud.portaljs.com/auth/signup" title="Sign up for free" style="secondary" trackConversion={true}>
                   Sign up for free
                 </ButtonLink>
               </div>

--- a/site/pages/compare/opendatasoft.tsx
+++ b/site/pages/compare/opendatasoft.tsx
@@ -229,7 +229,7 @@ export default function PortalJSvsOpenDataSoft() {
                 <ButtonLink href={calendarLink} title="Book a demo">
                   Book a demo
                 </ButtonLink>
-                <ButtonLink href="https://cloud.portaljs.com/auth/signup" title="Sign up for free" style="secondary">
+                <ButtonLink href="https://cloud.portaljs.com/auth/signup" title="Sign up for free" style="secondary" trackConversion={true}>
                   Sign up for free
                 </ButtonLink>
               </div>


### PR DESCRIPTION
Track get_started_click events across site for GA4 analytics:
- Hero sections (main, CKAN)
- Navigation header CTA
- Compare pages CTAs
- Pricing plan signup buttons

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added conversion tracking to key call-to-action buttons across the site. When enabled, clicking these buttons now records a Google Analytics event if analytics are configured.
- **Enhancements**
	- Introduced an optional setting to enable or disable conversion tracking for individual buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->