### PR TITLE
Add custom acquisition source tracking for cold email campaigns

### DIFF
--- a/site/components/ButtonLink.tsx
+++ b/site/components/ButtonLink.tsx
@@ -44,12 +44,23 @@ export default function ButtonLink({
     // Track conversion if enabled
     if (trackConversion && siteConfig.analytics && typeof window.gtag === 'function') {
       try {
-        gtag.event({
+        const eventData = {
           action: 'get_started_click',
           category: 'Conversion',
           label: 'CTA Button',
           value: 1,
-        });
+        };
+
+        // Only add acquisition_source if it exists (cold email visitors)
+        const acquisitionSource = typeof window !== 'undefined' 
+          ? sessionStorage.getItem('acquisition_source')
+          : null;
+        
+        if (acquisitionSource) {
+          eventData.acquisition_source = acquisitionSource;
+        }
+
+        gtag.event(eventData);
       } catch (error) {
         console.warn('Failed to track conversion event:', error);
       }

--- a/site/components/ButtonLink.tsx
+++ b/site/components/ButtonLink.tsx
@@ -44,7 +44,7 @@ export default function ButtonLink({
     // Track conversion if enabled
     if (trackConversion && siteConfig.analytics && typeof window.gtag === 'function') {
       try {
-        const eventData = {
+        const eventData: any = {
           action: 'get_started_click',
           category: 'Conversion',
           label: 'CTA Button',

--- a/site/pages/welcome.tsx
+++ b/site/pages/welcome.tsx
@@ -10,6 +10,14 @@ export default function Welcome() {
     const trackAndRedirect = () => {
       // Track the visit to the welcome page
       if (siteConfig.analytics && typeof window.gtag === 'function') {
+        // Store acquisition source in sessionStorage for later use
+        sessionStorage.setItem('acquisition_source', 'cold_email')
+
+        // Set custom user property for cold email acquisition
+        window.gtag('set', {
+          acquisition_source: 'cold_email'
+        })
+
         gtag.event({
           action: 'welcome_page_visit',
           category: 'Engagement',


### PR DESCRIPTION
- Set acquisition_source user property on /welcome page visits
- Store in sessionStorage to persist across page navigation
- Include acquisition_source in conversion events for attribution
- Only track custom source for cold email visitors, not regular traffic

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Acquisition source is now tracked and included in analytics events when available.
  - Visiting the welcome page sets the acquisition source for improved analytics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->