### PR TITLE
Add learning section with metadata topics

### DIFF
--- a/site/components/LearnCard.tsx
+++ b/site/components/LearnCard.tsx
@@ -9,6 +9,7 @@ interface LearnCardProps {
   comingSoon?: boolean;
   underline?: boolean;
   href: string;
+  compact?: boolean;
 }
 
 const LearnCard: FC<LearnCardProps> = ({
@@ -19,20 +20,18 @@ const LearnCard: FC<LearnCardProps> = ({
   comingSoon = false,
   underline = false,
   href,
+  compact = false,
 }) => {
-  return (
-    <Link href={href} className={`block relative overflow-hidden border border-zinc-200 dark:border-zinc-700 
-         dark:bg-[#020817] p-8 transition-all duration-300 shadow-lg
-        hover:bg-slate-100 dark:hover:bg-gray-800 ${className} min-h-[300px] lg:min-h-[600px] group`}>
-      <div className="absolute right-8 bottom-0 mb-6 text-4xl opacity-0 group-hover:opacity-30 transition ease-in-out ">
+  const cardContent = (
+    <>
+      <div className={`absolute right-8 bottom-0 mb-6 ${compact ? 'text-2xl' : 'text-4xl'} opacity-0 group-hover:opacity-30 transition ease-in-out`}>
         {icon}
       </div>
-      <h5 className="text-5xl font-semibold text-gray-900 dark:text-white transition-colors duration-300 
-        ">
+      <h5 className={`${compact ? 'text-2xl' : 'text-5xl'} font-semibold text-gray-900 dark:text-white transition-colors duration-300`}>
         {title}
       </h5>
       {underline && <div className="h-1 w-32 bg-custom_blue mt-2 mb-3"></div>}
-      <p className="text-gray-600 dark:text-gray-400 text-base leading-relaxed transition-colors duration-300">
+      <p className={`text-gray-600 dark:text-gray-400 ${compact ? 'text-sm' : 'text-base'} leading-relaxed transition-colors duration-300`}>
         {description}
       </p>
       {comingSoon && (
@@ -40,6 +39,27 @@ const LearnCard: FC<LearnCardProps> = ({
           Coming Soon
         </div>
       )}
+    </>
+  );
+
+  const heightClass = compact ? 'min-h-[300px]' : 'min-h-[300px] lg:min-h-[600px]';
+  const paddingClass = compact ? 'p-6' : 'p-8';
+
+  if (comingSoon) {
+    return (
+      <div className={`block relative overflow-hidden border border-zinc-200 dark:border-zinc-700 
+           dark:bg-[#020817] ${paddingClass} transition-all duration-300 shadow-lg
+          ${className} ${heightClass} group cursor-not-allowed opacity-75`}>
+        {cardContent}
+      </div>
+    );
+  }
+
+  return (
+    <Link href={href} className={`block relative overflow-hidden border border-zinc-200 dark:border-zinc-700 
+         dark:bg-[#020817] ${paddingClass} transition-all duration-300 shadow-lg
+        hover:bg-slate-100 dark:hover:bg-gray-800 ${className} ${heightClass} group`}>
+      {cardContent}
     </Link>
   );
 }

--- a/site/components/LearnCard.tsx
+++ b/site/components/LearnCard.tsx
@@ -42,7 +42,7 @@ const LearnCard: FC<LearnCardProps> = ({
     </>
   );
 
-  const heightClass = compact ? 'min-h-[300px]' : 'min-h-[300px] lg:min-h-[600px]';
+  const heightClass = compact ? 'min-h-[300px]' : 'min-h-[400px] lg:min-h-[600px]';
   const paddingClass = compact ? 'p-6' : 'p-8';
 
   if (comingSoon) {

--- a/site/components/LearnPostCard.tsx
+++ b/site/components/LearnPostCard.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react';
+import Link from 'next/link';
+
+interface LearnPostCardProps {
+  title: string;
+  description: string;
+  date?: string;
+  readTime?: string;
+  href: string;
+  className?: string;
+}
+
+const LearnPostCard: FC<LearnPostCardProps> = ({
+  title,
+  description,
+  date,
+  readTime,
+  href,
+  className = "",
+}) => {
+  return (
+    <Link href={href} className={`block border border-zinc-200 dark:border-zinc-700 
+         dark:bg-[#020817] p-6 transition-all duration-300 shadow-sm
+        hover:bg-slate-50 dark:hover:bg-gray-800 hover:shadow-md ${className} group`}>
+      <div className="flex flex-col h-full">
+        <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-3 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+          {title}
+        </h3>
+        <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed flex-grow">
+          {description}
+        </p>
+        {(date || readTime) && (
+          <div className="flex items-center gap-3 mt-4 text-xs text-gray-500 dark:text-gray-500">
+            {date && <span>{date}</span>}
+            {date && readTime && <span>•</span>}
+            {readTime && <span>{readTime}</span>}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export default LearnPostCard;

--- a/site/components/custom/Footer.tsx
+++ b/site/components/custom/Footer.tsx
@@ -5,6 +5,7 @@ const navigation = {
   resources: [
     { name: 'Case Studies', href: '/case-studies' },
     { name: 'Data Portals', href: '/data-portals' },
+    { name: 'Learn', href: '/learn' },
     { name: 'Documentation', href: '/docs' },
     { name: 'Blog', href: '/blog' },
     { name: 'FAQ', href: '/faq' },

--- a/site/content/config.js
+++ b/site/content/config.js
@@ -96,6 +96,10 @@ const config = {
           href: '/opensource/docs',
         },
         {
+          name: 'Learn',
+          href: '/learn',
+        },
+        {
           name: 'Discord Community',
           href: 'https://discord.com/invite/KrRzMKU',
           target: '_blank',

--- a/site/pages/learn/index.tsx
+++ b/site/pages/learn/index.tsx
@@ -66,7 +66,11 @@ const LearnPage = () => {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-16">
+        <div 
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-16"
+          role="grid"
+          aria-label="Learning topics grid"
+        >
           {learningTopics.map((topic, index) => (
             <LearnCard
               key={index}

--- a/site/pages/learn/index.tsx
+++ b/site/pages/learn/index.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { FaBook, FaGraduationCap, FaShieldAlt, FaChartLine, FaDatabase, FaCogs } from "react-icons/fa";
+import Layout from "@/components/Layout";
+import LearnCard from "@/components/LearnCard";
+
+const learningTopics = [
+  {
+    icon: <FaBook />,
+    title: "Metadata",
+    description: "Master the fundamentals of metadata—what it is, how it works, and why it's essential for data discovery. Learn about metadata schemas, standards, and best practices for making your data discoverable.",
+    href: "/learn/metadata",
+    underline: true,
+  },
+  {
+    icon: <FaGraduationCap />,
+    title: "Data Management Systems",
+    description: "Explore data management software components and architectures. Learn about data catalogs, portals, CKAN, and how different systems work together to manage data at scale.",
+    href: "/learn/data-management-systems",
+    underline: true,
+    comingSoon: true,
+  },
+  {
+    icon: <FaShieldAlt />,
+    title: "Data Governance",
+    description: "Learn about data governance frameworks, policies, and best practices. Understand data stewardship, compliance requirements, and how to establish governance in your organization.",
+    href: "/learn/data-governance",
+    underline: true,
+    comingSoon: true,
+  },
+  {
+    icon: <FaChartLine />,
+    title: "Data Quality",
+    description: "Discover techniques for measuring, monitoring, and improving data quality. Learn about validation rules, data profiling, cleansing strategies, and quality metrics.",
+    href: "/learn/data-quality",
+    underline: true,
+    comingSoon: true,
+  },
+  {
+    icon: <FaDatabase />,
+    title: "Data Integration",
+    description: "Master data integration patterns and technologies. Learn about ETL processes, APIs, real-time data sync, and building robust data pipelines.",
+    href: "/learn/data-integration",
+    underline: true,
+    comingSoon: true,
+  },
+  {
+    icon: <FaCogs />,
+    title: "Data Lifecycle",
+    description: "Understand the complete data lifecycle from creation to archival. Learn about data retention policies, versioning, backup strategies, and deletion processes.",
+    href: "/learn/data-lifecycle",
+    underline: true,
+    comingSoon: true,
+  },
+];
+
+const LearnPage = () => {
+  return (
+    <Layout>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold text-primary dark:text-primary-dark mb-4">
+            Learn Data Management
+          </h1>
+          <p className="text-lg text-slate-600 dark:text-slate-400 max-w-3xl mx-auto">
+            Master the fundamentals of data management through our comprehensive learning paths. Choose a topic below to explore in-depth guides and best practices.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-16">
+          {learningTopics.map((topic, index) => (
+            <LearnCard
+              key={index}
+              icon={topic.icon}
+              title={topic.title}
+              description={topic.description}
+              href={topic.href}
+              underline={topic.underline}
+              comingSoon={topic.comingSoon}
+              compact={true}
+            />
+          ))}
+        </div>
+
+        <div className="bg-slate-50 dark:bg-slate-800 rounded-lg p-8 text-center">
+          <h2 className="text-2xl font-semibold text-primary dark:text-primary-dark mb-4">
+            More Learning Resources Coming Soon
+          </h2>
+          <p className="text-slate-600 dark:text-slate-400">
+            We're continuously expanding our learning resources. Stay tuned for more guides on advanced data management, API integration, and best practices.
+          </p>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default LearnPage;

--- a/site/pages/learn/metadata.tsx
+++ b/site/pages/learn/metadata.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { FaArrowLeft, FaBook } from "react-icons/fa";
+import Link from "next/link";
+import Layout from "@/components/Layout";
+import LearnPostCard from "@/components/LearnPostCard";
+import ButtonLink from "@/components/ButtonLink";
+
+const metadataPosts = [
+  {
+    title: "Basics of Metadata: How It Helps Understand Your Data",
+    description: "Learn the basics of metadata—from built-in CSV attributes like filename and media type to simple external files—and see how it makes your data discoverable.",
+    href: "/blog/basics-of-metadata-how-it-helps-to-understand-your-data",
+    date: "June 2, 2025",
+    readTime: "8 min read",
+  },
+  {
+    title: "How Rich Metadata Powers Data Discovery in Modern Data Catalogs",
+    description: "Learn how metadata transforms data discovery at scale—from search engines like Solr and Elasticsearch to standardized schemas that help users find exactly what they need among thousands of datasets.",
+    href: "/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs",
+    date: "June 25, 2025",
+    readTime: "10 min read",
+  },
+];
+
+const MetadataLearnPage = () => {
+  return (
+    <Layout>
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Breadcrumb */}
+        <div className="mb-8">
+          <Link href="/learn" className="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors">
+            <FaArrowLeft className="mr-2 text-sm" />
+            Back to Learning Topics
+          </Link>
+        </div>
+
+        {/* Header */}
+        <div className="text-center mb-12">
+          <div className="flex justify-center mb-4">
+            <div className="p-4 bg-blue-100 dark:bg-blue-900/30 rounded-full">
+              <FaBook className="text-3xl text-blue-600 dark:text-blue-400" />
+            </div>
+          </div>
+          <h1 className="text-4xl font-bold text-primary dark:text-primary-dark mb-4">
+            Metadata Fundamentals
+          </h1>
+          <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
+            Master the fundamentals of metadata—what it is, how it works, and why it's essential for data discovery and management.
+          </p>
+        </div>
+
+        {/* Learning Path */}
+        <div className="mb-8">
+          <h2 className="text-2xl font-semibold text-primary dark:text-primary-dark mb-6">
+            Learning Path
+          </h2>
+          <div className="grid gap-6">
+            {metadataPosts.map((post, index) => (
+              <div key={index} className="relative">
+                {/* Step number */}
+                <div className="absolute -left-4 top-6 w-8 h-8 bg-blue-600 dark:bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-semibold">
+                  {index + 1}
+                </div>
+                <div className="ml-8">
+                  <LearnPostCard
+                    title={post.title}
+                    description={post.description}
+                    href={post.href}
+                    date={post.date}
+                    readTime={post.readTime}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Next Steps */}
+        <div className="bg-slate-50 dark:bg-slate-800 rounded-lg p-8 text-center">
+          <h3 className="text-xl font-semibold text-primary dark:text-primary-dark mb-4">
+            What's Next?
+          </h3>
+          <p className="text-slate-600 dark:text-slate-400 mb-6">
+            Ready to expand your knowledge? Explore other data management topics or dive deeper into advanced metadata concepts.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <ButtonLink href="/learn" className="text-sm">
+              Explore Other Topics
+            </ButtonLink>
+            <ButtonLink style="secondary" href="/blog" className="text-sm">
+              Browse All Posts
+            </ButtonLink>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default MetadataLearnPage;


### PR DESCRIPTION
- Create /learn page with structured learning paths
- Add metadata fundamentals section at /learn/metadata
- Link directly to existing blog posts to avoid content duplication
- Include comprehensive topic placeholders (metadata, data management systems, governance, quality, integration, lifecycle)
- Add Learn link to navbar Resources dropdown and footer
- Enhance LearnCard component with compact mode and coming soon states
- Use standard ButtonLink components for consistent styling

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Learn" hub page showcasing data management learning topics in a compact, card-based layout.
  * Added detailed "Metadata" learning topic page with curated blog post learning paths, navigation, and resource links.
  * Launched a new `LearnPostCard` component for displaying learning resources with title, description, date, and read time.
  * Updated site navigation and footer to include a direct link to the new "Learn" section.

* **Enhancements**
  * Improved `LearnCard` component to support a compact mode and visually distinguish "coming soon" topics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->