### PR TITLE
Include full content in RSS/Atom feeds for cross-posting

### DIFF
--- a/site/public/atom.xml
+++ b/site/public/atom.xml
@@ -21,6 +21,1063 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+## Introduction
+
+In our [previous exploration of metadata and data discovery](/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs), we saw how rich metadata transforms search and discovery in data catalogs. But here&apos;s the challenge: rich metadata without standards creates chaos. When every organization describes data differently, you get the digital equivalent of Tower of Babel—lots of information, zero interoperability.
+
+Consider this scenario: A data portal contains datasets from various departments within a government agency. Without metadata standards, the transportation department describes their datasets using fields like &quot;author,&quot; &quot;created_date,&quot; and &quot;topic.&quot; The health department uses &quot;publisher,&quot; &quot;last_modified,&quot; and &quot;subject_area.&quot; The education department uses &quot;creator,&quot; &quot;updated,&quot; and &quot;category.&quot; All contain the same core information, but without standardized metadata fields, users can&apos;t consistently search, filter, or understand what&apos;s available across the portal.
+
+This is where metadata standards come in—providing the consistent structure that makes data discoverable and manageable within your portal, while also enabling interoperability across the broader data ecosystem.
+
+## The Major Players: Core Metadata Standards
+
+The metadata standards landscape might seem overwhelming at first, but it&apos;s built around a few foundational standards that work together rather than compete. Let&apos;s explore the key players and how they complement each other.
+
+### Dublin Core: The Universal Foundation
+
+Dublin Core is the veteran of metadata standards with its 15 basic elements that can describe virtually any resource. Published as ISO Standard 15836, it&apos;s domain-agnostic and internationally recognized.
+
+**The 15 Core Elements:**
+
+```yaml
+# Dublin Core basics
+title: &quot;NYC 311 Service Requests - 2023 Q1&quot;
+creator: &quot;NYC Department of Information Technology&quot;
+subject: &quot;citizen services, municipal data, complaints&quot;
+description: &quot;Citizen complaints and service requests from NYC&apos;s 311 system&quot;
+publisher: &quot;NYC Open Data&quot;
+contributor: &quot;NYC 311 Contact Center&quot;
+date: &quot;2023-04-01&quot;
+type: &quot;Dataset&quot;
+format: &quot;CSV&quot;
+identifier: &quot;https://data.cityofnewyork.us/311-2023-q1&quot;
+source: &quot;NYC 311 System&quot;
+language: &quot;en&quot;
+relation: &quot;Part of NYC Open Data Portal&quot;
+coverage: &quot;New York City, 2023 Q1&quot;
+rights: &quot;Public Domain&quot;
+```
+
+**Why Dublin Core Works:**
+
+- **Universal applicability** - Works for datasets, documents, images, anything
+- **Low barrier to entry** - Easy to understand and implement
+- **Foundation for other standards** - DCAT, MODS, and others build on Dublin Core
+- **Proven longevity** - 25+ years of development and refinement
+
+### DCAT: Purpose-Built for Data Catalogs
+
+Data Catalog Vocabulary (DCAT) is Dublin Core&apos;s specialized cousin, designed specifically for describing datasets in data catalogs. As a W3C Recommendation, it&apos;s the gold standard for data portal interoperability.
+
+**DCAT&apos;s Key Additions:**
+
+```yaml
+# DCAT builds on Dublin Core with data-specific concepts
+dataset:
+  title: &quot;NYC 311 Service Requests - 2023 Q1&quot;
+  description: &quot;Citizen complaints and service requests...&quot;
+  publisher: &quot;NYC Department of Information Technology&quot;
+  theme: &quot;Government, Public Services&quot;
+  keyword: [&quot;311&quot;, &quot;citizen services&quot;, &quot;complaints&quot;]
+  landingPage: &quot;https://data.cityofnewyork.us/311-2023-q1&quot;
+
+  # Data-specific metadata Dublin Core lacks
+  distribution:
+    - downloadURL: &quot;https://data.cityofnewyork.us/311-2023-q1.csv&quot;
+      mediaType: &quot;text/csv&quot;
+      format: &quot;CSV&quot;
+    - downloadURL: &quot;https://data.cityofnewyork.us/311-2023-q1.json&quot;
+      mediaType: &quot;application/json&quot;
+      format: &quot;JSON&quot;
+
+  temporal: &quot;2023-01-01/2023-03-31&quot;
+  spatial: &quot;New York City, NY, USA&quot;
+  accrualPeriodicity: &quot;quarterly&quot;
+  contactPoint:
+    fn: &quot;NYC Open Data Team&quot;
+    hasEmail: &quot;opendata@cityhall.nyc.gov&quot;
+```
+
+**DCAT&apos;s Power:**
+
+- **Federated search** - Multiple catalogs can be searched as one
+- **Automated harvesting** - Systems can automatically collect metadata from DCAT-compliant catalogs
+- **Distribution management** - Tracks multiple formats (CSV, JSON, API) of the same dataset
+- **Data catalog-specific concepts** - Update frequency, spatial/temporal coverage, data quality
+
+### Schema.org Dataset: Web-Native Discovery
+
+Schema.org Dataset brings metadata into the web era, designed specifically for search engine optimization and web-based discovery.
+
+**Schema.org in Practice:**
+
+```html
+&lt;!-- Embedded in webpage HTML for search engines --&gt;
+&lt;script type=&quot;application/ld+json&quot;&gt;
+{
+  &quot;@context&quot;: &quot;https://schema.org&quot;,
+  &quot;@type&quot;: &quot;Dataset&quot;,
+  &quot;name&quot;: &quot;NYC 311 Service Requests - 2023 Q1&quot;,
+  &quot;description&quot;: &quot;Citizen complaints and service requests from NYC&apos;s 311 system during January-March 2023&quot;,
+  &quot;url&quot;: &quot;https://data.cityofnewyork.us/311-2023-q1&quot;,
+  &quot;creator&quot;: {
+    &quot;@type&quot;: &quot;Organization&quot;,
+    &quot;name&quot;: &quot;NYC Department of Information Technology&quot;
+  },
+  &quot;temporalCoverage&quot;: &quot;2023-01-01/2023-03-31&quot;,
+  &quot;spatialCoverage&quot;: &quot;New York City, NY, USA&quot;,
+  &quot;distribution&quot;: [
+    {
+      &quot;@type&quot;: &quot;DataDownload&quot;,
+      &quot;encodingFormat&quot;: &quot;CSV&quot;,
+      &quot;contentUrl&quot;: &quot;https://data.cityofnewyork.us/311-2023-q1.csv&quot;
+    }
+  ]
+}
+&lt;/script&gt;
+```
+
+**Schema.org&apos;s Advantage:**
+
+- **Google Dataset Search** - Direct integration with Google&apos;s dataset discovery platform – https://datasetsearch.research.google.com/
+- **SEO benefits** - Search engines understand and rank your data
+- **Web-standard JSON-LD** - Fits naturally into web development workflows
+- **Rich snippets** - Enhanced search results with download links and previews
+
+## Standards in Practice: Who Uses What
+
+Different sectors have gravitated toward different standards based on their specific needs, organizational culture, and regulatory requirements.
+
+### Government Sector: Transparency and Interoperability
+
+Government data portals prioritize standardization and cross-agency interoperability, leading to strong adoption of DCAT-based approaches.
+
+**United States Federal Government:**
+
+The Project Open Data Metadata Schema, mandated for federal agencies, builds directly on DCAT:
+
+```yaml
+# Project Open Data Schema (DCAT-based)
+title: &quot;Federal Student Aid Recipients by State&quot;
+description: &quot;Annual data on federal student aid recipients and amounts by state and program type&quot;
+keyword: [&quot;education&quot;, &quot;financial aid&quot;, &quot;students&quot;, &quot;federal programs&quot;]
+modified: &quot;2023-09-15&quot;
+publisher: &quot;Department of Education&quot;
+contactPoint:
+  fn: &quot;Federal Student Aid Data Team&quot;
+  hasEmail: &quot;data@ed.gov&quot;
+mbox: &quot;data@ed.gov&quot;
+identifier: &quot;ED-FSA-2023-001&quot;
+accessLevel: &quot;public&quot;
+bureauCode: [&quot;018:00&quot;]
+programCode: [&quot;018:001&quot;]
+license: &quot;https://creativecommons.org/publicdomain/zero/1.0/&quot;
+spatial: &quot;United States&quot;
+temporal: &quot;2022-07-01/2023-06-30&quot;
+```
+
+**European Union:**
+
+DCAT-AP (DCAT Application Profile) extends DCAT with European-specific requirements:
+
+```yaml
+# DCAT-AP adds EU-specific fields
+dataset:
+  # Standard DCAT fields
+  title: &quot;EU Carbon Emissions by Sector&quot;
+  description: &quot;Annual greenhouse gas emissions data by economic sector across EU member states&quot;
+
+  # DCAT-AP extensions
+  conformsTo: &quot;https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32019R2152&quot;
+  page: &quot;https://ec.europa.eu/eurostat/carbon-data&quot;
+  versionInfo: &quot;2.1&quot;
+  hasVersion: &quot;https://data.europa.eu/carbon-emissions-v2.1&quot;
+  language: [&quot;en&quot;, &quot;fr&quot;, &quot;de&quot;]
+  provenance: &quot;Collected from national statistical offices via standardized reporting&quot;
+```
+
+**Benefits for Government:**
+
+- **Cross-agency compatibility** - Datasets from different agencies can be easily combined
+- **Automated compliance checking** - Tools can validate metadata completeness
+- **Public transparency** - Citizens can find and understand government data
+- **International data sharing** - Compatible metadata enables collaboration between countries
+
+### Academic and Research: Preservation and Scholarly Discovery
+
+Academic institutions balance standardization with discipline-specific needs, often layering specialized standards on Dublin Core foundations.
+
+**Research Data Repositories:**
+
+```yaml
+# Dublin Core + research-specific extensions
+title: &quot;Longitudinal Study of Urban Heat Islands - Chicago 2015-2023&quot;
+creator: [&quot;Dr. Sarah Chen&quot;, &quot;Dr. Michael Rodriguez&quot;, &quot;Climate Research Lab&quot;]
+subject: &quot;climatology, urban planning, environmental science&quot;
+description: &quot;Temperature measurements from 150 sensors across Chicago measuring urban heat island effects over 8 years&quot;
+publisher: &quot;University Research Data Repository&quot;
+date: &quot;2023-08-15&quot;
+type: &quot;Dataset&quot;
+format: [&quot;CSV&quot;, &quot;NetCDF&quot;]
+
+# Research-specific additions
+fundingAgency: &quot;National Science Foundation&quot;
+grantNumber: &quot;NSF-GEO-1847392&quot;
+methodology: &quot;Fixed sensor networks with 15-minute measurement intervals&quot;
+relatedPublication: &quot;doi:10.1038/climate.2023.456&quot;
+ethicsApproval: &quot;IRB-2015-378&quot;
+dataCollectionPeriod: &quot;2015-06-01/2023-05-31&quot;
+spatialResolution: &quot;100m grid&quot;
+temporalResolution: &quot;15 minutes&quot;
+```
+
+**Social Science Data (DDI Standard):**
+The Data Documentation Initiative provides rich metadata for survey and social science data:
+
+```yaml
+# DDI (Data Documentation Initiative) for social science
+study:
+  citation:
+    title: &quot;American Community Survey 2023&quot;
+    creator: &quot;U.S. Census Bureau&quot;
+    producer: &quot;U.S. Census Bureau&quot;
+    distributionDate: &quot;2024-03-15&quot;
+
+  dataCollection:
+    methodology: &quot;Probability sample survey&quot;
+    samplingProcedure: &quot;Stratified systematic sampling&quot;
+    collectionMode: &quot;Mail, telephone, and in-person interviews&quot;
+    responseRate: 97.2
+
+  variableGroups:
+    demographics:
+      variables: [&quot;age&quot;, &quot;gender&quot;, &quot;race&quot;, &quot;ethnicity&quot;]
+    economic:
+      variables: [&quot;income&quot;, &quot;employment_status&quot;, &quot;occupation&quot;]
+    housing:
+      variables: [&quot;housing_type&quot;, &quot;tenure&quot;, &quot;housing_costs&quot;]
+```
+
+**Academic Priorities:**
+
+- **Long-term preservation** - Metadata must support data archiving for decades
+- **Citation tracking** - Clear links between datasets and publications
+- **Methodology documentation** - Detailed information about data collection methods
+- **Interdisciplinary discovery** - Subject classifications that work across fields
+
+### Nonprofits: Balancing Standards and Resources
+
+Nonprofit organizations often follow government standards for compatibility while adapting to resource constraints and mission-specific needs.
+
+```yaml
+# Nonprofit metadata - simplified DCAT approach
+title: &quot;Global Health Initiative: Vaccination Rates 2020-2023&quot;
+description: &quot;Country-level vaccination coverage data collected through partnerships with WHO and national health ministries&quot;
+publisher: &quot;Global Health Alliance&quot;
+theme: &quot;Health, International Development&quot;
+keyword: [&quot;vaccination&quot;, &quot;global health&quot;, &quot;immunization&quot;, &quot;public health&quot;]
+license: &quot;CC-BY-4.0&quot;
+contactPoint:
+  fn: &quot;Data Team&quot;
+  hasEmail: &quot;data@globalhealthalliance.org&quot;
+
+# Mission-specific fields
+programArea: &quot;Vaccine Equity Initiative&quot;
+partnerOrganizations: [&quot;WHO&quot;, &quot;UNICEF&quot;, &quot;Gavi Alliance&quot;]
+impactMetrics:
+  - &quot;Lives saved through improved vaccination access&quot;
+  - &quot;Healthcare systems strengthened&quot;
+fundingSource: &quot;Private foundation grants&quot;
+dataUseAgreement: &quot;Must acknowledge source and share derivative works&quot;
+```
+
+## Enterprise vs. Public Portals: Different Needs, Different Standards
+
+The choice of metadata standards often depends on whether your data portal serves internal enterprise needs or public discovery. Each context brings distinct requirements and constraints.
+
+### Public Data Portals: Standardization First
+
+Public-facing data portals prioritize interoperability and discoverability, leading to strict adherence to established standards.
+
+**Characteristics of Public Portal Metadata:**
+
+- **Strict DCAT compliance** - Enables cross-portal search and data harvesting
+- **Schema.org integration** - Ensures Google and other search engines can index datasets
+- **Quality assurance at scale** - Automated validation of metadata completeness and accuracy
+- **Multi-language support** - Metadata in multiple languages for international accessibility
+
+```yaml
+# Public portal: strict standards compliance
+dataset:
+  # Required DCAT fields - enforced by validation
+  title: &quot;Public Transit Routes and Schedules&quot;
+  description: &quot;Real-time and scheduled route information for city public transportation&quot;
+  publisher: &quot;Metropolitan Transit Authority&quot;
+  issued: &quot;2023-01-15&quot;
+  modified: &quot;2023-06-29&quot;
+
+  # Standardized vocabularies
+  theme: &quot;http://publications.europa.eu/resource/authority/data-theme/TRAN&quot;
+  keyword: [&quot;transportation&quot;, &quot;public transit&quot;, &quot;GTFS&quot;, &quot;real-time&quot;]
+
+  # Interoperability requirements
+  conformsTo: &quot;https://gtfs.org/reference/static&quot;
+  accessRights: &quot;http://publications.europa.eu/resource/authority/access-right/PUBLIC&quot;
+  license: &quot;https://creativecommons.org/licenses/by/4.0/&quot;
+
+  # Multiple format support
+  distribution:
+    - downloadURL: &quot;https://transit.city.gov/gtfs/routes.zip&quot;
+      mediaType: &quot;application/zip&quot;
+      format: &quot;GTFS&quot;
+    - accessURL: &quot;https://api.transit.city.gov/routes&quot;
+      mediaType: &quot;application/json&quot;
+      format: &quot;JSON API&quot;
+```
+
+### Internal Enterprise Portals: Flexibility and Integration
+
+Enterprise data portals start with standards but customize heavily for business needs, integration requirements, and organizational workflows.
+
+**Enterprise Portal Adaptations:**
+
+```yaml
+# Enterprise portal: standards + business context
+dataset:
+  # Standard fields (DCAT-based)
+  title: &quot;Customer Purchase History - Q2 2023&quot;
+  description: &quot;Anonymized customer transaction data for business intelligence and analytics&quot;
+  publisher: &quot;Data Engineering Team&quot;
+
+  # Business-specific extensions
+  businessDomain: &quot;Customer Analytics&quot;
+  dataOwner: &quot;VP Customer Experience&quot;
+  technicalContact: &quot;data-engineering@company.com&quot;
+  businessContact: &quot;customer-analytics@company.com&quot;
+
+  # Governance and compliance
+  dataClassification: &quot;Internal - Confidential&quot;
+  retentionPeriod: &quot;7 years&quot;
+  complianceFramework: [&quot;GDPR&quot;, &quot;CCPA&quot;, &quot;SOX&quot;]
+  approvalStatus: &quot;Approved for Business Use&quot;
+  lastAuditDate: &quot;2023-06-15&quot;
+
+  # Technical integration
+  sourceSystem: &quot;SAP Customer Management&quot;
+  refreshFrequency: &quot;Daily at 2:00 AM UTC&quot;
+  dataLineage: &quot;Customer DB -&gt; ETL Pipeline -&gt; Data Warehouse -&gt; Analytics View&quot;
+  qualityScore: 94.2
+  slaTarget: &quot;99.5% availability, &lt;4 hour data latency&quot;
+
+  # Access control (enterprise-specific)
+  accessLevel: &quot;Department Level&quot;
+  approvedRoles: [&quot;Customer Analytics Team&quot;, &quot;Marketing Analysts&quot;, &quot;Product Managers&quot;]
+  dataUseAgreement: &quot;Internal use only, no external sharing without Data Office approval&quot;
+```
+
+### Key Differences in Practice
+
+**1. Governance Requirements**
+
+*Public Portals:*
+
+- Transparency and open access focus
+- Standardized licenses (CC, Public Domain)
+- Public accountability for data quality
+
+*Enterprise Portals:*
+
+- Complex access controls and permissions
+- Business approval workflows
+- Integration with identity management systems
+
+**2. Discovery Mechanisms**
+
+*Public Portals:*
+
+- SEO optimization for web search engines
+- Cross-portal federation and harvesting
+- Social media and link sharing
+
+*Enterprise Portals:*
+
+- Integration with business intelligence tools
+- Internal search and recommendation systems
+- Context-aware suggestions based on user role
+
+**3. Quality and Validation**
+
+*Public Portals:*
+
+- Automated quality checks against standards
+- Public feedback and error reporting
+- Reputation and trust metrics
+
+*Enterprise Portals:*
+
+- Business rule validation
+- Integration with data quality tools
+- SLA monitoring and alerting
+
+## Frictionless Data: Datopian&apos;s Approach to Simplicity
+
+While standards like DCAT and Dublin Core provide excellent frameworks, implementing them in real-world systems often becomes complex. This is where Frictionless Data shines—offering a pragmatic approach that bridges the gap between standards and practical implementation.
+
+### The Philosophy: Progressive and Practical
+
+Frictionless Data, developed through a joint stewardship between the Open Knowledge Foundation and Datopian, embodies a &quot;progressive, incrementally adoptable&quot; philosophy. Rather than forcing organizations to adopt complex standards all at once, it provides a pathway to better metadata that grows with your needs.
+
+**Core Design Principles:**
+
+- **Simplicity over complexity** - Start simple, add sophistication gradually
+- **Developer-friendly** - Easy to implement and maintain
+- **Standards-compatible** - Works alongside and bridges to other standards
+- **Real-world tested** - 10+ years of iteration with open data communities
+
+### Core Specifications: Building Blocks for Any System
+
+Frictionless Data provides four core specifications that work together or independently:
+
+**1. Data Package: The Container**
+
+```json
+{
+  &quot;name&quot;: &quot;customer-transactions-q2-2023&quot;,
+  &quot;title&quot;: &quot;Customer Transactions Q2 2023&quot;,
+  &quot;description&quot;: &quot;Anonymized customer purchase data for Q2 business analysis&quot;,
+  &quot;version&quot;: &quot;1.2.0&quot;,
+  &quot;licenses&quot;: [
+    {
+      &quot;name&quot;: &quot;CC-BY-4.0&quot;,
+      &quot;title&quot;: &quot;Creative Commons Attribution 4.0&quot;,
+      &quot;path&quot;: &quot;https://creativecommons.org/licenses/by/4.0/&quot;
+    }
+  ],
+  &quot;resources&quot;: [
+    {
+      &quot;name&quot;: &quot;transactions&quot;,
+      &quot;path&quot;: &quot;transactions.csv&quot;,
+      &quot;title&quot;: &quot;Customer Transaction Records&quot;,
+      &quot;description&quot;: &quot;Individual transaction records with product and customer details&quot;,
+      &quot;schema&quot;: &quot;schema/transactions-schema.json&quot;
+    }
+  ],
+  &quot;contributors&quot;: [
+    {
+      &quot;title&quot;: &quot;Data Engineering Team&quot;,
+      &quot;email&quot;: &quot;data@company.com&quot;,
+      &quot;role&quot;: &quot;author&quot;
+    }
+  ],
+  &quot;created&quot;: &quot;2023-07-01&quot;
+}
+```
+
+**2. Table Schema: Structure Definition**
+
+```json
+{
+  &quot;fields&quot;: [
+    {
+      &quot;name&quot;: &quot;transaction_id&quot;,
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;title&quot;: &quot;Transaction ID&quot;,
+      &quot;description&quot;: &quot;Unique identifier for each transaction&quot;,
+      &quot;constraints&quot;: {
+        &quot;required&quot;: true,
+        &quot;unique&quot;: true
+      }
+    },
+    {
+      &quot;name&quot;: &quot;purchase_date&quot;,
+      &quot;type&quot;: &quot;date&quot;,
+      &quot;title&quot;: &quot;Purchase Date&quot;,
+      &quot;description&quot;: &quot;Date when the transaction occurred&quot;,
+      &quot;format&quot;: &quot;%Y-%m-%d&quot;
+    },
+    {
+      &quot;name&quot;: &quot;amount&quot;,
+      &quot;type&quot;: &quot;number&quot;,
+      &quot;title&quot;: &quot;Transaction Amount&quot;,
+      &quot;description&quot;: &quot;Total transaction amount in USD&quot;,
+      &quot;constraints&quot;: {
+        &quot;minimum&quot;: 0
+      }
+    },
+    {
+      &quot;name&quot;: &quot;product_category&quot;,
+      &quot;type&quot;: &quot;string&quot;,
+      &quot;title&quot;: &quot;Product Category&quot;,
+      &quot;description&quot;: &quot;High-level product category&quot;,
+      &quot;constraints&quot;: {
+        &quot;enum&quot;: [&quot;Electronics&quot;, &quot;Clothing&quot;, &quot;Home&quot;, &quot;Books&quot;, &quot;Sports&quot;]
+      }
+    }
+  ]
+}
+```
+
+**3. Data Resource: Individual Asset Metadata**
+
+```json
+{
+  &quot;name&quot;: &quot;sales-summary&quot;,
+  &quot;path&quot;: &quot;https://data.company.com/sales/summary.json&quot;,
+  &quot;title&quot;: &quot;Monthly Sales Summary&quot;,
+  &quot;description&quot;: &quot;Aggregated sales data by product category and region&quot;,
+  &quot;format&quot;: &quot;json&quot;,
+  &quot;mediatype&quot;: &quot;application/json&quot;,
+  &quot;encoding&quot;: &quot;utf-8&quot;,
+  &quot;schema&quot;: {
+    &quot;fields&quot;: [
+      {
+        &quot;name&quot;: &quot;month&quot;,
+        &quot;type&quot;: &quot;date&quot;,
+        &quot;format&quot;: &quot;%Y-%m&quot;
+      },
+      {
+        &quot;name&quot;: &quot;region&quot;,
+        &quot;type&quot;: &quot;string&quot;
+      },
+      {
+        &quot;name&quot;: &quot;total_sales&quot;,
+        &quot;type&quot;: &quot;number&quot;
+      }
+    ]
+  }
+}
+```
+
+### Why Frictionless Data Matters for Implementation
+
+**1. Standards Bridge**
+Frictionless Data doesn&apos;t compete with DCAT or Dublin Core—it complements them. You can easily map Frictionless metadata to other standards:
+
+```python
+# Python example: Frictionless to DCAT mapping
+from frictionless import Package
+
+# Load Frictionless Data Package
+package = Package(&apos;datapackage.json&apos;)
+
+# Map to DCAT
+dcat_metadata = {
+    &apos;dcat:Dataset&apos;: {
+        &apos;dct:title&apos;: package.title,
+        &apos;dct:description&apos;: package.description,
+        &apos;dcat:keyword&apos;: package.keywords,
+        &apos;dct:issued&apos;: package.created,
+        &apos;dcat:distribution&apos;: [
+            {
+                &apos;dcat:downloadURL&apos;: resource.path,
+                &apos;dct:format&apos;: resource.format,
+                &apos;dcat:mediaType&apos;: resource.mediatype
+            }
+            for resource in package.resources
+        ]
+    }
+}
+```
+
+**2. Incremental Adoption**
+Start with basic Frictionless Data Package, then add sophistication:
+
+```json
+// Week 1: Basic package
+{
+  &quot;name&quot;: &quot;sales-data&quot;,
+  &quot;resources&quot;: [
+    {&quot;name&quot;: &quot;sales&quot;, &quot;path&quot;: &quot;sales.csv&quot;}
+  ]
+}
+
+// Month 1: Add schema validation
+{
+  &quot;name&quot;: &quot;sales-data&quot;,
+  &quot;resources&quot;: [
+    {
+      &quot;name&quot;: &quot;sales&quot;,
+      &quot;path&quot;: &quot;sales.csv&quot;,
+      &quot;schema&quot;: &quot;sales-schema.json&quot;
+    }
+  ]
+}
+
+// Month 3: Full metadata
+{
+  &quot;name&quot;: &quot;sales-data&quot;,
+  &quot;title&quot;: &quot;Monthly Sales Data&quot;,
+  &quot;description&quot;: &quot;Comprehensive sales analytics dataset&quot;,
+  &quot;contributors&quot;: [...],
+  &quot;licenses&quot;: [...],
+  &quot;resources&quot;: [
+    {
+      &quot;name&quot;: &quot;sales&quot;,
+      &quot;path&quot;: &quot;sales.csv&quot;,
+      &quot;schema&quot;: &quot;sales-schema.json&quot;,
+      &quot;title&quot;: &quot;Sales Transactions&quot;,
+      &quot;description&quot;: &quot;Individual sales records with customer and product details&quot;
+    }
+  ]
+}
+```
+
+**3. Developer Experience**
+Frictionless provides libraries in multiple languages with consistent APIs:
+
+```python
+# Python
+from frictionless import validate, Package
+package = Package(&apos;datapackage.json&apos;)
+report = validate(package)
+
+# Validation happens automatically
+if report.valid:
+    print(&quot;Data package is valid!&quot;)
+else:
+    for error in report.errors:
+        print(f&quot;Error: {error.message}&quot;)
+```
+
+```javascript
+// JavaScript
+import { Package } from &apos;frictionless-js&apos;
+
+const package = await Package.load(&apos;datapackage.json&apos;)
+const report = await package.validate()
+
+if (report.valid) {
+  console.log(&apos;Data package is valid!&apos;)
+} else {
+  report.errors.forEach(error =&gt; {
+    console.log(`Error: ${error.message}`)
+  })
+}
+```
+
+### Real-World Applications
+
+**Government Portal Enhancement:**
+
+```json
+{
+  &quot;name&quot;: &quot;city-budget-2024&quot;,
+  &quot;title&quot;: &quot;City Budget 2024&quot;,
+  &quot;description&quot;: &quot;Complete municipal budget data with departmental breakdowns&quot;,
+
+  // Frictionless simplicity
+  &quot;resources&quot;: [
+    {
+      &quot;name&quot;: &quot;budget-summary&quot;,
+      &quot;path&quot;: &quot;budget-summary.csv&quot;,
+      &quot;schema&quot;: &quot;budget-schema.json&quot;
+    }
+  ],
+
+  // Easy mapping to government standards
+  &quot;custom&quot;: {
+    &quot;dcat&quot;: {
+      &quot;theme&quot;: &quot;http://publications.europa.eu/resource/authority/data-theme/GOVE&quot;,
+      &quot;accrualPeriodicity&quot;: &quot;annual&quot;
+    },
+    &quot;project-open-data&quot;: {
+      &quot;bureauCode&quot;: [&quot;019:20&quot;],
+      &quot;programCode&quot;: [&quot;019:006&quot;]
+    }
+  }
+}
+```
+
+**Enterprise Data Catalog:**
+
+```json
+{
+  &quot;name&quot;: &quot;customer-analytics-datasets&quot;,
+  &quot;title&quot;: &quot;Customer Analytics Data Collection&quot;,
+  &quot;description&quot;: &quot;Curated datasets for customer behavior analysis and segmentation&quot;,
+
+  &quot;resources&quot;: [
+    {
+      &quot;name&quot;: &quot;customer-profiles&quot;,
+      &quot;path&quot;: &quot;s3://data-lake/customer-profiles/&quot;,
+      &quot;format&quot;: &quot;parquet&quot;,
+      &quot;schema&quot;: &quot;schemas/customer-profile.json&quot;
+    },
+    {
+      &quot;name&quot;: &quot;purchase-history&quot;,
+      &quot;path&quot;: &quot;s3://data-lake/purchases/&quot;,
+      &quot;format&quot;: &quot;parquet&quot;,
+      &quot;schema&quot;: &quot;schemas/purchase-history.json&quot;
+    }
+  ],
+
+  // Enterprise-specific metadata alongside standard fields
+  &quot;custom&quot;: {
+    &quot;governance&quot;: {
+      &quot;dataOwner&quot;: &quot;customer-analytics@company.com&quot;,
+      &quot;classification&quot;: &quot;internal-confidential&quot;,
+      &quot;retentionPeriod&quot;: &quot;7-years&quot;
+    },
+    &quot;technical&quot;: {
+      &quot;refreshSchedule&quot;: &quot;daily-2am&quot;,
+      &quot;sourceSystem&quot;: &quot;customer-db-prod&quot;,
+      &quot;qualityChecks&quot;: [&quot;completeness&quot;, &quot;accuracy&quot;, &quot;timeliness&quot;]
+    }
+  }
+}
+```
+
+## Choosing Your Standard: A Decision Framework
+
+With multiple standards available, how do you choose the right approach for your organization? The answer often isn&apos;t picking one standard, but rather understanding how to layer them effectively.
+
+### The Progressive Standards Approach
+
+**Layer 1: Dublin Core Foundation**
+Start with Dublin Core&apos;s 15 elements for any metadata initiative:
+
+```yaml
+# Minimum viable metadata - Dublin Core
+title: &quot;Quarterly Sales Report Q2 2023&quot;
+creator: &quot;Sales Analytics Team&quot;
+subject: &quot;sales, revenue, performance&quot;
+description: &quot;Comprehensive sales performance data for Q2 2023 including regional breakdowns&quot;
+publisher: &quot;Acme Corporation&quot;
+date: &quot;2023-07-15&quot;
+type: &quot;Dataset&quot;
+format: &quot;CSV&quot;
+language: &quot;en&quot;
+rights: &quot;Internal use only&quot;
+```
+
+**Layer 2: Domain-Specific Standards**
+Add specialized vocabulary based on your sector:
+
+*Government/Public Data → DCAT:*
+
+```yaml
+# Dublin Core + DCAT for government
+title: &quot;Municipal Budget 2024&quot;
+description: &quot;Complete city budget with departmental allocations&quot;
+publisher: &quot;City Finance Department&quot;
+
+# DCAT additions
+theme: &quot;Government Finance&quot;
+accrualPeriodicity: &quot;annual&quot;
+spatial: &quot;Springfield, IL&quot;
+contactPoint:
+  fn: &quot;Budget Office&quot;
+  hasEmail: &quot;budget@springfield.gov&quot;
+distribution:
+  - downloadURL: &quot;https://data.springfield.gov/budget-2024.csv&quot;
+    mediaType: &quot;text/csv&quot;
+```
+
+*Research/Academic → Dublin Core + DDI:*
+
+```yaml
+# Dublin Core + research extensions
+title: &quot;Climate Change Perception Survey 2023&quot;
+creator: &quot;Dr. Sarah Johnson, Climate Research Institute&quot;
+description: &quot;National survey on public perception of climate change&quot;
+
+# Research-specific additions
+methodology: &quot;Random digit dialing telephone survey&quot;
+sampleSize: 2847
+responseRate: 34.2
+fundingSource: &quot;National Science Foundation Grant #NSF-1234567&quot;
+ethicsApproval: &quot;IRB-2023-045&quot;
+```
+
+**Layer 3: Technical Implementation**
+Choose implementation format based on your technical needs:
+
+*Web-based Discovery → Schema.org:*
+
+```html
+&lt;script type=&quot;application/ld+json&quot;&gt;
+{
+  &quot;@context&quot;: &quot;https://schema.org&quot;,
+  &quot;@type&quot;: &quot;Dataset&quot;,
+  &quot;name&quot;: &quot;Municipal Budget 2024&quot;,
+  &quot;description&quot;: &quot;Complete city budget with departmental allocations&quot;,
+  &quot;url&quot;: &quot;https://data.springfield.gov/budget-2024&quot;
+}
+&lt;/script&gt;
+```
+
+*Developer-Friendly → Frictionless Data:*
+
+```json
+{
+  &quot;name&quot;: &quot;municipal-budget-2024&quot;,
+  &quot;title&quot;: &quot;Municipal Budget 2024&quot;,
+  &quot;description&quot;: &quot;Complete city budget with departmental allocations&quot;,
+  &quot;resources&quot;: [
+    {
+      &quot;name&quot;: &quot;budget&quot;,
+      &quot;path&quot;: &quot;budget-2024.csv&quot;,
+      &quot;schema&quot;: &quot;budget-schema.json&quot;
+    }
+  ]
+}
+```
+
+### Decision Factors
+
+**1. Organizational Context**
+
+*Government/Public Sector:*
+
+- **Primary choice:** DCAT (often with regional extensions)
+- **Web presence:** Add Schema.org for SEO
+- **Implementation:** Consider Frictionless for technical flexibility
+
+*Academic/Research:*
+
+- **Foundation:** Dublin Core
+- **Discipline-specific:** DDI (social science), DataCite (research data), MODS (libraries)
+- **Implementation:** Frictionless for data packages, Schema.org for discoverability
+
+*Enterprise/Corporate:*
+
+- **Start with:** Dublin Core basics
+- **Business integration:** Custom extensions for governance, lineage, quality
+- **Implementation:** Frictionless for flexibility, Schema.org if public-facing
+
+**2. Technical Capabilities**
+
+*High Technical Resources:*
+
+- Can implement multiple standards simultaneously
+- Custom mapping between standards
+- Advanced validation and quality checking
+
+*Limited Technical Resources:*
+
+- Start with Frictionless Data for simplicity
+- Use hosted platforms that handle standards compliance
+- Focus on content quality over technical sophistication
+
+**3. Interoperability Requirements**
+
+*High Interoperability Needs:*
+
+- Strict DCAT compliance for government portals
+- Schema.org for web discoverability
+- Clear mapping to partner organization standards
+
+*Internal Focus:*
+
+- Prioritize business-specific metadata
+- Use standards as a foundation but customize heavily
+- Focus on integration with existing tools and workflows
+
+### Implementation Roadmap
+
+**Month 1-2: Foundation**
+
+```yaml
+# Minimum viable metadata
+title: &quot;Required - Human readable name&quot;
+description: &quot;Required - 2-3 sentences explaining the data&quot;
+creator: &quot;Required - Who created this data&quot;
+date: &quot;Required - When was this created/published&quot;
+format: &quot;Required - File format (CSV, JSON, etc.)&quot;
+```
+
+**Month 3-6: Standardization**
+
+```yaml
+# Add standard vocabulary
+title: &quot;Quarterly Sales Performance Data&quot;
+description: &quot;Revenue, units sold, and performance metrics by product category and region&quot;
+creator: &quot;Sales Analytics Team, Acme Corp&quot;
+subject: [&quot;sales&quot;, &quot;revenue&quot;, &quot;business intelligence&quot;]  # Controlled vocabulary
+type: &quot;Dataset&quot;  # Standard resource type
+format: &quot;CSV&quot;
+license: &quot;Internal Use Only&quot;  # Clear usage terms
+identifier: &quot;acme-sales-q2-2023&quot;  # Unique ID
+```
+
+**Month 6-12: Enhancement**
+
+```yaml
+# Full metadata with domain-specific extensions
+title: &quot;Quarterly Sales Performance Data Q2 2023&quot;
+description: &quot;Revenue, units sold, and performance metrics by product category and region for Q2 2023 business analysis&quot;
+
+# Standard Dublin Core
+creator: &quot;Sales Analytics Team&quot;
+publisher: &quot;Acme Corporation&quot;
+subject: [&quot;sales&quot;, &quot;revenue&quot;, &quot;business intelligence&quot;, &quot;performance metrics&quot;]
+type: &quot;Dataset&quot;
+format: [&quot;CSV&quot;, &quot;JSON&quot;]
+date: &quot;2023-07-15&quot;
+language: &quot;en&quot;
+rights: &quot;Internal Use - Business Confidential&quot;
+
+# Business-specific extensions
+businessDomain: &quot;Sales Analytics&quot;
+dataOwner: &quot;VP Sales Operations&quot;
+refreshFrequency: &quot;Monthly&quot;
+qualityScore: 94.7
+approvalStatus: &quot;Approved for Business Use&quot;
+retentionPeriod: &quot;7 years&quot;
+sourceSystem: &quot;Salesforce CRM&quot;
+```
+
+## The Future of Metadata Standards
+
+The metadata standards landscape continues evolving, driven by new technologies, changing organizational needs, and lessons learned from large-scale implementations.
+
+### Emerging Trends
+
+**1. AI and Machine Learning Integration**
+Modern data catalogs increasingly use AI to enhance metadata:
+
+```yaml
+# AI-enhanced metadata example
+title: &quot;Customer Transaction Data Q2 2023&quot;
+description: &quot;Payment processing data for customer analytics&quot;
+
+# Traditional metadata
+format: &quot;CSV&quot;
+size: &quot;2.3 GB&quot;
+records: 1847293
+
+# AI-generated additions
+aiGenerated:
+  qualityScore: 94.2
+  completenessProfile:
+    customerID: 100%
+    transactionAmount: 99.8%
+    merchantCategory: 87.3%
+  dataProfile:
+    numericalColumns: 12
+    categoricalColumns: 8
+    dateColumns: 3
+  suggestedTags: [&quot;ecommerce&quot;, &quot;payments&quot;, &quot;customer-behavior&quot;]
+  similarDatasets: [&quot;customer-profiles-2023&quot;, &quot;payment-methods-analysis&quot;]
+  potentialIssues: [&quot;Some merchant categories missing&quot;, &quot;Date format inconsistency in 0.2% of records&quot;]
+```
+
+**2. Real-time and Dynamic Metadata**
+Static metadata gives way to dynamic, real-time information:
+
+```yaml
+dataset:
+  title: &quot;Live Traffic Sensor Data&quot;
+  description: &quot;Real-time traffic speed and volume from city sensors&quot;
+
+  # Static metadata
+  publisher: &quot;Department of Transportation&quot;
+  license: &quot;CC-BY-4.0&quot;
+
+  # Dynamic metadata (updated automatically)
+  lastUpdated: &quot;2023-06-29T14:23:47Z&quot;
+  recordCount: 45729841  # Updates in real-time
+  dataFreshness: &quot;3 seconds&quot;  # How recent is the latest data
+  systemStatus: &quot;operational&quot;
+  avgUpdateFrequency: &quot;every 30 seconds&quot;
+  currentDataRange: &quot;2023-06-29T14:20:00Z to 2023-06-29T14:23:00Z&quot;
+```
+
+**3. Privacy and Governance Integration**
+Metadata standards evolve to include privacy and compliance information:
+
+```yaml
+dataset:
+  title: &quot;Customer Analytics Dataset&quot;
+  description: &quot;Customer behavior and preference data for personalization&quot;
+
+  # Traditional metadata
+  publisher: &quot;Marketing Analytics Team&quot;
+  format: &quot;Parquet&quot;
+
+  # Privacy-aware metadata
+  privacyLevel: &quot;PII-containing&quot;
+  gdprCompliant: true
+  dataSubjects: &quot;EU and US customers&quot;
+  legalBasis: &quot;Legitimate interest for service improvement&quot;
+  retentionPeriod: &quot;2 years&quot;
+  anonymizationMethod: &quot;k-anonymity with k=5&quot;
+  sensitiveFields: [&quot;customer_id&quot;, &quot;email_hash&quot;, &quot;location_zip&quot;]
+  accessControls:
+    - role: &quot;Marketing Analysts&quot;
+      permissions: [&quot;read&quot;, &quot;aggregate&quot;]
+    - role: &quot;Data Scientists&quot;
+      permissions: [&quot;read&quot;, &quot;model&quot;]
+  auditLog: &quot;All access logged for 7 years&quot;
+```
+
+### Convergence and Interoperability
+
+The future points toward greater convergence between standards rather than fragmentation:
+
+**Cross-Standard Mapping**
+Tools and platforms increasingly support automatic translation between standards:
+
+```python
+# Hypothetical future API
+from metadata_converter import StandardsConverter
+
+converter = StandardsConverter()
+
+# Load data in any standard
+metadata = converter.load(&apos;datapackage.json&apos;, format=&apos;frictionless&apos;)
+
+# Convert to any other standard
+dcat_output = converter.convert(metadata, target=&apos;dcat&apos;)
+schema_org_output = converter.convert(metadata, target=&apos;schema.org&apos;)
+dublin_core_output = converter.convert(metadata, target=&apos;dublin_core&apos;)
+
+# Validate against multiple standards simultaneously
+validation_report = converter.validate(metadata, standards=[&apos;dcat&apos;, &apos;schema.org&apos;])
+```
+
+**Universal Metadata APIs**
+Future data platforms may expose unified metadata APIs that work with any standard:
+
+```http
+GET /api/metadata/dataset/12345?format=dcat
+GET /api/metadata/dataset/12345?format=schema.org
+GET /api/metadata/dataset/12345?format=frictionless
+```
+
+### Recommendations for Future-Proofing
+
+**1. Build on Stable Foundations**
+
+- Start with Dublin Core elements—they&apos;ve remained stable for 25+ years
+- Use DCAT for data catalog applications—W3C backing provides long-term stability
+- Implement Schema.org for web presence—Google&apos;s support ensures longevity
+
+**2. Design for Flexibility**
+
+- Use JSON-based formats for easier parsing and transformation
+- Implement clear separation between core metadata and extensions
+- Plan for automated migration between standards
+
+**3. Embrace Tooling**
+
+- Invest in metadata management platforms that support multiple standards
+- Use validation tools to ensure quality and compliance
+- Implement automated metadata generation where possible
+
+## Conclusion
+
+Navigating the metadata standards landscape doesn&apos;t require choosing a single &quot;winner&quot;—it requires understanding how different standards work together to solve different problems. Dublin Core provides the universal foundation, DCAT adds data catalog sophistication, Schema.org enables web discovery, and Frictionless Data offers practical implementation flexibility.
+
+The key insight is that metadata standards should serve your organizational goals, not constrain them. Start with basic Dublin Core elements, add domain-specific standards as needed, and use tools like Frictionless Data to bridge the gap between standards and practical implementation.
+
+Most importantly, remember that the best metadata standard is the one that gets used consistently. A simple, well-maintained Dublin Core implementation beats a complex DCAT setup that no one maintains. Focus on creating metadata that serves your users&apos; discovery needs, and let standards provide the framework for consistency and interoperability.
+
+As the data ecosystem continues to mature, organizations that invest in flexible, standards-based metadata approaches will find themselves better positioned to share data, collaborate across boundaries, and adapt to new technological developments. The metadata standards landscape may seem complex, but with the right approach, it becomes a powerful foundation for making data truly discoverable across organizations.
+
+Whether you&apos;re building a government open data portal, an academic research repository, or an enterprise data catalog, the principles remain the same: start simple, build consistently, and let standards amplify the value of your data through improved discovery and interoperability.
+</content>
     <summary type="html">Navigate the world of metadata standards from Dublin Core to DCAT to Frictionless Data. Learn which standards work best for government, academic, and enterprise data portals, and how to choose the right approach for your organization.</summary>
   </entry>
   <entry>
@@ -32,6 +1089,297 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+## Introduction
+
+In our [previous post](/blog/basics-of-metadata-how-it-helps-to-understand-your-data), we explored what metadata is and how it transforms raw data files into understandable resources. But metadata&apos;s true power emerges when you&apos;re managing not just one CSV file, but hundreds or thousands of datasets in a data catalog or portal.
+
+Imagine you’re a researcher looking for climate data about New York City in a government data portal with 5,000 datasets. Without good metadata and search capabilities, you’d need to browse through endless pages of cryptically named files. With rich metadata powering a search engine, you can simply type “climate data New York” and instantly find relevant datasets ranked by relevance. This doesn’t yet account for using natural language queries to discover data, which we’ll explore in upcoming posts on modern data catalogs and portals.
+
+## The Scale Challenge: From Dozens to Thousands of Datasets
+
+### When Browsing Breaks Down
+
+Small data collections work fine with simple browsing. A research team with 20 datasets can organize them in folders or basic categories. Users can scan through everything and find what they need.
+
+But data catalogs grow quickly:
+
+* **Municipal open data portals**: Often contain 50-2,000 datasets covering everything from parking violations to budget data.
+* **Enterprise data catalogs**: Can house 500-50,000 datasets across departments and systems.
+* **Research repositories**: May contain hundreds of thousands of datasets from different studies and institutions.
+
+At this scale, browsing becomes impossible. Users need search capabilities—and search engines need rich, consistent metadata to deliver relevant results.
+
+![Metadata search discovey illustration](/static/img/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs/metadata-search-discovery-illustration.png)
+
+&gt; [!info] A common question:
+&gt; Can our search engine query the actual data rows within tables?
+&gt; **Answer:**
+&gt; Not directly. Indexing every data row—especially for tables with millions of time-series records—would be prohibitively large and memory-intensive for engines like Elasticsearch. Instead, we index structured metadata (e.g., table schemas, column descriptions, data dictionaries) and generate salient “key points” or summaries. This approach keeps the search index lean and performant while still guiding users to the most relevant tables.
+
+### The Standardization Imperative
+
+When you have thousands of datasets, inconsistent or insufficient metadata creates chaos:
+
+```text
+// Inconsistent or insufficient metadata across datasets:
+Dataset 1: &quot;nyc_311_jan2023.csv&quot;
+Dataset 2: &quot;New York City 311 Service Requests - January 2023.xlsx&quot;
+Dataset 3: &quot;January 2023 NYC Citizen Complaints and Service Calls.pdf&quot;
+```
+
+Search engines can&apos;t effectively match these three related datasets to a user query like &quot;NYC 311 data&quot; because the metadata varies wildly.
+
+The solution is a **metadata schema**—a standardized list of metadata fields that all datasets must follow, a simple example would be:
+
+```yaml
+# Example metadata schema
+required_fields:
+  - title          # Human-readable dataset name
+  - description    # 2-3 sentence explanation
+  - owner          # Dataset maintainer/publisher
+  - license        # Usage permissions
+  - last_updated   # When data was last modified
+
+recommended_fields:
+  - tags           # Keywords for discovery
+  - category       # Thematic classification
+  - format         # File format (CSV, JSON, etc.)
+  - temporal_coverage  # Date range covered
+
+optional_fields:
+  - geographic_coverage  # Spatial extent
+  - update_frequency    # How often data changes
+  - data_quality_score  # Completeness/accuracy rating
+```
+
+This schema enables three critical capabilities:
+
+1. **Systematic indexing**: Search engines can reliably index the same fields across all datasets, ensuring consistent search behavior.
+
+2. **Enforced quality**: Required fields ensure every dataset has minimum discoverable information before publication.
+
+3. **Guided creation**: Data publishers know exactly what metadata to provide, with clear distinctions between required, recommended, and optional fields.
+
+&gt; [!info] Note about our simple yet powerful metadata standard and tooling
+&gt; [Frictionless Data](https://frictionlessdata.io/) is a progressive open-source framework for building data infrastructure – data management, data integration, data flows, etc. It includes various data standards and provides software to work with data.
+
+## Search Engines: The Discovery Engine Behind Data Catalogs
+
+### Popular Platform Combinations
+
+Modern data catalogs pair with powerful search engines to handle discovery at scale:
+
+* **CKAN + Apache Solr**: CKAN uses Solr&apos;s faceted search and text analysis capabilities to index dataset metadata, enabling complex filtering by organization, tags, formats, and date ranges.
+
+* **OpenMetadata + Elasticsearch**: OpenMetadata leverages Elasticsearch&apos;s real-time indexing to make data assets searchable immediately after ingestion, with support for complex queries across schemas, lineage, and usage patterns.
+
+* **Custom portals + various engines**: Many organizations build custom data portals using search engines like Elasticsearch, Solr, or even newer solutions like Meilisearch for specific performance requirements.
+
+### How Search Engines Index Metadata
+
+Here&apos;s what happens when you add a new dataset to a catalog:
+
+1. **Ingestion**: The catalog system reads both built-in metadata (filename, format, size) and external metadata files (title, description, tags)
+
+2. **Parsing &amp; Validation**: Metadata is parsed according to the catalog&apos;s schema and validated for required fields
+
+3. **Transformation**: Data is normalized—dates converted to standard formats, tags split into arrays, categories mapped to controlled vocabularies
+
+4. **Indexing**: The search engine creates searchable indexes from metadata fields, with different indexing strategies for text search vs. faceted filtering
+
+5. **Ranking**: Search algorithms determine relevance based on text matching, metadata completeness, dataset popularity, and recency
+
+## Rich Metadata = Better Matches
+
+### Title &amp; Description: The Foundation of Text Search
+
+Compare these two approaches to naming the same dataset:
+
+**Minimal metadata approach:**
+```text
+filename: NYC-311-2023-Q1.csv
+title: [same as filename]
+description: [empty]
+```
+
+**Rich metadata approach:**
+```text
+filename: NYC-311-2023-Q1.csv
+title: New York City 311 Service Requests - Q1 2023
+description: Comprehensive dataset of citizen complaints, service requests,
+and municipal responses from NYC&apos;s 311 system during January-March 2023.
+Includes request types, geographic distribution, response times, and
+resolution status for over 500,000 service requests.
+```
+
+When someone searches for &quot;NYC citizen complaints,&quot; the rich metadata provides multiple text matching opportunities:
+- &quot;NYC&quot; matches &quot;New York City&quot;
+- &quot;citizen&quot; matches &quot;citizen complaints&quot;
+- &quot;complaints&quot; matches the description text
+- &quot;service requests&quot; provides additional context
+
+The search engine can confidently rank this dataset highly for the user&apos;s query.
+
+### Tags &amp; Keywords: Enabling Faceted Discovery
+
+Tags transform search from simple text matching to structured exploration:
+
+```yaml
+# Example rich tagging for a transportation dataset
+tags:
+  - transportation
+  - public-transit
+  - bus-routes
+  - geographic-data
+  - real-time
+  - gtfs-format
+```
+
+These tags enable users to:
+- **Filter results**: &quot;Show me only transportation datasets&quot;
+- **Discover related data**: &quot;Other datasets tagged &apos;gtfs-format&apos;&quot;
+- **Refine searches**: &quot;Real-time transportation data&quot;
+
+### Categories &amp; Themes: Structured Browsing Paths
+
+While search handles specific queries, categories provide structure for exploration:
+
+```text
+Government Data Portal Categories:
+├── Transportation
+│   ├── Public Transit
+│   ├── Traffic &amp; Parking
+│   └── Infrastructure
+├── Environment
+│   ├── Air Quality
+│   ├── Water Resources
+│   └── Climate &amp; Weather
+└── Demographics
+    ├── Census Data
+    ├── Housing
+    └── Economic Indicators
+```
+
+Good categorization helps users discover datasets they didn&apos;t know existed.
+
+### Temporal &amp; Spatial Metadata: Context That Matters
+
+Time and location metadata enable powerful filtering:
+
+```yaml
+# Temporal metadata
+date_created: &quot;2023-01-15&quot;
+date_modified: &quot;2023-03-20&quot;
+temporal_coverage_start: &quot;2023-01-01&quot;
+temporal_coverage_end: &quot;2023-03-31&quot;
+update_frequency: &quot;daily&quot;
+
+# Spatial metadata
+geographic_coverage: &quot;New York City, NY, USA&quot;
+bounding_box:
+  north: 40.9176
+  south: 40.4774
+  east: -73.7004
+  west: -74.2591
+```
+
+This enables queries like:
+- &quot;Show me datasets updated in the last week&quot;
+- &quot;Find data covering Manhattan from 2020-2023&quot;
+- &quot;Daily updated transportation data&quot;
+
+## Real-World Example: Search in Action
+
+Let&apos;s trace how rich metadata helps a user find relevant data:
+
+**User query:** &quot;climate data New York&quot;
+
+**Dataset 1 (Poor metadata):**
+```text
+filename: weather_station_data_2023.csv
+title: weather_station_data_2023
+description: [empty]
+tags: [empty]
+```
+
+**Dataset 2 (Rich metadata):**
+```text
+filename: weather_station_data_2023.csv
+title: New York State Climate Monitoring Network - 2023 Weather Data
+description: Hourly temperature, precipitation, humidity, and wind measurements
+from 45 weather stations across New York State. Data quality controlled and
+validated by NYS Climate Office. Includes extreme weather events and monthly
+climate summaries.
+tags: climate, weather, temperature, precipitation, new-york, monitoring, hourly-data
+geographic_coverage: New York State, USA
+temporal_coverage: 2023-01-01 to 2023-12-31
+```
+
+**Search engine matching process:**
+
+1. **Text relevance**: Dataset 2 matches &quot;climate&quot; (exact match in tags and description) and &quot;New York&quot; (in title and geographic coverage)
+
+2. **Metadata completeness bonus**: Dataset 2 has rich descriptions and complete metadata fields, suggesting higher quality
+
+3. **Geographic precision**: &quot;New York State&quot; closely matches user&apos;s &quot;New York&quot; query
+
+4. **Thematic relevance**: Climate-related tags confirm this dataset is specifically about climate data
+
+**Result**: Dataset 2 ranks much higher and provides the user with clear information about whether it meets their needs—all before they even download it.
+
+## Building for Discovery: Metadata Standards
+
+### Popular Metadata Schemas
+
+Successful data catalogs adopt standardized metadata schemas:
+
+**DCAT (Data Catalog Vocabulary)**
+- W3C standard for web-based data catalogs
+- Defines common properties: title, description, keywords, themes, publisher, license
+- Enables cross-catalog data discovery and harvesting
+
+**Schema.org Dataset**
+- Structured data markup for web search engines
+- Helps Google and other search engines understand and index your datasets
+- Includes properties for data downloads, temporal coverage, and spatial coverage
+
+**Frictionless Data Package**
+- Lightweight standard with focus on data usability
+- Emphasizes clear resource descriptions and table schemas
+- Popular in research and scientific data communities
+
+**Custom Organizational Schemas**
+- Extended versions of standards with domain-specific fields
+- Example: Adding &quot;data_sensitivity_level&quot; for enterprise catalogs
+- Balance between standardization and specific organizational needs
+
+### The Consistency Advantage
+
+The most important factor isn&apos;t which schema you choose—it&apos;s applying it consistently across all datasets. A catalog where every dataset has a clear title, description, tags, and category will outperform one with perfect but inconsistent metadata.
+
+```yaml
+# Minimal but consistent schema across all datasets:
+title: [required - human readable name]
+description: [required - 2-3 sentences explaining the data]
+tags: [required - 3-5 relevant keywords]
+category: [required - from controlled vocabulary]
+license: [required - usage terms]
+last_updated: [required - ISO date format]
+```
+
+This consistency enables:
+- **Reliable search results**: Users can depend on finding complete information
+- **Effective filtering**: Faceted search works when fields are consistently populated
+- **Automated processing**: APIs and integrations can rely on standard fields being present
+
+## Conclusion
+
+Rich metadata is the bridge between data creators and data users at scale. While a single CSV file might need only basic context, data catalogs with hundreds or thousands of datasets require standardized, searchable metadata to remain useful.
+
+The combination of rich metadata and powerful search engines transforms data discovery from a frustrating browsing experience into targeted, relevant search results. Whether you&apos;re using CKAN with Solr, OpenMetadata with Elasticsearch, or building a custom solution, the principle remains the same: invest in consistent, descriptive metadata and your users will find exactly what they need.
+
+In our next post, we&apos;ll dive into the practical aspects of implementing metadata standards in your data portal—covering schema design, validation workflows, and migration strategies for existing catalogs.</content>
     <summary type="html">Learn how metadata transforms data discovery at scale—from search engines like Solr and Elasticsearch to standardized schemas that help users find exactly what they need among thousands of datasets.</summary>
   </entry>
   <entry>
@@ -43,6 +1391,154 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+## Introduction
+
+In the age of big data, raw datasets alone are seldom enough. Without context, understanding a table’s fields, provenance, or usage constraints can be a guessing game. **Metadata**—often described as “data about data”—fills this gap by providing structured, machine-readable descriptions of your datasets. In this article, we’ll explore:
+
+* What metadata is, at a technical level
+* Core metadata concepts including built-in information and external metadata.
+* Basics of further ingestion of metadata in various systems.
+
+Whether you’re building an internal data catalog or a public open-data portal, a robust metadata strategy is the key to making data discoverable, interoperable, and reusable.
+
+## 1. Defining Metadata
+
+Metadata is information that describes the characteristics and context of a data asset. It bridges the gap between raw data and meaningful insight by answering questions such as:
+
+* **What** the data represents (descriptive metadata)
+* **How** it is structured or formatted (structural metadata)
+* **Who**, **when**, and **where** the data was created or modified (administrative metadata)
+
+At the simplest level, metadata can be built into your storage layer (e.g., file name, format, timestamps). For richer context, you can supply external metadata files (JSON, YAML, XML, or simple text) that complement and enhance built-in attributes.
+
+![&quot;An iceberg showing a small tip labeled &apos;CSV File&apos; above water and a large submerged base labeled with metadata attributes like title, description, license, timestamps, and keywords.&quot;](/static/img/blog/basics-of-metadata-how-it-helps-to-understand-your-data/metadata-iceberg-illustration-vector.png)
+
+## 2. From Built-In to External Metadata: A Step-by-Step Example
+
+Let’s say you have a simple CSV file of temperature readings:
+
+```text
+// File on disk:
+temperature-readings-20250528.csv
+
+// Content preview:
+timestamp,value
+2025-05-28T00:00:00Z,15.2
+2025-05-28T01:00:00Z,14.9
+...
+```
+
+### 2.1. Built-In Metadata
+
+Every file system (and HTTP response) carries minimal metadata. For our CSV:
+
+* **File name**: `temperature-readings-20250528.csv`
+* **Media type**: `text/csv`
+
+These two attributes already tell machines:
+
+1. *what* the file is called, and
+2. *how* to parse it (as comma-separated values).
+
+But to your users—or to a search engine—you need richer context.
+
+&gt; [!info] Note about other built-in metadata:
+&gt; Beyond **file name** and **media type**, file systems and delivery protocols expose several other built-in metadata attributes you can leverage before you even add an external metadata file:
+&gt; 1. **File System Attributes**
+&gt;   * **Size** (`Content-Length` in HTTP): the total byte length of the CSV.
+&gt;   * **Timestamps**:
+&gt;     * **Created** (`birthtime` on many Unix-style systems)
+&gt;     * **Last modified** (`mtime`)
+&gt;     * **Last accessed** (`atime`)
+&gt;   * **Permissions &amp; Ownership**: who owns the file and its read/write/execute bits.
+&gt; 2. **HTTP/Transport Metadata** (when serving over HTTP)
+&gt;   * **ETag** or **Last-Modified** header: for cache validation.
+&gt;   * **Content-Encoding**: if you gzip/brotli the CSV in transit.
+&gt;   * **Content-Disposition**: suggests a download filename or whether to display inline.
+&gt; 3. **CSV-Specific “Built-In” Info** (derivable by quickly inspecting the file)
+&gt;   * **Header Row**: column names—essential structural metadata.
+&gt;   * **Row Count**: number of records (you can compute this cheaply on ingest).
+&gt;   * **Character Encoding**: e.g. UTF-8 vs. ISO-8859-1 (often exposed as `charset` in the MIME type).
+
+### 2.2. External Metadata
+
+Often, file names and media types alone are insufficient to convey the context users need. To enrich your CSV with human-readable information, you can provide an external metadata file. For a single attribute—such as a title—you might start with a basic text file named `metadata.txt`:
+
+```text
+Hourly temperature readings for May 28, 2025
+```
+
+While this simple file supplies a clear title, real-world use cases typically require multiple metadata fields (e.g., title, description, type). To represent these as structured data that programs can parse reliably, a key-value format is ideal. Consider the following YAML example:
+
+```yaml
+title: Hourly temperature readings for May 28, 2025
+description: |
+  This CSV contains one-hour-interval temperature measurements
+  recorded in Almaty, Kazakhstan on May 28, 2025. All timestamps
+  are in UTC. Data sourced from XXX weather station.
+```
+
+&gt; [!info] What is YAML?
+&gt; YAML (&quot;YAML Ain&apos;t Markup Language&quot;) is a human-friendly serialization format. Its indentation-based syntax and key-value structure make it easy to author and parse, making YAML a popular choice for metadata, configuration, and data interchange.
+
+The same information rendered in tabular form:
+
+| Metadata Field | Value                                                     | Purpose                                                                               |
+| -------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `title`        | Hourly temperature readings for May 28, 2025              | Provides a concise, human-readable name—easier for users to scan than a raw filename  |
+| `description`  | This CSV contains one-hour-interval temperature measurements recorded in Almaty, Kazakhstan on May 28, 2025. All timestamps are in UTC. Data sourced from XXX weather station. | Offers detailed context upfront, improving relevance judgment without inspecting data |
+
+&gt; [!info] Why add external metadata?
+&gt; Providing even a simple companion metadata file gives users immediate context—transforming opaque filenames into understandable resource descriptions. It enhances discoverability, improves usability, and lays the groundwork for rich search and filtering features.
+
+### 2.3. Taking It Further: Additional Attributes
+
+Once you’ve mastered `title` and `description`, you can add:
+
+* **keywords**: e.g. `temperature, Almaty, time series`
+* **license**: e.g. `CC-BY-4.0`
+* **provenance**: who collected it and when (e.g. `collectedBy: XXX weather station`).
+
+Each new attribute is just another line in your metadata file:
+
+```text
+keywords: temperature,Almaty,time series
+license: CC-BY-4.0
+collectedBy: XXX weather station
+```
+
+Many systems would automatically pick these up—no custom code required.
+
+### 2.4. How Ingestion Works
+
+1. **Discovery**
+   * An ingestion pipeline identifies data files and their companion metadata files (e.g., `.meta.txt`, `.json`, or `.yaml`).
+2. **Parsing**
+   * Read built-in metadata attributes (filename, media type, file size, timestamps) directly from the file system or HTTP headers.
+   * Parse the external metadata into structured fields (e.g., `title`, `description`, `keywords`).
+3. **Validation**
+   * Validate parsed metadata against a predefined schema or set of rules to ensure completeness and correctness.
+4. **Transformation**
+   * Normalize and transform metadata values (e.g., convert date formats, split comma lists into arrays).
+5. **Indexing**
+   * Store both built-in and external metadata in a search or catalog index, mapping specific fields to facets, full-text search, and structured exports (JSON‑LD, DCAT).
+   * This index powers discovery features like faceted filters, semantic ranking, and metadata exports.
+
+![&quot;Five-step metadata ingestion diagram showing Discovery, Parsing, Validation, Transformation, and Indexing stages with simple icons for each.&quot;](/static/img/blog/basics-of-metadata-how-it-helps-to-understand-your-data/metadata-ingestion-pipeline-steps-diagram.png)
+
+### 2.5. Why This Matters
+
+* **Clarity for Users**: A friendly title beats a cryptic filename.
+* **Better Search**: Rich text in `description` fuels full-text relevancy ranking.
+* **Faceted Filters**: Adding `keywords` and `license` turns those into clickable filters.
+* **Automation**: Keep your metadata alongside your data; pipelines stay simple.
+
+By starting with two built-in attributes and a tiny external text file, you can already transform raw CSV dumps into a fully searchable, self-documenting dataset. From here, extending to full JSON-LD or DCAT becomes a natural next step.
+
+## Conclusion
+
+Implementing metadata is not just a best practice—it&apos;s essential for unlocking the value of your data. By combining built-in attributes (file name, media type, timestamps) with external metadata files, you provide the context users need to discover, understand, and trust your datasets. A clear metadata strategy powers faceted search, semantic ranking, and linked-data features that scale from a simple CSV repository to enterprise-grade data catalogs. Start small with human-readable titles and descriptions, then grow your metadata alongside your data products to build truly data-driven experiences.</content>
     <summary type="html">Learn the basics of metadata—from built-in CSV attributes like filename and media type to simple external files—and see how it makes your data discoverable.</summary>
   </entry>
   <entry>
@@ -54,6 +1550,179 @@
     <author>
       <name>popovayoana</name>
     </author>
+    <content type="html">
+![CKAN](/static/img/blog/2025-05-28-Why-we-decoupled-CKAN’s-frontend/image1.png)  
+
+&gt; [!info] The short version?
+&gt; [CKAN](https://www.datopian.com/solutions/ckan) is a rock-solid backend for open data portals. 
+But what happens when you want to modernize the user experience?
+For us, the answer was simple: decouple the frontend.
+
+Modern open data portals need more than just a reliable backend. They need speed, customization, and a frontend that’s easy to scale and maintain.
+
+[CKAN](https://www.datopian.com/solutions/ckan) remains one of the most trusted open-source backends for managing datasets. But when it comes to the frontend experience, we chose to decouple — and here’s why.
+
+In this article, we’ll share why we chose to separate the frontend from CKAN’s traditional stack, how we approached it with **PortalJS**, and what we learned about performance, scalability, and developer experience along the way.
+
+## **CKAN: A Powerful Engine for Open Data**
+
+CKAN is widely used by governments, NGOs, and research institutions. Its backend is flexible, reliable, and API-driven — perfect for managing datasets at scale.
+
+But CKAN ships with a built-in frontend based on Flask, a lightweight Python web framework. While this works well for many use cases, we found that as user expectations evolved, so did the need for a more dynamic, scalable, and customizable frontend experience.
+
+That’s when we started asking:
+
+**What if we didn’t replace CKAN, but extended it — with a modern frontend layer built around today’s web standards?**
+
+## **What Is PortalJS and How Does It Work with CKAN?**
+
+**PortalJS** is a decoupled frontend framework built on Next.js. It connects to CKAN via API and replaces the traditional Flask frontend with a faster, more flexible layer.
+
+**Key Features**
+
+- **Static Site Generation (SSG):** Pre-render content that doesn’t change often
+- **Incremental Static Regeneration (ISR):** Update static content in the background
+- **Serverless functions:** Handle dynamic parts on demand
+- **React + TailwindCSS:** Build beautiful, responsive interfaces
+
+This means you can keep CKAN’s backend and get a frontend that:
+- Loads faster
+- Scales easier
+- Is more fun to build on
+
+## **The Case for a Decoupled Frontend**
+
+Our decision wasn’t about what&apos;s wrong with CKAN — it was about what&apos;s possible with a decoupled architecture.
+
+### **Monolithic Frontends: Solid, But Not Always Flexible**
+
+The traditional CKAN frontend is tightly coupled to the backend:
+
+- Each page is rendered dynamically by the server
+- Customizing the UI often means diving into Python templates
+- Developers need to manage full local stacks (Docker, Solr, PostgreSQL, Redis)
+
+This setup is reliable but comes with friction — especially for frontend teams used to modern JavaScript tooling and performance patterns.
+
+## **Why We Decoupled: The Benefits of Using PortalJS with CKAN**
+
+We built **PortalJS** to bring the best of both worlds together:
+
+- Keep CKAN as the backend
+- Replace the frontend with a modern, decoupled layer powered by **Next.js**
+
+PortalJS communicates with CKAN over its existing API. You still use CKAN to manage datasets, users, organizations, and metadata — but everything the user sees is rendered through a faster, more flexible frontend. 
+
+## **What We Gained by Decoupling**
+
+### **Better Performance**
+
+PortalJS uses Next.js features like:
+
+- **Static Site Generation (SSG)** for pages that rarely change
+- **Incremental Static Regeneration (ISR)** for fresh content, without backend load
+- **Serverless functions** for dynamic rendering only when needed
+
+This reduces API strain, speeds up page loads, and improves SEO dramatically.
+
+### **Happier Developers**
+
+Setting up CKAN’s frontend locally means spinning up Docker containers, databases, and search services.
+
+With PortalJS, the workflow looks like this:
+
+```shell
+npm install
+npm start
+```
+
+That’s it. Developers can focus on building features, not configuring infrastructure.
+
+### **More Customization**
+
+Because PortalJS is built with React and TailwindCSS, it’s easy to:
+
+- Redesign pages and navigation
+- Add filters and search interactions
+- Create responsive, mobile-friendly layouts
+
+You&apos;re no longer bound to the default CKAN UI — you can make it your own.
+
+## **Example: How We Handle Dataset Metadata Pages**
+
+In CKAN, every metadata page is rendered dynamically — even though most of that information rarely changes. And every visit hits the backend and database.
+
+With PortalJS, we pre-generate those pages using SSG. That means:
+
+- Instant load times
+- No database hit
+- SEO-friendly static content
+
+For parts that do change (like download counts or updated timestamps), we use client-side rendering or ISR.
+
+It’s the best of both worlds.
+
+## **CKAN + PortalJS: A Collaborative Architecture**
+
+**PortalJS is a frontend layer that works with CKAN — not against it.**
+
+You keep CKAN’s backend, workflows, extensions, and APIs.
+
+But you gain:
+
+- A smoother user experience
+- Easier customization
+- Better performance and scalability
+- Simpler developer onboarding
+
+It’s the same engine — just a better dashboard.
+
+## **Who This Is For**
+
+We’ve seen PortalJS help:
+
+- Governments modernize their public open data portals
+- Nonprofits simplify dataset publishing
+- Enterprises create internal data platforms with custom branding and UX
+
+If you&apos;re already using CKAN and want a more modern, maintainable frontend — **this is for you.**
+
+## **Final Thoughts: Let CKAN Do What It Does Best**
+
+CKAN remains one of the best backend systems for open data.
+
+PortalJS doesn’t change that — it simply opens new possibilities.
+
+By decoupling the frontend, we’ve been able to deliver faster, more beautiful, more usable portals — while still relying on the CKAN core that’s trusted worldwide.
+
+[🔗 Explore the full technical breakdown](https://www.portaljs.com/blog/why-portaljs-is-the-future-of-decoupled-frontend-for-data-portals)
+
+## **FAQs**
+
+**What’s the main reason to decouple the CKAN frontend?**
+
+To improve performance, scalability, and developer experience by using a modern, API-first frontend.
+
+**Does PortalJS replace CKAN?**
+
+No. PortalJS replaces only the frontend. CKAN still powers the backend, APIs, and admin functions.
+
+**Can I use existing CKAN extensions?**
+
+Yes. Since the backend remains CKAN, your extensions continue working as expected.
+
+**Where do I deploy PortalJS?**
+
+It runs on any frontend hosting provider. We recommend Vercel, Netlify, or Cloudflare Pages.
+
+**What’s the dev experience like?**
+
+Fast. No Docker required. Just clone, install dependencies, and start building with React.
+
+
+
+
+</content>
     <summary type="html">We explain why we chose to decouple CKAN’s frontend and how PortalJS made our data portal faster, more flexible, and easier to maintain. A practical look at SSG, serverless scaling, and modern dev workflows with CKAN.</summary>
   </entry>
   <entry>
@@ -65,6 +1734,112 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+## **Imagine a Faster, Smarter NASA Data Portal**
+
+What if a climate scientist visiting [data.nasa.gov](https://data.nasa.gov) could explore global time-series datasets through an interface that loads instantly, adapts to their workflow, and feels intuitive—on any device?
+Today, NASA’s portal runs on CKAN’s built-in frontend, which serves its purpose but limits performance and flexibility. By adopting a **decoupled frontend using PortalJS**, NASA could dramatically improve speed, user experience, and accessibility—without changing the backend.
+**This shift unlocks a more modern open data experience**, tailored for researchers, analysts, and developers working with large, complex datasets.
+
+![CKAN](/static/img/blog/2025-05-19-why-anyone-should-consider-decoupled-frontend/image2.webp)  
+
+## **The Current CKAN-Based Approach**
+
+[NASA’s portal](https://data.nasa.gov) uses CKAN’s built-in frontend — a unified structure where the user interface and backend are tightly connected.
+
+### **Monolithic UI &amp; API**
+
+CKAN’s integrated UI and backend deliver robust search and data-management workflows out of the box. It serves well for dataset CRUD, geospatial previews, and basic theming.
+
+**What Works:**
+
+- Out-of-the-box dataset management
+- Geospatial previews
+- Basic theming and search
+
+**Limitations**
+
+- **Release Cycle Coupling:** UI updates often require CKAN core upgrades or plugin rebuilds.
+
+&gt; [!info] In simple terms
+&gt; If you want to tweak the interface, you have to dig into the backend code. That slows things down and makes small changes more complicated than they should be.
+
+- **Branding Constraints:** Deep theming adjustments can be labor-intensive and risk conflicts with upstream.
+
+&gt; [!info] In simple terms
+&gt; Making your portal look like “NASA” (or any other organization) takes a lot of effort, and those changes may not survive future updates.
+
+- **Performance Overheads:** Server-side rendering for every page load can introduce latency under heavy traffic.
+
+&gt; [!info] In simple terms
+&gt; Every time someone opens a page, the server has to rebuild it. That slows things down when lots of people visit at once.
+
+## **Why a Decoupled PortalJS Front-End?**
+PortalJS is a frontend framework purpose-built for CKAN. PortalJS consumes CKAN’s REST API and renders the frontend independently using Next.js. This architecture gives teams more control over UX, while keeping the backend untouched.
+
+**Key advantages:**
+
+**1. Rapid Iteration**
+
+PortalJS applications consume CKAN’s REST APIs, enabling independent deployment of UI components. New features — like custom data-visualization panels — can ship without touching the CKAN codebase.
+
+
+**2. Enhanced UX &amp; Branding**
+
+- **Component Library:** Reusable “DatasetCard,” “FilterPanel,” and “MapExplorer” snippets conform to NASA’s design system.
+- **Responsive &amp; Accessible:** Built-in patterns for ARIA compliance and mobile-first layouts ensure broad reach.
+
+&gt; [!info] In simple terms
+&gt; You can make the portal look and feel exactly how your users expect, with reusable building blocks. Works well on phones and meets accessibility standards by default.
+
+**3. Scalability &amp; Resilience** Scalability &amp; Resilience By hosting the PortalJS front end on a CDN (e.g., Cloudflare) and separating it from CKAN servers, static assets load faster and UI downtime can be decoupled from backend maintenance windows.
+
+&gt; [!info] In simple terms
+&gt; Pages load almost instantly because they’re already generated and stored near your users — no waiting for the server to respond.
+
+## **A Blueprint for Decoupled Architecture**
+
+A decoupled setup keeps CKAN as the backend and places PortalJS on top as the user-facing layer. The backend stays stable, while the frontend can evolve quickly and scale independently. You serve pages fast, keep your infrastructure lightweight, and give teams more control.
+
+**1. API Gateway:**
+- AWS API Gateway or CloudFront Lambda@Edge enforcing API keys, rate-limits, and caching for CKAN REST endpoints.
+
+
+**2. PortalJS Application:**
+- Deployed to an S3 bucket + CloudFront distribution.
+- Integrations: CKAN’s /api/3/action routes for dataset search, resource download, and user authentication.
+
+
+**3. Extensibility Hooks:**
+- **Widget Registry:** Dynamically load visualization widgets (e.g., D3 timelines, Cesium 3D maps) based on dataset metadata.
+- **Theme Manager:** Allow NASA web teams to tweak color tokens and font scales via a JSON config file.
+
+![PortalJS](/static/img/blog/2025-05-19-why-anyone-should-consider-decoupled-frontend/PortalJS.gif) 
+
+## **Why This Matters**
+
+CKAN’s backend is solid. But a modern frontend makes ALL the difference. 
+
+This isn’t just about NASA. The same constraints exist for many governments, research labs, and institutions using CKAN.
+
+**Decoupling with PortalJS** unlocks:
+- Speed
+- Flexibility
+- Custom and modern UX
+- Resilient architecture
+
+&gt; [!info] Bottom line
+&gt; Your portal can grow, adapt, and look modern — without expensive rebuilds or risky changes to your data backend.
+
+### **See It in Action**
+
+Curious what this would look like for your team? Start a pilot in minutes — no backend changes required. 
+
+If you’d like to explore a PortalJS pilot on your CKAN instance — government, research institution, or enterprise — visit our [site](https://www.portaljs.com) and get started in minutes!
+
+📩 [Talk to us](https://calendar.app.google/sn2PU7ZvzjCPo1ok6) to discuss your use case.
+
+---</content>
     <summary type="html">NASA’s open data portal is powered by CKAN—but what if its user experience could match its scientific depth? This post explores how a decoupled frontend using PortalJS can transform performance, design flexibility, and scalability—without changing the backend. Learn how CKAN and PortalJS can work together to deliver a faster, smarter, and more user-friendly data experience.</summary>
   </entry>
   <entry>
@@ -76,6 +1851,209 @@
     <author>
       <name>williamlima</name>
     </author>
+    <content type="html">
+At PortalJS Cloud, we believe that managing and sharing open data should be effortless, beautiful, and accessible. That’s why we’ve launched a complete redesign of the PortalJS Cloud frontend—combining performance upgrades with a sleek, modern interface designed for everyone, from governments and non-profits to academic institutions and private organizations.
+
+The new version offers a cleaner interface, enhanced accessibility, and lightning-fast search—making it the smartest choice for modern open data initiatives.
+
+Let’s explore what’s new and how these improvements help you deliver a better data experience to your users.
+
+## **What’s New?**
+
+### **A Revamped User Interface**
+
+We’ve introduced a fresh, professional design across the entire portal. Pages like the homepage, dataset view, and search experience now feel smoother and more intuitive for all users.
+
+- **Modern, minimalist layout** for a polished first impression:
+
+![Home page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image14.webp)  
+_Home page_
+
+![Search page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image9.webp)  
+_Search page_
+
+![Dataset page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image3.webp)  
+_Dataset page_
+
+![Resource Preview Page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image7.webp)  
+_Resource Preview Page_
+
+- Optimized for **performance**
+- **Fully responsive** across desktop, tablet, and mobile devices  
+  ![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image2.gif)
+
+- Designed with accessibility in mind, meeting **WCAG 2.1 / 2.2 standards**
+  - All interactive elements (filters, tabs, buttons) are keyboard-friendly
+  - “Skip to content” navigation for screen reader users
+
+_![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image6.webp)_
+
+## **Smarter Search &amp; Filtering 🔍**
+
+We’ve made the search experience much easier and more powerful—especially when it comes to filtering and sharing results.
+
+**Shareable search results**
+
+We’ve rebuilt the search page so that every filter you apply—such as keywords, tags, or formats—is automatically reflected in the page URL. This is known as URL-synced search state.
+
+In other words, the portal keeps track of your search settings directly in the web address.
+
+What this means for the user:
+
+Let’s say a user filters for _“climate data from 2024”_. The page URL will automatically update to reflect those filters. They can now copy that link and send it to a colleague, who will land on the exact same filtered view. No need to repeat the search.  
+Plus, filters are saved in the browser history. So if someone clicks on a dataset, they can use the **Back** button to return to their filtered results—just like browsing a regular website.
+
+- You can copy and share the page link, and others will see the exact same filtered view
+- Saved URLs can act like bookmarks, helping users return to specific filtered searches anytime
+- The portal behaves more like modern apps, where your current view is always reflected in the URL
+
+**Minimal state usage**
+
+In web development, **&quot;state&quot;** is the information a page keeps track of while you’re using it—like which filters you’ve applied or what search terms you’ve entered.
+
+We’ve made sure that the search page in PortalJS Cloud only stores the _essential_ state. This means the system isn’t overloaded with unnecessary data, making everything simpler and faster behind the scenes.
+
+**What this means for the user:**
+
+- Pages load faster
+- Filters respond instantly
+- The portal is more stable—even with large datasets
+- Less chance of bugs or crashes
+
+**Faster and more reliable behind-the-scenes logic with React Context (no more prop-drilling)**
+
+Previously, when different parts of a web page needed to &quot;talk&quot; to each other (for example, when a filter affected the search results), the data had to be passed through multiple layers—like a game of telephone. This process is called **prop-drilling**, and it can get messy and hard to manage.
+
+Now, thanks to improved architecture (using something called [**React Context**](https://react.dev/learn/passing-data-deeply-with-context)), all search filters and components stay in sync automatically—without needing to repeat the same logic in multiple places. Think of it like everyone checking the same live dashboard instead of passing sticky notes around.
+
+**What this means for the user:**
+
+- The search page is easier to maintain, faster to load, and more robust
+- All filters, search bars, and results stay perfectly in sync
+- No lag, no glitches—just smooth, instant updates without reloading the page. The technology behind the scenes is optimized to deliver results quickly, even on slower internet connections.
+- New features and filters can be added quickly without breaking anything
+
+These upgrades make it easier for users to find the data they need—and to share it with others.
+
+![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image8.webp)
+
+### **Better Data Visualizations 📊**
+
+We’ve significantly improved the CSV preview component to make exploring data easier, more accessible, and more interactive.
+
+**Accessibility-First Design**
+
+The preview is now fully compliant with **WCAG 2.1 / 2.2 standards**, meaning it works smoothly with **keyboard navigation** and **screen readers**. Users can tab through rows and columns or use assistive technologies to understand and interact with the data.
+
+**New Interactive Features**
+
+We’ve added powerful new tools to help users make sense of large tables:
+
+- **Search within the table** – Instantly find specific columns or values.  
+   _Example: type “GDP” and jump straight to that column or row._
+- **Column selector** – Choose which columns to show or hide.  
+   _Great for reducing clutter when working with wide datasets._
+- **Pagination control** – Browse large datasets more easily, page by page.
+- **Export to JSON** – Download the data in developer-friendly format for further analysis or integration.
+
+![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image5.gif)
+
+### **Form &amp; Filter Accessibility**
+
+We’ve upgraded all form and filter components to be fully accessible (see Accessibility improvements screenshot above).
+
+- **Accessible labels** – Every input field, dropdown, and button now has a proper label that screen readers can detect and announce.
+- **Live filter updates** – When a user applies a filter, screen readers now receive real-time feedback about the change.  
+   _For example, “3 datasets found for your selection” is announced automatically._
+
+**What this means for the user:**
+
+- People using screen readers or keyboard navigation can interact with forms just as smoothly as others
+- Everyone can confidently use filters and forms, knowing exactly what’s happening on the page
+- Your data portal is more inclusive, user-friendly, and aligned with accessibility best practices
+
+**Visual &amp; Semantic Structure**
+
+Beyond visual design, we’ve made deeper improvements to the way the site is structured under the hood (see Accessibility improvements screenshot above).
+
+- **Verified color contrast** – All UI elements now meet recommended contrast ratios, ensuring readability for users with low vision or color blindness.
+- **Semantic HTML and ARIA roles** – We’ve reorganized the site structure using proper tags (like headers, sections, and landmarks), and added ARIA roles to give screen readers clear context and navigation cues.
+
+**What this means for the user:**
+
+- Text and buttons are easier to read in all lighting conditions
+- Assistive technologies can “understand” the layout and flow of each page
+- The portal feels more predictable and intuitive for everyone, including users with disabilities
+
+### **Easy Customization, Delivered Fast**
+
+Want to match your data portal to your brand’s color and logo? No problem. We’ve made it incredibly simple for our developers to update key visual elements like:
+
+- **Main template color** – Choose a color that fits your brand
+- **Portal logo** – Upload your organization’s logo in seconds
+
+These changes are configured via `.env` variable:
+
+`NEXT_PUBLIC_THEME_COLOR` and `NEXT_PUBLIC_PORTAL_LOGO`
+
+For example:
+
+```shell
+NEXT_PUBLIC_THEME_COLOR=#8847cd
+NEXT_PUBLIC_PORTAL_LOGO=/images/logos/purple.jpg
+```
+
+**What this means for you:**  
+If you need a color or logo update, we can make the change and deploy it almost instantly—no long wait times, no messy custom coding. Because we’ve built it smart from the start.
+
+![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image1.webp)
+
+### **Why Did We Change It?**
+
+- The old template had some outdated design elements and usability gaps.
+- We wanted to ensure first-time users have a smooth experience setting up their portal.
+- Aligning with modern web standards makes the portal more maintainable and professional.
+- Compliance with accessibility standards was a priority (more on that in our [accessibility article](https://docs.google.com/document/d/1nOBBnGbvPot30MAGonG7dOBxkXWSavVNmEb2o9ZzLBw/edit?tab=t.0#heading=h.1rkstvo96k3f)).
+
+### **Why We Redesigned PortalJS Cloud**
+
+We didn’t just give PortalJS Cloud a facelift—we rebuilt it with purpose.
+
+The previous design, while functional, had limitations. Some visual elements felt outdated, and usability gaps made it harder for new users to get started quickly.
+
+So we took a step back and asked: _What does a modern data portal need in 2025?_
+
+The answer was clear:
+
+- A **clean, intuitive interface** that welcomes first-time users
+- **Streamlined performance** across all devices
+- **Built-in accessibility**, ensuring everyone can navigate and explore data
+- A **future-proof foundation** that aligns with today’s web standards—and tomorrow’s
+
+You can read a bit more about why compliance with accessibility standards were a priority in our [accessibility article.](https://www.portaljs.com/blog/making-portalJS-cloud-admin-panel-accessible)
+
+This redesign is about helping governments, non-profits, researchers, and companies launch professional, user-friendly data portals—faster and more efficiently than ever before.
+
+👉 [**Try the new PortalJS Cloud today with a free 14-day trial**](https://cloud.portaljs.com/dashboard)—no credit card required. Experience the new look, lightning-fast performance, and modern accessibility, all in minutes.
+
+---
+
+### **Before &amp; After Comparison**
+
+![Homepage before](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image10.webp)
+_Homepage before_
+
+![Homepage after](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image11.webp)
+_Homepage after_
+
+![Search page before](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image12.webp)
+_Search page before_
+
+![Search page after](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image13.webp)
+_Search page after_
+
+---
+</content>
     <summary type="html">Discover how the redesigned PortalJS Cloud helps you launch a modern, WCAG 2.1/2.2-compliant open data portal—fully responsive, customizable, and optimized for lightning-fast search and data sharing. Built for governments, non-profits, academic institutions, and private organizations, it&apos;s the easiest way to deploy a user-friendly data platform in minutes.</summary>
   </entry>
   <entry>
@@ -87,6 +2065,82 @@
     <author>
       <name>Yoana Popova</name>
     </author>
+    <content type="html">
+What if the key to smarter, more transparent governance wasn’t spending more—but spending less? Too often, data portals are seen as unavoidable financial burdens, rather than an opportunity. But they don’t have to be. Your data portal can be a cornerstone of transparency, innovation, and better decision-making without draining your budget.
+
+Proprietary solutions, while promising the world, often deliver a painful bill. Hidden fees, rigid systems, and vendor lock-in quietly inflate costs while limiting your ability to adapt. And for what? A tool that’s supposed to serve your organization ends up as a line item that’s tough to justify.
+
+But what if it didn’t have to be this way? What if you could cut your data portal expenses by 90%—or more—every year **without compromising on performance, compliance, or scalability**? It’s not just a possibility; it’s a practical reality. Let’s break down where your money is going, and how a smarter approach can turn your data portal from a financial burden into a strategic asset.
+
+## Where Do the Costs Come From?
+
+If you’ve ever stared at a bloated invoice from a data portal vendor, you’ve probably wondered: Where is all this money going? Here’s what you’re often paying for:
+
+1. **Licensing Fees**: Proprietary solutions can charge six or even seven figures annually. And guess what? Those fees only grow as your data needs increase.
+
+2. **Customization Costs**: Need your portal to match your organization’s branding or workflows? Many platforms charge extra for every tweak.
+
+3. **Maintenance &amp; Hosting**: Whether it’s managing servers, ensuring uptime, or resolving bugs, these costs add up fast.
+
+4. **Training &amp; Support**: Onboarding your team often comes at an additional cost, and premium support packages can be staggeringly expensive.
+
+When you add it all up, it’s no wonder small towns, mid-sized cities, and even large governments struggle to justify the expense. But it doesn’t have to be this way.
+
+## The Open Source Alternative: Why CKAN Is the Gold Standard
+
+CKAN, the open-source data portal solution has become the gold standard for governments, NGOs, and research institutions. Unlike proprietary systems, CKAN is free to use, infinitely customizable, and backed by a global community of developers. But—and this is a big one—while CKAN saves you licensing fees, it doesn’t eliminate all costs. You still need hosting, maintenance, and a user-friendly frontend to make it work for your audience.
+
+That’s where solutions like **PortalJS Cloud** come into play. By combining CKAN’s power with modern, fully managed hosting and customizable frontends, you get the best of both worlds: open-source affordability and enterprise-grade performance.
+
+## How PortalJS Cloud Helps You Save
+
+Let’s break down exactly how PortalJS Cloud can help you trim 90% (or more) from your annual data portal expenses.
+
+1. No Licensing Fees
+Most proprietary platforms lock you into expensive annual contracts. PortalJS Cloud? None of that. Since it’s built on CKAN, you’re free from those hefty licensing costs. You’re essentially only paying for the hosting and support you need—not for the privilege of using the platform.
+
+2. Streamlined Maintenance &amp; Hosting
+Maintaining your own CKAN instance can be time-consuming and expensive, especially if you’re not a tech-heavy organization. PortalJS Cloud offers fully managed hosting, which means we handle the backend, updates, and troubleshooting for you. That’s one less thing for your IT team to worry about (or for you to outsource).
+
+3. Scalable Pricing
+Instead of a one-size-fits-all model, PortalJS Cloud scales to meet your needs. For small towns with limited budgets, plans start at just $99/month. Larger governments can choose plans with advanced features while still saving massively compared to proprietary options.
+
+4. Customizable Frontend Without Extra Fees
+Proprietary platforms often charge an arm and a leg for customization. PortalJS Cloud lets you tailor your data portal’s design and functionality without breaking the bank. Want your portal to reflect your city’s branding? Done. Need specific features for public-facing users? No problem.
+
+5. Faster Deployment, Lower Costs
+Some systems take months to set up, driving up costs with each passing day. PortalJS Cloud offers 5-minute deployment for basic configurations, so you can start sharing data (and seeing value) almost immediately.
+
+## A Quick Comparison: PortalJS Cloud vs. Proprietary Solutions
+
+
+| Feature             | Proprietary Solutions | PortalJS Cloud     |
+|---------------------|-----------------------|--------------------|
+| Annual Cost         | $100,000+             | Starting at $1,188 |
+| Customization Fees  | High                  | Included           |
+| Vendor Lock-In      | Yes                   | No                 |
+| Compliance Standards| Yes                   | Yes                |
+| Deployment Time     | Months                | Minutes            |
+
+## A Closer Look at Value
+
+When you’re not tied to a vendor’s roadmap or locked into their support contracts, you’re free to build the portal your community actually needs. Whether it’s improving data accessibility, expanding transparency efforts, or aligning your data strategy with your long-term goals, the shift to a smarter, more flexible solution creates space for meaningful progress.
+
+## More Than Savings: Future-Proofing Your Data Portal
+
+It’s not just about saving money. It’s about investing in a system that grows with you. PortalJS Cloud combines CKAN’s open-source foundation with modern architecture, ensuring your portal is scalable, adaptable, and built to last. Compliance with standards like WCAG 2.1 AA and DCAT ensures accessibility and interoperability, while features like automated updates and robust APIs simplify your workflow.
+
+Whether you’re managing a small-town transparency initiative or a large-scale federal data program, the combination of CKAN’s open-source foundation and PortalJS’s modern capabilities ensures your portal stays fast, flexible, and future-ready.
+
+By stepping away from rigid, high-cost systems, you regain control over your portal’s direction. This isn’t just a cost decision; it’s a strategic one.
+
+## Get Started Today
+
+Your data portal doesn’t need to be a burden. With PortalJS Cloud, you can achieve a balance between affordability, functionality, and long-term viability.
+
+Ready to cut your data portal costs by 90% (or more)? With PortalJS Cloud, you get the affordability of open source with the reliability of a fully managed platform.
+
+💡 **[Start Your Free Trial](https://portaljs.com/pricing)** today and see how easy and cost-effective your data portal can be. Or, if you’d prefer a closer look, **schedule a demo** with our team. </content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -98,6 +2152,177 @@
     <author>
       <name>shreyas</name>
     </author>
+    <content type="html">
+### Introduction
+CKAN, a powerful open-source data management system, traditionally stores only metadata about uploaded resources, leaving file storage to external solutions. In our implementation, we used Cloudflare R2 for resource storage, enabling users to upload assets either through a frontend application.
+
+However, we lacked an API-based approach for users to upload files directly. This blog details how we solved this limitation by introducing a new API endpoint for resource uploads and integrating Cloudflare R2 with CKAN using Cloudflare Workers, Queues, and Notifications to automate metadata updates.
+
+### Problem Statement
+By default, CKAN only stores metadata for resources, not the actual files. Users could:
+- Upload files through the frontend, which would generate and store the file URL in CKAN.
+- Provide an external URL directly via the UI or API.
+
+However, there was no provision for users to upload images through the API while ensuring seamless metadata association.
+
+### Solution Approach
+We tackled the issue in two steps:
+1. Enhancing CKAN API to support pre-signed URLs for uploads.
+2. Automating metadata linking after the upload using Cloudflare services.
+
+### Step 1: Modifying and Adding API Endpoints
+We introduced two key API improvements:
+- **`resource_upload` Endpoint**: Returns a pre-signed URL for an existing resource, allowing users to upload assets directly.
+- **Enhanced `resource_create` Endpoint**: Generates a pre-signed URL whenever a new resource is created, enabling direct uploads.
+
+#### Implementation:
+```python
+from ckanext.s3filestore.uploader import BaseS3Uploader
+from ckan.plugins.toolkit import get_action
+import ckan.plugins.toolkit as tk
+import ckan.logic as logic
+import logging
+
+ValidationError = logic.ValidationError
+log = logging.getLogger(__name__)
+
+def _generate_presigned_url(resource_id):
+    try:
+        uploader = BaseS3Uploader()
+        s3_client = uploader.get_s3_client()
+        bucket_name = uploader.bucket_name
+        object_key = f&quot;resources/api_uploads/{resource_id}&quot;
+
+        params = {&apos;Bucket&apos;: bucket_name, &apos;Key&apos;: object_key}
+        presigned_url = s3_client.generate_presigned_url(
+            ClientMethod=&apos;put_object&apos;, Params=params, ExpiresIn=3600)
+
+        return presigned_url
+    except Exception as e:
+        log.error(f&quot;Failed to generate presigned URL: {e}&quot;)
+        raise ValidationError({&quot;error&quot;: f&quot;Failed to generate presigned URL: {e}&quot;})
+
+def resource_upload(context, data_dict):
+    resource_id = data_dict.get(&apos;id&apos;)
+    if not resource_id:
+        raise ValidationError({&quot;id&quot;: &quot;Resource ID is required to generate upload URL.&quot;})
+
+    get_action(&apos;resource_show&apos;)(context, {&apos;id&apos;: resource_id})
+    presigned_url = _generate_presigned_url(resource_id)
+    return {&quot;presigned_url&quot;: presigned_url}
+
+@tk.chained_action
+def resource_create(up_func, context, data_dict):
+    result = up_func(context, data_dict)
+    resource_id = result.get(&quot;id&quot;)
+    presigned_url = _generate_presigned_url(resource_id)
+    result[&quot;presigned_url&quot;] = presigned_url
+    return result
+```
+This enhancement enables users to securely upload files via the API without needing to interact with the frontend.
+
+### Step 2: Automating Metadata Linking Using Cloudflare
+Once the file is uploaded, we need to link the uploaded file’s metadata with its CKAN resource entry. While the frontend seamlessly handles this by storing the file URL during resource creation, our API-based approach required an additional step to update metadata post-upload.
+
+To automate this process, we leveraged:
+- **Cloudflare R2 Event Notifications**
+- **Cloudflare Queues**
+- **Cloudflare Workers**
+
+#### Why Use These Cloudflare Features?
+- **Notifications**: Detect file uploads in real-time.
+- **Queues**: Buffer file upload events and handle them asynchronously.
+- **Workers**: Process queued events and update CKAN accordingly.
+
+#### Implementation
+##### Configuring R2 Event Notifications
+- Events triggered for objects in `resources/api_uploads/` on `PutObject`, `CopyObject`, and `CompleteMultipartUpload`.
+- Sends an event to the `r2-file-uploads` queue.
+
+##### Processing Events with Cloudflare Worker
+```javascript
+export default {
+  async queue(batch, env, ctx) {
+    for (const message of batch.messages) {
+      try {
+        let data = typeof message.body === &quot;string&quot; ? JSON.parse(message.body) : message.body;
+        console.log(&quot;Received R2 Event:&quot;, data);
+
+        const objectKey = data?.object?.key;
+        const resourceId = objectKey.replace(&quot;resources/api_uploads/&quot;, &quot;&quot;);
+        const fileUrl = `https://blob.datopian.com/${objectKey}`;
+
+        console.log(&quot;Updating CKAN with URL:&quot;, fileUrl);
+
+        // Fetch metadata (Content-Type)
+        const metadataResponse = await fetch(fileUrl, { method: &quot;HEAD&quot; });
+        if (!metadataResponse.ok) continue;
+
+        const fileType = metadataResponse.headers.get(&quot;Content-Type&quot;) || &quot;application/octet-stream&quot;;
+        console.log(&quot;Detected MIME Type:&quot;, fileType);
+
+        // Update CKAN resource metadata
+        const ckanApiUrl = &quot;https://demo.dev.datopian.com/api/3/action/resource_update&quot;;
+        const ckanApiKey = env.CKAN_API_KEY;
+
+        const updatePayload = { id: resourceId, url: fileUrl, format: fileType };
+        const response = await fetch(ckanApiUrl, {
+          method: &quot;POST&quot;,
+          headers: { &quot;Content-Type&quot;: &quot;application/json&quot;, &quot;Authorization&quot;: ckanApiKey },
+          body: JSON.stringify(updatePayload)
+        });
+
+        if (!response.ok) console.error(&quot;CKAN API Error:&quot;, await response.text());
+        else console.log(&quot;CKAN update successful!&quot;);
+      } catch (error) {
+        console.error(&quot;Error processing message:&quot;, error);
+      }
+    }
+  }
+};
+```
+The provided JavaScript code is a Cloudflare Worker that processes events from a Cloudflare Queue triggered by file uploads to Cloudflare R2 storage. Here&apos;s a brief explanation:
+
+1. **Event Processing**: The Worker listens for batch messages from the `r2-file-uploads` queue, which contains details about uploaded files.  
+
+2. **Extracting Metadata**: It extracts the uploaded file&apos;s key (path) and derives the `resourceId` from it.  
+
+3. **Fetching File Type**: It makes a `HEAD` request to the file URL to determine the MIME type.  
+
+4. **Updating CKAN**: It sends an API request to CKAN to update the resource metadata (file URL and format).  
+
+5. **Error Handling**: Logs errors if any step fails.  
+
+This automates linking uploaded files to CKAN resources, ensuring seamless metadata updates.
+
+### Future Possibilities
+This automation can be extended to other CKAN functionalities, such as:
+- Uploading organization or group images via API.
+- Supporting other cloud providers (AWS S3, Azure Blob Storage) using their event-driven tools like AWS Lambda and Azure Functions.
+
+### Example Integrations
+**AWS S3 → SNS + SQS + Lambda → CKAN API**
+- A file is uploaded to an S3 bucket.
+- An event notification triggers an SNS topic.
+- The SNS topic sends a message to an SQS queue.
+- A Lambda function reads the SQS message and updates the CKAN API with the file metadata.
+
+**Azure Blob → Event Grid + Functions → CKAN API**
+- A file is uploaded to an Azure Blob Storage container.
+- Event Grid detects the upload and triggers an Azure Function.
+- The Azure Function extracts metadata and updates the CKAN API accordingly.
+
+These platforms offer similar event-driven mechanisms, making it easy to integrate CKAN with different cloud providers.
+
+### Conclusion
+By integrating CKAN APIs with Cloudflare R2, Workers, and Queues, we successfully:
+- Enabled direct file uploads via API.
+- Automated the linking of uploaded files to CKAN resources.
+- Leveraged event-driven processing to ensure seamless user experience.
+
+This approach reduces API complexity for users while maintaining data consistency across systems. With similar integrations, CKAN can be extended to other cloud storage providers, enabling flexible and scalable data management.
+
+</content>
     <summary type="html">Integrating Cloudflare R2 with CKAN revolutionizes resource uploads by enabling direct API-based file storage. Using pre-signed URLs, event-driven processing, and automated metadata updates via Workers and Queues, this approach streamlines uploads, enhances data consistency, and eliminates manual intervention.</summary>
   </entry>
   <entry>
@@ -109,6 +2334,42 @@
     <author>
       <name>popovayoana</name>
     </author>
+    <content type="html">
+
+&gt;[!Key Takeaways]
+&gt; PortalJS has made user management much smoother. Admins can now add existing users to organizations instantly by entering their email—no redundant invites, no errors. If the user isn’t in the system, the invite process works as usual. This update streamlines team management, reduces admin workload, and ensures a better onboarding experience.
+
+
+## PortalJS Now Supports Smoother User Management
+
+Managing users across multiple organizations should be simple, not a tedious task. Yet, until now, adding existing users to a new team in PortalJS required unnecessary steps, redundant invitations, and, at times, frustrating errors.
+ 
+The latest PortalJS user management update makes this process more intuitive. Now, admins can add existing users to an organization by simply entering their registered email in the Members tab. If the user already exists, the system assigns them instantly. No extra steps. No unnecessary complications. If not, the usual invite process applies. This ensures a smooth and efficient team management for data platforms. 
+
+## What’s Improved?
+
+Previously, the system would always attempt to create a new user when sending an invite, causing errors if the user was already registered. The update refines the `user_invite` function by:
+
+- Checking for existing users before sending an invite.
+- Assigning users instantly if they are already in the system.
+- Falling back to the traditional invite process only if necessary.
+- Improving error handling so issues with email invites don’t block the process.
+
+![Add user to organization](/images/blog/add-user.webp)
+
+These refinements remove friction, ensuring admins spend less time on user management and more time on their actual work.
+
+## A More Streamlined Onboarding Experience
+
+For businesses and organizations scaling their data portals with PortalJS, efficient user administration is critical. This update reduces administrative workload for PortalJS admins, allowing them to focus on managing data, not troubleshooting user invites.
+
+With these improved user management features in PortalJS, teams can collaborate more effectively, ensuring smooth workflows for data-driven organizations. 
+
+## Get Started with PortalJS Cloud Today
+
+Launch your Data portal in under 5 minutes with PortalJS Cloud—the fastest and simplest way to share, manage, and collaborate on data. No infrastructure setup, no complex configurations—just a streamlined solution for governments, non-profits, academics, and companies of all sizes.
+
+[Get started now](https://cloud.portaljs.com/) and bring your data to life effortlessly.</content>
     <summary type="html">The latest PortalJS user management update makes this process more intuitive.</summary>
   </entry>
   <entry>
@@ -120,6 +2381,104 @@
     <author>
       <name>popovayoana</name>
     </author>
+    <content type="html">
+## The Need for Accessibility: Building a Digital City for All
+
+Imagine a city where half the streets have potholes so deep that some people can’t pass through. Where doors swing open only for those who fit a certain mold. Where street signs disappear when you look at them from a different angle. Sounds frustrating, right? That’s exactly how the web feels for millions of users when accessibility isn’t a priority.
+
+Accessibility isn’t a nice-to-have—it’s the foundation of a web that welcomes everyone. At PortalJS Cloud, we didn’t just tick compliance checkboxes; we built a digital ramp that ensures everyone gets through the front door.
+
+And we didn’t stop at the admin panel. Every **data portal built with PortalJS Cloud—in just five minutes—is fully WCAG-compliant.** Because accessibility isn’t a checkbox—it’s a mindset woven into everything we build.
+
+## WCAG 2.1 vs. WCAG 2.2: The Blueprint for Digital Inclusion
+
+Think of WCAG (Web Content Accessibility Guidelines) as an evolving map for a fairer internet.
+
+- **WCAG 2.1 (2018)** was like upgrading a city’s infrastructure to accommodate more people—introducing smoother sidewalks, better-lit streets, and accessible public transport for those with diverse needs.
+- **WCAG 2.2 (2023)** took it further by fine-tuning details that improve usability for people with cognitive disabilities and motor impairments. Think of it as adjusting traffic lights, widening sidewalks, and ensuring door handles work for everyone.
+
+## The Journey to an Accessible Admin Panel
+### **1. Auditing and Identifying Issues: Finding the Potholes**
+
+Before fixing anything, we needed to see where the cracks were. Using industry-standard tools like [WAVE](https://wave.webaim.org/), [axe DevTools](https://www.deque.com/axe/), and [Lighthouse](https://developer.chrome.com/docs/lighthouse/accessibility/), we ran a full audit. Every missing label, poor contrast ratio, and keyboard trap was a pothole we needed to fill.
+
+![Lighthouse accessibility check image](/images/blog/lighthouse.png)
+
+### **2. Keyboard Navigation: Every Click Should Have a Clear Path**
+
+For some users, a mouse is as useful as a submarine in a desert. They navigate using keyboards, screen readers, or voice commands. So we made sure that:
+
+- Every button, link, and form could be reached using only a keyboard. 
+![Keyboard navigation image](/images/blog/keyboard-navigation-1.png)
+- A clear visual focus was added to show users where they were on the page.
+- We built skip navigation links, the express lanes of web browsing, allowing users to jump straight to important sections.
+  &lt;img src=&quot;/images/blog/keyboard-navigation-2.png&quot; alt=&quot;Keyboard navigation image&quot; width=&quot;200&quot;/&gt;
+- All interactive elements were designed with a minimum target size of 24x24 pixels, ensuring ease of use for users with motor impairments.
+
+### **3. Fixing Forms: Because Guesswork Shouldn’t Be a Requirement**
+
+Forms are the bureaucratic paperwork of the web. Done wrong, they become a maze. Done right, they feel like a conversation. We ensured that:
+
+- Every form field had clear labels and instructions.
+- Error messages were descriptive and polite, guiding users instead of scolding them.
+- Focus didn’t disappear like a magician’s trick—it stayed predictable and logical.
+- Error prevention mechanisms were implemented for sensitive data entries, giving users confirmation prompts or undo options.
+  ![Error message image](/images/blog/error-message-1.png)
+  &lt;img src=&quot;/images/blog/error-message-2.png&quot; alt=&quot;Error message image&quot; width=&quot;400&quot;/&gt;
+
+### **4. Color Contrast: Making Text Stand Out Like a Lighthouse**
+
+Imagine reading a book where the ink is only a shade darker than the page. That’s what poor color contrast feels like. We ensured that:
+
+- Text and interactive elements had a minimum contrast ratio of 4.5:1, making them readable in all lighting conditions.
+- Alternative visual indicators (icons, underlines, patterns) helped those with color blindness navigate effortlessly.
+  ![Colour contrast image](/images/blog/color-contrast.png)
+
+### **5. Using Semantic HTML and ARIA Roles: Speaking a Universal Language**
+
+Screen readers rely on structure. If a webpage isn’t built with **semantic HTML**, it’s like trying to read a scrambled recipe. We:
+
+- Used semantic HTML to ensure that screen readers understood the page structure.
+- Added ARIA roles and attributes so users with assistive tech could grasp the purpose of each section.
+- Ensured consistent navigation elements throughout the admin panel to maintain familiarity for users.
+  &lt;img src=&quot;/images/blog/aria-labels.png&quot; alt=&quot;Aria labels image&quot; width=&quot;300&quot;/&gt;
+
+### **6. Testing with Real Users: Because Theory is Nothing Without Practice**
+
+Automated audits are useful, but they don’t catch everything. So we tested the admin panel with:
+
+- Screen readers (NVDA, JAWS, VoiceOver) to ensure content made sense.
+- Keyboard-only navigation to confirm smooth interactions.
+- Real users with disabilities, because lived experience trumps theory every time.
+
+## Why Accessibility is a Competitive Advantage
+
+This isn’t just about being compliant—it’s about creating an exceptional product. Here’s why accessibility matters:
+
+- **Inclusivity is Innovation** — The best designs work for everyone. Curb cuts, originally made for wheelchair users, are now a blessing for cyclists and parents with strollers. Digital accessibility follows the same rule.
+- **SEO Rewards Accessibility** — Search engines love structured, accessible content. Fixing accessibility often improves rankings.
+- **Legal Risks are Real** — Many companies have faced lawsuits for failing to meet accessibility standards. Avoiding them is smart business.
+- **Better UX for Everyone** — Accessibility improvements make life easier for **all** users—whether they’re on mobile, in a rush, or in a low-bandwidth area.
+
+## Accessibility Beyond the Admin Panel: A Fully Compliant Data Portal
+
+Accessibility isn’t a feature—it’s the foundation. That’s why **every data portal built with PortalJS Cloud is fully WCAG-compliant right out of the box**. In just five minutes, users can deploy a portal that:
+
+- **Provides seamless screen reader support**, ensuring datasets are easily navigable.
+- **Offers fully accessible data preview tables**, making data exploration effortless for everyone.
+- **Maintains optimized color contrast and keyboard accessibility**, enhancing usability across all devices.
+- **Eliminates mandatory dragging movements**, allowing users to interact without precision-based gestures.
+
+In an upcoming article, we’ll dive deeper into how we designed our out-of-the-box data portal templates to be fully WCAG-compliant, ensuring that accessibility is baked into every dataset preview, every UI element, and every interaction.
+
+## Accessibility is a Journey, Not a Destination
+
+Making the PortalJS Cloud Admin Panel accessible wasn’t a one-and-done project. It’s an ongoing commitment—like maintaining roads, updating maps, and making sure everyone can move freely in our digital city.
+
+The internet is a vast landscape, but we get to decide what kind of world we build. At PortalJS, we’re choosing one where **everyone** has a way in.
+
+Want to make your product accessible? Start with the [official WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) and build a web that works for all.
+</content>
     <summary type="html">Learn how PortalJS Cloud’s commitment to accessibility enhances the user experience for everyone.</summary>
   </entry>
   <entry>
@@ -131,6 +2490,114 @@
     <author>
       <name>Anuar Ustayev</name>
     </author>
+    <content type="html">
+## Introduction
+
+In the world of (open) data portals, a seamless, fast, and scalable frontend is crucial for delivering a great user experience. As the amount of data grows and user interactions become more complex, traditional monolithic frontends can become bottlenecks. This is especially true for platforms like CKAN, where the default frontend, built with Flask, can struggle to handle the demands of modern data-rich applications.
+
+This is where **PortalJS** comes in—a modern, decoupled frontend framework designed specifically for data portals. Built on top of **NextJS**, it brings the latest in web performance optimization to the world of open data. Unlike CKAN’s built-in frontend, PortalJS enables faster load times, more efficient use of APIs, and a far more flexible development environment.
+
+One of the key features that sets PortalJS apart is its ability to leverage **NextJS’s rendering strategies**, such as **Static Site Generation (SSG)**, **Server-Side Rendering (SSR)**, and **Incremental Static Regeneration (ISR)**. These techniques ensure that your data portal isn’t just faster but also scales more easily, reducing the load on your CKAN APIs and databases.
+
+In this post, we’ll explore how PortalJS transforms the frontend experience for data portals, compare it to CKAN’s traditional frontend, and dive into why features like ISR and SSG make a significant difference in performance and scalability.
+
+## Leveraging NextJS for Better Performance
+
+When it comes to performance, PortalJS, powered by NextJS, has a significant advantage. One of the key features NextJS brings to the table is its Incremental Static Regeneration (ISR) strategy. ISR allows for the generation of static pages on-demand, which means pages are pre-rendered once and then updated in the background, keeping the load on APIs and databases low. 
+
+This is a game-changer for data portals, especially those powered by CKAN, where the Flask-based frontend often regenerates pages dynamically. ISR, in contrast, helps keep pages static until necessary updates are made, making the whole system much more efficient. You get the best of both worlds: the speed of static pages and the freshness of dynamic content.
+
+But NextJS also offers other approaches like Static Site Generation (SSG) and Server-Side Rendering (SSR), which can be applied based on the specific needs of your data portal.
+
+### SSG for Static Content
+
+A perfect example of where **SSG** shines in CKAN is on its homepage. Most of the content on the homepage remains static—the structure, layout, and majority of the information doesn’t change often. While some sections, such as the “latest datasets” or statistics about the number of datasets, organizations, and groups, might be dynamic, these can be handled separately (for example, by re-fetching the dynamic parts on the client side).
+
+By building the CKAN homepage using **SSG**, you can ensure the page loads super fast, since it’s served as pre-generated static HTML, reducing load on the API and databases.
+
+### SSG for Dataset Metadata
+
+Another excellent use case for SSG is dataset metadata pages. In many data portals, dataset metadata—such as the title, description, tags, authors, and sources—are generally created once and remain unchanged. This makes it a great candidate for **SSG**. Pre-building these pages means they’ll load instantly, without the need for the backend to dynamically generate them with each request. This results in faster page loads and an overall smoother user experience.
+
+By using a combination of these strategies, PortalJS can dramatically reduce latency, improve SEO, and ensure that your data portal is scalable without overwhelming CKAN&apos;s APIs or databases.
+
+## Improved User Experience
+
+User experience is at the heart of any successful web application, and data portals are no exception. The way users interact with data—whether they’re browsing datasets, filtering through complex metadata, or simply exploring the portal’s interface—directly affects how useful and engaging the platform becomes.
+
+### Faster Page Loads
+
+One of the biggest frustrations users face with data portals is slow loading times, especially when the portal is packed with large datasets. CKAN’s Flask-based frontend typically relies on dynamic page generation, which can slow things down as each request hits the server and database.
+
+PortalJS, by contrast, can take advantage of Static Site Generation (SSG) and Incremental Static Regeneration (ISR) to pre-build pages and serve them instantly. The result? Faster load times, snappier navigation, and a much smoother experience for users.
+
+### Modern UI/UX Design
+
+With PortalJS, the frontend is decoupled from the backend, giving developers the freedom to craft highly customized user interfaces. You’re no longer restricted by the more rigid CKAN frontend, which can sometimes feel difficult to modify without diving into Python application, Docker set up and dealing with Apache Solr, Postgresql etc.
+
+PortalJS allows developers to integrate modern UI libraries, such as React components, Tailwind CSS, or Material UI, providing a much more polished, user-friendly design. This flexibility lets you create intuitive navigation, visually appealing layouts, and even responsive features that make the portal easier to use across devices.
+
+### Seamless Client-Side Interactions
+
+Another major benefit of PortalJS is its ability to handle client-side interactions more effectively. Using dynamic rendering capabilities, features like filtering datasets, sorting results, and searching for content can all be done without constantly reloading the page or hitting the backend server.
+
+This not only improves performance but also creates a more seamless user experience. With CKAN’s built-in frontend, interactions like these often require a round trip to the server, resulting in slower response times and more friction for users.
+
+## Scalability &amp; Modularity
+
+Scalability is a critical factor for data portals, especially when handling large datasets and growing user bases. With **PortalJS**, scaling your application becomes far more straightforward and cost-efficient compared to CKAN’s traditional monolithic frontend, which relies heavily on server-side resources.
+
+### Scaling Without a Server
+
+One of the most significant advantages of PortalJS is its ability to serve most of your pages statically, without requiring a dedicated server. Thanks to **Static Site Generation (SSG)**, many pages can be pre-built and then served from a simple object storage solution, such as **Cloudflare R2** or **AWS S3**. This not only reduces infrastructure costs but also dramatically improves the app’s ability to scale since you’re offloading traffic to globally distributed storage networks (CDNs), which are optimized for delivering static assets.
+
+For dynamic content that still requires server-side logic, **serverless functions** come into play. Pages that need to be generated on the fly can be handled by, for example, **AWS Lambda** functions, eliminating the need for traditional server infrastructure. By leveraging serverless architecture, you only pay for what you use, and scaling becomes seamless since cloud providers automatically manage resource allocation.
+
+### Common Deployment Platforms
+
+PortalJS applications are often deployed using modern hosting platforms like **Vercel** and **Netlify**, which make it incredibly easy to scale without the complexities of managing servers. These platforms are built to handle dynamic content using **Incremental Static Regeneration (ISR)** and support serverless functions to process on-demand requests. Additionally, **Cloudflare** has started supporting **server-side rendering** for PortalJS apps, giving developers even more options to balance static and dynamic content delivery.
+
+### Scaling on Vercel vs Hosting CKAN on AWS/GCP
+
+Now, let’s compare what it means to scale an app on Vercel versus hosting CKAN’s Python-based Flask application on traditional cloud services like **AWS** or **GCP** or **Azure**. When deploying a CKAN instance, you’re dealing with a monolithic application that requires dedicated servers or virtual machines. You must manage uptime, load balancing, and scaling on your own. If traffic spikes, the infrastructure needs to scale vertically or horizontally, often leading to increased complexity and higher costs.
+
+With **Vercel** (or platforms like **Netlify** or **Cloudflare Pages**), PortalJS handles scaling automatically. Static pages can be served globally via CDNs, and serverless functions take care of dynamic requests. You don’t have to worry about managing backend infrastructure—scaling is built into the platform, and your app adapts to changes in traffic without additional manual configuration.
+
+## Developer Experience
+
+A great developer experience (DX) is essential for productivity, especially in fast-paced environments where engineers need to iterate quickly. When it comes to building data portals, **PortalJS** dramatically simplifies the development workflow compared to CKAN’s traditional frontend setup.
+
+### Modern Development Stack
+
+Frontend engineers typically prefer working with a modern JavaScript stack, which includes tools like **React**, **NextJS** and **TailwindCSS** (or other modern CSS frameworks). These technologies are widely adopted, well-documented, and come with robust community support. However, developing with CKAN’s Flask-based frontend can feel much more cumbersome.
+
+To start working on CKAN’s default frontend, developers need to spin up Docker containers with services like **PostgreSQL**, **Apache Solr**, **Redis**, and CKAN (Python app) itself. This setup can take up a lot of storage on the developer&apos;s machine, especially when you need multiple CKAN instances for different projects. All these moving parts not only slow down the setup process but also increase the chances of running into configuration issues.
+
+With **PortalJS**, the workflow is refreshingly simple. Frontend engineers can clone a project and start development with just two commands:
+
+* npm install  
+* npm start
+
+That’s it. In a matter of minutes, developers have a fully functional local environment running, without the need to worry about databases, search engines, or caching systems.
+
+### Efficient Development with Hot Reloading
+
+Another significant advantage of PortalJS is its support for **hot reloading**. As soon as you make changes to your code, the browser automatically refreshes to reflect those updates, creating an instant feedback loop. This drastically improves productivity, allowing developers to see their changes in real-time without having to restart services or manually refresh the page.
+
+CKAN does have hot reloading through its Flask development server, which reloads the application when changes are detected. However, the experience may not be as smooth or fast as the hot reloading tools available in modern JavaScript frameworks like NextJS and React. Flask’s hot reloading works well for small changes but might slow down significantly in larger applications, especially if you’re dealing with Docker setups and various integrated services (like PostgreSQL, Solr, and Redis).
+
+### Simplified Multi-Project Development
+
+When handling multiple CKAN projects, spinning up individual instances for each one can be a heavy burden on your machine. Each CKAN instance requires its own PostgreSQL database, Solr service, and sometimes even Redis, making it a storage and resource hog. In contrast, PortalJS decouples the frontend entirely from CKAN’s backend. You can easily create and switch between different projects with minimal overhead, saving both time and disk space.
+
+By offloading backend complexity and streamlining the frontend, PortalJS enables a smoother, faster, and more enjoyable development experience for engineers, helping them focus on building beautiful interfaces instead of wrestling with infrastructure.
+
+## Conclusion
+
+In the evolving landscape of data portals, delivering an exceptional user experience while ensuring scalability and ease of development is crucial. The **PortalJS** framework, built on the powerful **NextJS**, offers a modern solution that addresses the limitations of CKAN&apos;s traditional frontend.
+
+Ultimately, choosing PortalJS as a decoupled frontend engine for data portals allows organizations to harness the best of both worlds—robust, high-performing applications that are easy to develop, scale, and maintain. By embracing this innovative approach, data portals can not only meet the demands of today but also adapt to the challenges of tomorrow.
+</content>
     <summary type="html">Let’s take a look at how PortalJS based decoupled frontend can improve your data portal, its performance, user experience and more.</summary>
   </entry>
   <entry>
@@ -142,6 +2609,35 @@
     <author>
       <name>Luccas Mateus</name>
     </author>
+    <content type="html">
+_This post was originally published on [the Datopian blog](http://datopian.com/blog/the-open-spending-revamp-behind-the-scenes)._
+
+In our last article, we explored [the Open Spending revamp](https://www.datopian.com/blog/the-open-spending-revamp). Now, let&apos;s dive into the tech stack that makes it tick. We&apos;ll unpack how PortalJS, Cloudflare R2, Frictionless Data Packages, and Octokit come together to power this next-level data portal. From our Javascript framework PortalJS, that shapes the user experience, to Cloudflare R2, the robust storage solution that secures the data, we&apos;ll examine how each piece of technology contributes to the bigger picture. We&apos;ll also delve into the roles of Frictionless Data Packages for metadata management and Octokit for automating dataset metadata retrieval. Read on for the inside scoop!
+
+## The Core: PortalJS
+
+At the core of the revamped OpenSpending website is [PortalJS](https://portaljs.org), a JavaScript library that&apos;s a game-changer in building powerful data portals with data visualizations. What makes it so special? Well, it&apos;s packed with reusable React components that make our lives - and yours - a whole lot easier. Take, for example, our sleek CSV previews; they&apos;re brought to life by PortalJS&apos; [FlatUI Component](https://storybook.portaljs.org/?path=/story/components-flatuitable--from-url). It helps transform raw numbers into visuals that you can easily understand and use. Curious to know more? Check out the [official PortalJS website](https://portaljs.org).
+
+![Data visualization](/static/img/blog/2023-10-13-the-open-spending-revamp-behind-the-scenes/data-visualization.png)
+
+## Metadata: Frictionless Data Packages
+
+Storing metadata might seem like a backstage operation, but it is pivotal. We chose Frictionless Data Packages, housed in the `os-data` GitHub organization as repositories, to serve this purpose. Frictionless Data Packages offer a simple but powerful format for cataloging and packaging a collection of data - in our scenario, that&apos;s primarily tabular data. These aren&apos;t merely storage bins - they align with FAIR principles, ensuring that the data is easily Findable, Accessible, Interoperable, and Reusable. This alignment positions them as an ideal solution for publishing datasets designed to be both openly accessible and highly usable. Learn more from their [official documentation](https://framework.frictionlessdata.io/).
+
+## The Link: Octokit
+
+Can you imagine having to manually gather metadata for each dataset from multiple GitHub repositories? Sounds tedious, right? That’s why we used Octokit, a GitHub API client for Node.js. This tool takes care of the heavy lifting, automating the metadata retrieval process for us. If you&apos;re intrigued by Octokit&apos;s capabilities, you can discover more in its [GitHub repository](https://github.com/octokit/octokit.js). To explore the datasets we&apos;ve been working on, take a look at [OpenSpending Datasets](https://github.com/os-data).
+
+## Storage: Cloudflare R2
+
+When it comes to data storage, Cloudflare R2 emerges as our choice, defined by its blend of speed and reliability. This service empowers developers to securely store large amounts of blob data without the costly egress bandwidth fees associated with typical cloud storage services. For a comprehensive understanding of Cloudflare R2, their [blog post](https://cloudflare.net/news/news-details/2021/Cloudflare-Announces-R2-Storage-Rapid-and-Reliable-S3-Compatible-Object-Storage-Designed-for-the-Edge/default.aspx) serves as an excellent resource.
+
+## In Closing
+
+In closing, we invite you to explore the architecture and code that power this project. It&apos;s all openly accessible in our [GitHub repository](https://github.com/datopian/portaljs/tree/main/examples/openspending). Should you want to experience the end result firsthand, feel free to visit [openspending.org](https://www.openspending.org/). If you encounter any issues or have suggestions to improve the project, we welcome your contributions via our [GitHub issues page](https://github.com/datopian/portaljs/issues). For real-time assistance and to engage with our community, don&apos;t hesitate to join our [Discord Channel](https://discord.com/invite/EeyfGrGu4U). Thank you for taking the time to read about our work! We look forward to fostering a collaborative environment where knowledge is freely shared and continually enriched. ♥️
+
+![FlatUiTable Code Snippet](/static/img/blog/2023-10-13-the-open-spending-revamp-behind-the-scenes/code-example.png)
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -153,6 +2649,149 @@
     <author>
       <name>Ola Rubaj</name>
     </author>
+    <content type="html">
+Hello, dear readers!
+
+We&apos;re excited to announce the official launch of MarkdownDB, an open source library to transform markdown content into sql-queryable data. Get a rich SQL API to your markdown files in seconds and build rich markdown-powered sites easily and reliably.
+
+We&apos;ve also created a new dedicated website:
+
+https://markdowndb.com/
+
+## 🔍 What is MarkdownDB?
+
+MarkdownDB transforms your Markdown content into a queryable, lightweight SQLite database. Imagine being able to treat your collection of markdown files like entries in a database! Ever thought about fetching documents with specific tags or created in the past week? Or, say, pulling up all tasks across documents marked with the &quot;⏭️&quot; emoji? With MarkdownDB, all of this (and more) is not just possible, but a breeze.
+
+## 🌟 Features
+
+- Rich metadata extracted including frontmatter, links and more.
+- Lightweight and fast indexing 1000s of files in seconds.
+- Open source and extensible via plugin system.
+
+## 🚀 How it works
+
+### You have a folder of markdown content
+
+For example, your blog posts. Each file can have a YAML frontmatter header with metadata like title, date, tags, etc.
+
+```md
+---
+title: My first blog post
+date: 2021-01-01
+tags: [a, b, c]
+author: John Doe
+---
+
+# My first blog post
+
+This is my first blog post.
+I&apos;m using MarkdownDB to manage my blog posts.
+```
+
+### Index the files with MarkdownDB
+
+Use the npm `mddb` package to index Markdown files into an SQLite database. This will create a `markdown.db` file in the current directory.
+
+```bash
+# npx mddb &lt;path-to-folder-with-your-md-files&gt;
+npx mddb ./blog
+```
+
+### Query your files with SQL...
+
+E.g. get all the files with with tag `a`.
+
+```sql
+SELECT files.*
+FROM files
+INNER JOIN file_tags ON files._id = file_tags.file
+WHERE file_tags.tag = &apos;a&apos;
+```
+
+### ...or using MarkdownDB Node.js API in a framework of your choice!
+
+Use our Node API to query your data for your blog, wiki, docs, digital garden, or anything you want!
+
+E.g. here is an example of a Next.js page:
+
+```js
+// @/pages/blog/index.js
+import React from &apos;react&apos;;
+import clientPromise from &apos;@/lib/mddb.mjs&apos;;
+
+export default function Blog({ blogs }) {
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Blog&lt;/h1&gt;
+      &lt;ul&gt;
+        {blogs.map((blog) =&gt; (
+          &lt;li key={blog.id}&gt;
+            &lt;a href={blog.url_path}&gt;{blog.title}&lt;/a&gt;
+          &lt;/li&gt;
+        ))}
+      &lt;/ul&gt;
+    &lt;/div&gt;
+  );
+}
+
+export const getStaticProps = async () =&gt; {
+  const mddb = await clientPromise;
+  // get all files that are not marked as draft in the frontmatter
+  const blogFiles = await mddb.getFiles({
+    frontmatter: {
+      draft: false,
+    },
+  });
+
+  const blogsList = blogFiles.map(({ metadata, url_path }) =&gt; ({
+    ...metadata,
+    url_path,
+  }));
+
+  return {
+    props: {
+      blogs: blogsList,
+    },
+  };
+};
+```
+
+And the imported library with MarkdownDB database connection:
+
+```js
+// @/lib/mddb.mjs
+import { MarkdownDB } from &apos;mddb&apos;;
+
+const dbPath = &apos;markdown.db&apos;;
+
+const client = new MarkdownDB({
+  client: &apos;sqlite3&apos;,
+  connection: {
+    filename: dbPath,
+  },
+});
+
+const clientPromise = client.init();
+
+export default clientPromise;
+```
+
+### Build your blog, wiki, docs, digital garden, or anything you want
+
+And share it with the world!
+
+![[/static/img/blog/markdowbdb-launch-site-example.png]]
+
+👉 [Read the full tutorial](https://markdowndb.com/blog/basic-tutorial)
+
+---
+
+Find out more on our new official website: https://markdowndb.com/
+
+Check out the source on GitHub: https://github.com/datopian/markdowndb
+
+— Ola Rubaj, Developer at Datopian
+</content>
     <summary type="html">MarkdownDB - an open source library to transform markdown content into sql-queryable data. Build rich markdown-powered sites easily and reliably. New dedicated website at markdowndb.com</summary>
   </entry>
   <entry>
@@ -164,6 +2803,71 @@
     <author>
       <name>ola-rubaj</name>
     </author>
+    <content type="html">
+Hey everyone! 👋 Summer has been in full swing, and while I&apos;ve managed to catch some vacation vibes, I&apos;ve also been deep into code. I&apos;m super excited to share some of the latest updates and features we&apos;ve rolled out over the past two months. Let&apos;s dive in:
+
+## 🌷 Flowershow
+
+https://flowershow.app/
+
+1. **CLI is old news**: the Flowershow CLI has been deprecated in favor of our new [Flowershow Obsidian plugin](https://github.com/datopian/obsidian-flowershow).
+
+2. **Self-publishing made even easier**: I wrote a [self-publish tutorial](https://flowershow.app/docs/publish-howto) to guide you through using our Obsidian plugin for publishing your digital garden.
+
+3. **Cloud-publishing MVP**: The first version of our Flowershow Cloud which aims to make publishing your digital garden notes a breeze! [Check out the overview](https://flowershow.app#cloud-publish) and stay tuned 📻!
+
+4. **Hydration errors from Obsidian transclusions/note embeddings are fixed**: For now, note transclusions will convert to regular links, but stay tuned — support for note embeds may be on the horizon. [Learn more](https://github.com/datopian/flowershow/issues/545)
+
+5. **New Obsidian tags list format support**: I added support for Obsidian&apos;s new tag list format, so now your notes can be even more organized. [Learn more](https://github.com/datopian/flowershow/issues/543)
+
+## 🗂️ MarkdownDB
+
+https://github.com/datopian/markdowndb
+
+1. **Auto-Publishing to npm**: Changesets now trigger auto-publishing, so we&apos;re always up to date.
+2. **Obsidian-style wiki links**: Extracting wiki links with Obsidian-style shortest paths is supported now.
+
+## 📚 The Guide
+
+https://portaljs.org/guide
+
+I’ve sketched overviews for two upcoming tutorials:
+
+1. **Collaborating with others on your website**: Learn how to make your website projects a team effort. [See it here](https://portaljs.org/guide#tutorial-3-collaborating-with-others-on-your-website-project)
+2. **Customising your website and previewing your changes locally**: Customize and preview your site changes locally, without headaches. [See it here](https://portaljs.org/guide#tutorial-4-customising-your-website-locally-and-previewing-your-changes-locally)
+
+## 🌐 LifeItself.org
+
+https://lifeitself.org/
+
+LifeItself.org is our website built on the Flowershow template, and it&apos;s been getting some extra care too.
+
+1. New blog home page layout with:
+
+- **Team Top Selection**
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-top-picks.png]]
+
+- **Latest Blog Posts**
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-latest-blogs.png]]
+
+- And the long awaited filtering by category 🎉
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-categories.png]]
+
+[👉 Check out the changes!](https://lifeitself.org/blog)
+
+2. **Blog posts layout revamp**: Refreshed design with share options, reading time estimates, and more.
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-blog-post.png]]
+
+---
+
+That wraps it up for now! As always, I&apos;m eager to hear your thoughts and feedback. Feel free to report issues or ask for features on our GitHub repositories. Until next time and happy publishing!
+
+— Ola Rubaj, Developer at Datopian
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -175,6 +2879,67 @@
     <author>
       <name>João Demenech</name>
     </author>
+    <content type="html">
+This post walks you though adding maps and geospatial visualizations to PortalJS.
+
+Are you interested in building rich and interactive data portals? Do you find value in the power and flexibility of JavaScript, Nextjs, and React? If so, [PortalJS](https://portaljs.org/) is for you. It&apos;s a state-of-the-art framework leveraging these technologies to help you build rich data portals.
+
+Effective data visualization lies in the use  of various data components. Within [PortalJS](https://portaljs.org/), we take data visualization a step further. It&apos;s not just about displaying data - it&apos;s about telling a story through combining a variety of data components.
+
+In this post we will share our latest enhancement to PortalJS: maps, a powerful tool for visualizing geospatial data. In this post, we will to take you on a tour of our experiments and progress in enhancing map functionalities on PortalJS. The journey is still in its early stages, with new facets being unveiled and refined as we perfect our API.
+
+## Exploring Map Formats
+
+Maps play a crucial role in geospatial data visualization. Several formats exist for storing and sharing this type of data, with GeoJSON, KML, and shapefiles being among the most popular. As a prominent figure in the field of open-source data portal platforms, [PortalJS](https://portaljs.org/) strives to support as many map formats as possible.
+
+Taking inspiration from the ckanext-geoview extension, we currently support KML and GeoJSON formats in [PortalJS](https://portaljs.org/). This remarkable extension is a plugin for CKAN, the world’s leading open source data management system, that enables users to visualize geospatial data in diverse formats on an interactive map. Apart from KML and GeoJSON formats support, our roadmap entails extending compatibility to encompass all other formats supported by ckanext-geoview. Rest assured, we are committed to empowering users with a wide array of map format options in the future.
+
+So, what makes these formats special?
+
+- **GeoJSON**: This format uses JSON to depict simple geographic features and their associated attributes. It&apos;s often hailed as the most popular choice in the field.
+- **KML**: An XML-based format, KML can store details like placemarks, paths, polygons, and styles.
+- **Shapefiles**: These are file collections that store vector data—points, lines, and polygons—and their attributes.
+
+## Unveiling the Power of Leaflet and OpenLayers
+
+To display maps in [PortalJS](https://portaljs.org/), we utilize two powerful JavaScript libraries for creating interactive maps based on different layers: Leaflet and OpenLayers. Each offers distinct advantages (and disadvantages), inspiring us to integrate both and give users the flexibility to choose.
+
+Leaflet is the leading open-source JavaScript library known for its mobile-friendly, interactive maps. With its compact size (just 42 KB of JS), it provides all the map features most developers need. Leaflet is designed with simplicity, performance and usability in mind. It works efficiently across all major desktop and mobile platforms.
+
+OpenLayers is a high-performance library packed with features for creating interactive web maps. OpenLayers can display map tiles, vector data, and markers sourced from anywhere on any webpage. It&apos;s an excellent tool for leveraging geographic information of all kinds.
+
+## Introducing Map Feature
+
+Both components have some similar features and props, such as:
+
+### Polygons and points
+
+![Map with polygons and points](/static/img/blog/2023-07-18-Adding-maps-to-portaljs/2023-07-18-map-polygons-and-points.png)
+
+Our initial version enables the use of both vectors and points to display information. Points are simpler and faster to render than vectors, but they have less detail and interactivity. For example, if you have data that is represented by coordinates or addresses, you can use points to show them on the map. This way, you can avoid time-consuming loading and rendering complex vector shapes that may slow down your map.
+
+### Tooltips
+
+![Map with tooltips](/static/img/blog/2023-07-18-Adding-maps-to-portaljs/2023-07-18-map-tooltips.png)
+
+We have implemented an exciting feature that enhances the usability of our map component: tooltips. When you hover over a polygon or point on the map, a small pop-up window, known as a tooltip, appears. This tooltip provides relevant details about the feature under your cursor, according to what features the map creator wants to highlight. For example, when exploring countries, you can effortlessly discover their name, population, and area by hovering over them. Similarly, hovering over cities reveals useful information like their name, temperature, and elevation. To enable this handy tooltip functionality on our map, simply include a tooltip prop when using the map component.
+
+### Focus
+
+![Map with polygons over a region](/static/img/blog/2023-07-18-Adding-maps-to-portaljs/2023-07-18-map-polygons-on-region.png)
+
+Users can also choose a region of focus, which will depend on the data, by setting initial center coordinates and zoom level. This is especially helpful for maps that are not global, such as the ones that use data from a specific country, city or region.
+
+## Mapping the Future with PortalJS
+
+Through our ongoing enhancements to the [PortalJS library](https://storybook.portaljs.org/), we aim to empower users to create engaging and informative data portals featuring diverse map formats and data components.
+
+Why not give [PortalJS](https://portaljs.org/) a try today and discover the possibilities for your own data portals? To get started, check out our comprehensive documentation here: [PortalJS Documentation](https://portaljs.org/docs).
+
+Have questions or comments about using [PortalJS](https://portaljs.org/) for your data portals? Feel free to share your thoughts on our [Discord channel](https://discord.com/invite/EeyfGrGu4U). We&apos;re here to help you make the most of your data.
+
+Stay tuned for more exciting developments as we continue to enhance [PortalJS](https://portaljs.org/)!
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -186,6 +2951,251 @@
     <author>
       <name>Ola Rubaj</name>
     </author>
+    <content type="html">
+In this tutorial, we will walk you through the process of editing your Flowershow website locally on your computer. 
+
+By the end of this tutorial, you will:
+
+- Understand what is Markdown and why you should use Obsidian to edit content on your Flowershow websites in most cases.
+- Gain a deeper understanding of working with Git and GitHub Desktop.
+- Learn how to clone your website&apos;s repository to your computer.
+- Learn how to edit content using Obsidian and what are the benefits of it.
+- Learn how to commit (save) your changes locally and push them back to the GitHub repository.
+
+Below is a screenshot of how the final website will look like:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/tutorial-2-result.png]]
+
+Let&apos;s start by understanding why using GitHub UI as we did in tutorial 1 is not always a good choice.
+
+## What is Markdown and why use Obsidian for editing it in Flowershow-based websites
+
+While editing on the GitHub UI is convenient, there are certain limitations and drawbacks to consider. For example, you can&apos;t work offline, can&apos;t add or edit multiple files simultaneously, and the GitHub UI&apos;s preview doesn&apos;t render all the Markdown syntax elements that are supported by Flowershow-based websites.
+
+Ok, but, what exactly is Markdown?
+
+[Markdown](https://en.wikipedia.org/wiki/Markdown) is a simple and intuitive syntax, that allows you to structure your text documents. It&apos;s widely used for creating content on the web. As Wikipedia puts it:
+
+&gt; *Markdown is a lightweight [**markup language**](https://en.wikipedia.org/wiki/Markup_language) for creating [**formatted text**](https://en.wikipedia.org/wiki/Formatted_text) using a **plain-text editor**.*
+
+The key term here is &quot;markup language&quot;. In simple terms, it is a way to annotate or &quot;mark up&quot; a plain text document with symbols that describe how the document is structured and so, how it should be understood, processed, or displayed. These tags can tell a computer program that supports this syntax (e.g. a website) how to format the rendered text, for example: which words should be bold or italic, where to insert images, when to start new paragraphs, how to create tables, and so forth. It&apos;s important to note, that even though Markdown symbols change how the text is displayed when it&apos;s rendered by a Markdown-compatible viewer, the underlying document in still just a plain text. For instance, if you want to create a heading in Markdown, you use the &quot;#&quot; symbol before your heading text, like this:
+
+```md
+# This is a Heading
+```
+
+BUT, there is no single version of Markdown. It comes in different &quot;flavours&quot;, with CommonMark and GitHub Flavoured Markdown (GFM) being the most popular ones. And different tools supporting Markdown may use their own specific versions of Markdown. The two tools relevant in the context of this guide are Obsidian and Flowershow.
+
+Obsidian supports an extended version of Markdown that includes majority of elements from CommonMark and GFM, while also introducing its own unique features, like [wiki-links](https://help.obsidian.md/Linking+notes+and+files/Internal+links) or [callouts](https://help.obsidian.md/Editing+and+formatting/Callouts). And Flowershow template is Obsidian-compatible, meaning it supports (or aims to support) all of the Obsidian Markdown features.
+
+To make things a bit clearer, there are:
+
+- CommonMark
+- GitHub Flavored Markdown (GFM) - superset of CommonMark
+- &quot;Obsidian flavoured Markdown&quot; - majority of the GFM + some extra elements, like wiki-links or callouts
+- &quot;Flowershow flavoured Markdown&quot; - majority of Obsidian-supported syntax
+
+As you might have guessed by now, GitHub UI will only preview GitHub Flavoured Markdown. And while it&apos;s a majority of Markdown you would write, it won&apos;t be able to render Obsidian-only (or Flowershow-only) syntax elements, like callouts, wiki-links or inline table of contents.
+
+Another drawback of GitHub UI, is that it doesn&apos;t allow you to make changes (or to add) multiple files at once. Changes to each file will have to be commited (saved) separately, which can introduce a bit of a mess to your GitHub history, and may be cumbersome (e.g. if you want to update a link to some page on 10 other pages...).
+
+Ok, now we have this sorted, let&apos;s dive in and start editing your Flowershow website locally!
+
+## Prerequisites
+
+- A [GitHub](https://github.com/) account.
+- A [Vercel](https://vercel.com/) account. You can set it up using your GitHub account.
+- [Obsidian](https://obsidian.md/) installed
+- [GitHub Desktop](https://desktop.github.com/) installed
+- [[create-a-website-from-scratch|Tutorial 1: Create a website from scratch using Markdown and PortalJS]] completed - this one is recommended so that you have the same sandbox website we&apos;re working on in this tutorial.
+
+## Clone the GitHub repository on your computer
+
+### 1. Open GitHub Desktop app
+
+### 2.  Click on &quot;Clone a Repository from the Internet...&quot;
+
+Or click on &quot;File&quot; -&gt; &quot;Clone repository&quot;.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-starting-screen.png]]
+
+If this is the first time you&apos;re using GitHub Desktop, it will prompt you to log in to your GitHub account. Click &quot;Sign In&quot; and follow the prompts.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-clone-signin.png]]
+
+Once you&apos;re done and you&apos;ve authorised GitHub Desktop to access your repositories, go back to GitHub Desktop. You should now see a list of all your GitHub repositories. 
+
+### 3. Select the repository you want to clone
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-clone.png]]
+
+### 4. Choose where your repository should be saved
+
+Type the path manually or click &quot;Choose...&quot; to find it using file explorer.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-clone-path-select.png]]
+
+### 5. Click &quot;Clone&quot; and wait for the process to complete
+
+You should now see the following screen:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-no-local-changes.png]]
+
+Done! You&apos;ve successfully cloned your website&apos;s repository on your computer! 🎉
+
+## Edit your site in Obsidian
+
+### 1. Open Obsidian
+
+### 2. Open your repository&apos;s `/content` folder as vault
+
+Click on &quot;Open&quot; in &quot;Open folder as vault&quot; section and select the path to the `/content` of the cloned repository.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-starting.png]]
+Now you&apos;re ready to edit your site! In the left-hand side panel you should see the two files we created in [[create-a-website-from-scratch|tutorial 1]]: `index.md` and `about.md`.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-start.png]]
+
+### 3. Edit your site&apos;s content
+
+Now, let&apos;s add some more stuff to the home page.
+
+Click on `index.md` to open it and replace the dummy text with &quot;About Me&quot; section, .e.g.:
+
+```md
+## About Me
+
+Hey there! I&apos;m Your Name, a passionate learner and explorer of ideas.
+```
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-edit.png]]
+
+Now, let&apos;s say for more information about you and your site, you want to add link to the about page. You can do so, by creating a wiki-link to that page, like so:
+
+```md
+[[about]]
+```
+
+When you start typing, after writing empty double brackets `[[]]`, Obsidian will suggest all the available pages you can link to, and after you select one it will create the link automatically for you.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-add-link.png]]
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-add-link-2.png]]
+
+Now, let&apos;s say you want to show people what books you&apos;ve read and share your reviews and other information on each one. And let&apos;s say information on each book should be available at `/books/abc` path on our website. To achieve this, you need to create a folder called `books` in your vault and add all the project-related files in there.
+
+To create a new folder in Obsidian, click on the &quot;New folder&quot; icon, and give your folder a name:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-add-folder.png]]
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-add-folder-2.png]]
+
+Now, let&apos;s write some book reviews. You can do this by right-clicking on the `/books` folder, and selecting &quot;New note&quot; option. Rename the newly created `Untitled.md` file and add some review in it. Then add some other reviews.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book.png]]
+
+Ok, now let&apos;s make a page that will list all your books reviews - our Bookshelf! It would be nice to have it available under `/books` path on the website, since each of our books will be available under `/books/abc`. To achieve this, we have to create an index page **inside** our `/books` folder, like so:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book-index.png]]
+
+Then, let&apos;s list our book reviews with wiki-links to their pages:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book-index-2.png]]
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book-index-3.png]]
+
+Now, let&apos;s add a link to our Bookshelf page on our home page, so that it&apos;s easy to find.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-bookshelf-link.png]]
+
+Now, if you want to have your link say something different than the raw `books/index`, you can do this by typing `|` after the path and specifying an alternative name, .e.g:
+
+```md
+[[books/index|Bookshelf]]
+```
+
+Let&apos;s also do this for the about page:
+
+```md
+[[about|About me]]
+```
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-link-aliases.png]]
+
+That&apos;s better!
+
+Now, let&apos;s maybe add a short info at the bottom, that this site is new and is currently being worked on, in form of an Obsidian callout:
+
+```md
+&gt; [!info]
+&gt; 🚧 This site it pretty new and I&apos;m enhancing it every day. Stay tuned!
+```
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-callout.png]]
+
+Great, our updated site is ready to be published! 🔥
+
+## Save and publish your changes
+
+### 1. Navigate to GitHub Desktop app
+
+In the &quot;Changes&quot; tab, you&apos;ll see all the changes that have been made to the repository.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-all-changed-files.png]]
+
+All the new files will have `[+]` sign next to them, and all the edited files will have `[•]`.
+
+### 2. Commit your changes
+
+Now, to save these changes we need to &quot;commit&quot; them, which is a fancy term for making a checkpoint of the state at which your repository is currently in.
+
+Let&apos;s make this checkpoint! In the bottom left corner there is a &quot;Summary (required)&quot; field, which is the place for a commit message - a concise description of the changes you made. The &quot;Description&quot; field is optional, and it&apos;s only needed if you need to add some more information about your changes that doesn&apos;t fit in the commit message.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-add-commit-message.png]]
+
+Now, hit the &quot;Commit to main&quot; button, and done! Now GitHub Desktop should say there are no local changes again. And that&apos;s correct, as all the changes we made have successfully been saved, and no other changes have been made since then.
+
+You should see the last commit message under the button:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-commit-message.png]]
+
+You can also inspect the whole history of past commits in the &quot;History tab&quot;.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-history.png]]
+
+The very fist commit on top is the commit we&apos;ve just made, but you can also see all the commits to the repository we made in [[create-a-website-from-scratch|tutorial 1]], via GitHub UI.
+
+### 3. Push your changes to the remote repository
+
+The commit we&apos;ve just crated has ↑ sign next to it. It means it hasn&apos;t yet been pushed to our remote version of the repository - the changes you made has been saved, but only locally on your computer. In order to push them to the cloud copy of the repository (aka &quot;remote&quot;), click &quot;↑ Push origin (1 ↑)&quot; tab.
+
+When the &quot;push&quot; is complete, the arrow next to the last commit message should disappear, and there should be no `(1 )` indicator next to &quot;Push origin&quot; button.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-history-after-push.png]]
+
+### 4. See updated site live!
+
+Navigate to your [vercel dashboard](https://vercel.com/dashboard).
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/vercel-dashboard.png]]
+
+Click on the project repository to go to its dashboard.
+
+You may have to wait a bit until the site builds, but once it&apos;s ready, you should see the preview with our latest changes.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/vercel-project-dashboard.png]]
+
+Note, that under &quot;SOURCE&quot; section (next to the preview) there is also our last commit message, indicating that the latest deployment has been triggered by this commit.
+
+Click on the preview to see the updated site live!
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/tutorial-2-result.png]]
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/live-book-home-page.png]]
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/live-book.png]]
+
+Congratulations!
+
+You have successfully completed the tutorial on editing your Flowershow website locally on your computer. By utilising Obsidian and GitHub Desktop, you have unlocked powerful editing capabilities and improved the overall publishing process. Now, you can enjoy the benefits of offline editing, simultaneous file editing, and previewing the extended Markdown syntax provided by Obsidian.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -197,6 +3207,191 @@
     <author>
       <name>Ola Rubaj</name>
     </author>
+    <content type="html">
+In this tutorial we will walk you through creating an elegant, fully functional website written in simple markdown and published with Flowershow.
+
+By the end of this tutorial you will:
+
+- have a working markdown-based website powered by Flowershow.
+- be able to edit the text and add pages, all from an online interface without installing anything.
+
+Below is a screenshot of how the final website will look like:
+![[/static/img/blog/tutorial-1-result.png]]
+
+## Prerequisites
+
+- A [GitHub](https://github.com/) account.
+- A [Vercel](https://vercel.com/) account. You can set it up using your GitHub account.
+
+## Setting up a sandbox website
+
+### 1. Navigate to the [datopian/flowershow repository](https://github.com/datopian/flowershow).
+
+### 2. Scroll down and click on the &quot;Deploy&quot; button
+
+After clicking on it, you&apos;ll be redirected to Vercel&apos;s &quot;Create Git Repository&quot; page.
+
+![Step 2 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/35cb9df6-d93e-4ce6-9741-54be744cf9e7/55ca0e14-6780-40e3-9ecc-148a7fa7c08e.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.0945&amp;fp-y=0.4783&amp;fp-z=2.5970&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=162&amp;mark-y=440&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yNjUmaD03MiZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 3. Select your GitHub account in &quot;Git Scope&quot;
+
+Click on &quot;Select Git Scope&quot; dropdown and select your GitHub account name from the list if it&apos;s there.
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/bdd61961-e1fe-4282-abec-75ae66bfeaa5/85df39b9-51a8-410a-a83b-93f2d2d6256c.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.2455&amp;fp-y=0.4226&amp;fp-z=1.4615&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=94&amp;mark-y=427&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzQmaD05OSZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+If your GitHub account is not available in the dropdown list, click on &quot;Add GitHub Account&quot;...
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/879ebed5-fec7-443e-8be9-66b73a4ec044/583f8a42-fc35-43d8-b791-70e22976ed46.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.2455&amp;fp-y=0.5030&amp;fp-z=1.5031&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=113&amp;mark-y=429&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NTkmaD05NCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+...and authorize Vercel to access your GitHub repositories by clicking &quot;Install&quot;.
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/61441f7d-ccc4-45ca-b52d-4ccc0573d787/ff97c393-2fff-407e-abe2-bc96c18562cc.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.2922&amp;fp-y=0.7621&amp;fp-z=2.4427&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=440&amp;mark-y=385&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0zMjEmaD0xMjgmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+Now you can select your GitHub account.
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/d2382391-f4bc-4ffe-b8e8-e22b9f6550ad/f4817109-ae2e-49f9-98ad-2f8dfe9a5b3b.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.2455&amp;fp-y=0.5833&amp;fp-z=1.5031&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=113&amp;mark-y=429&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NTkmaD05NCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 4. Give your repository a name
+
+A good practice is to use lowercase and dashes.
+
+![Step 4 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/a9b6af4c-4645-4b93-9c28-75d23e7f48a3/55dcaf47-8851-4808-ab9e-6fe6c4d552aa.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.6919&amp;fp-y=0.4929&amp;fp-z=1.7767&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=57&amp;mark-y=416&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMDg2Jmg9MTIxJmZpdD1jcm9wJmNvcm5lci1yYWRpdXM9MTA%3D)
+
+### 5. Click on &quot;Create&quot; and wait until the site deploys
+
+After you click &quot;Create&quot;, Vercel will create a new repository on your GitHub account, using the `datopian/flowershow` repository as a template. Then, it will immediately start buidling the initial version of your website. This may take about 1-2 minutes.
+
+![Step 5 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/ae740310-736d-48e5-9fbf-cf567a2ff966/2bc653a7-0e6c-4eaa-a11b-85a2a4d4c1d3.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.5007&amp;fp-y=0.5152&amp;fp-z=1.0564&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=33&amp;mark-y=379&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMTM0Jmg9MTk1JmZpdD1jcm9wJmNvcm5lci1yYWRpdXM9MTA%3D)
+
+### 6. See your published website!
+
+And voila! Your site is up and running. Once on the &quot;Congratulations&quot; screen, navigate to the project dashboard...
+
+![Step 6 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/1df8967e-2bcf-43ec-b3d0-a9d638d21ff7/af6d363d-2872-4a45-b5e5-16ca754e4702.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.5005&amp;fp-y=0.3351&amp;fp-z=1.8197&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=328&amp;mark-y=414&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz01NDUmaD0xMjQmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+... and click on &quot;Visit&quot; to see your published website!
+
+![Step 6 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/319f8eef-5007-4885-a3d6-6dc7fd7472ea/80b34413-f7da-4765-90d6-89a93fb4eab5.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.0697&amp;fp-y=0.3482&amp;fp-z=2.5500&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=72&amp;mark-y=390&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yODImaD0xNzQmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+## Editing a page on your website
+
+Once your site is up and running, the next step is to customize it to your liking. Let&apos;s start by editing our home page.
+
+### 1. Navigate to the repository of your website on GitHub
+
+You can get there by going to GitHub, clicking on your profile icon, and going to &quot;Your repositories&quot;.
+
+![Step 1 screenshot](https://images.tango.us/workflows/5b5166f4-2965-4a91-9bec-47108fe34234/steps/adecdf18-e46a-4003-984e-1dc1945963df/6792cf00-20fc-4e24-88ca-8d35a41aadab.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.9589&amp;fp-y=0.0345&amp;fp-z=3.0108&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=992&amp;mark-y=53&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMjAmaD05MiZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+![Step 1 screenshot](https://images.tango.us/workflows/5b5166f4-2965-4a91-9bec-47108fe34234/steps/8578ff07-5dc9-4908-bc81-197293970344/9b01a3fb-47fe-48ed-a7bc-c9910e9e42ef.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.8963&amp;fp-y=0.1997&amp;fp-z=2.9422&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=553&amp;mark-y=420&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz01NjImaD0xMTImZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+Or, you can navigate to [your Vercel dashboard](https://vercel.com/dashboard), select your project in the &quot;Overview&quot; tab...
+
+![Step 1 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/b7f96b7d-28b1-4366-b889-681b327b5f40/a0d2bffd-2e81-4878-854b-0766cf710339.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.2578&amp;fp-y=0.4408&amp;fp-z=1.3063&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=39&amp;mark-y=274&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz03MzAmaD00MDQmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+...and click on &quot;Git Repository&quot;. You&apos;ll be redirected to the repository of your website on GitHub.
+
+![Step 1 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/2cfbda16-23dc-45b2-9be9-a4b5b3a255d1/da2be1ca-da13-4257-a830-3ece2b89ff51.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.4560&amp;fp-y=0.4590&amp;fp-z=1.1707&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=321&amp;mark-y=313&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yMjYmaD04MCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 2. Navigate to the &quot;content&quot; folder
+
+This is where all the Markdown-based pages live in a Flowershow-based project.
+
+![Step 2 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/4ce5b74e-40e5-4c3f-a3ce-be7fa8959489/25b9ddc8-c1df-44f8-bf3e-7d08960f0592.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.0900&amp;fp-y=0.4574&amp;fp-z=2.8680&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=226&amp;mark-y=441&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xNjgmaD03MCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 3. Edit the &quot;index.md&quot; file
+
+The homepage on your website is built with the &quot;index.md&quot; file in the root of the &quot;content&quot; folder. Click on it to open.
+
+![Step 3 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/b14c059d-89e4-419b-8ac4-0e219ed195af/4d86a32a-b5f8-48d1-bccd-ddbfd140fe5a.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.0754&amp;fp-y=0.4711&amp;fp-z=2.7997&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=157&amp;mark-y=442&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xOTImaD02OCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+Then, click on the &quot;Edit this file&quot; icon...
+
+![Step 3 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/e4d28cd5-3863-46e3-813d-5304ec0d769f/ce2bf765-9bef-4d96-8354-0eed3aa88c03.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.9435&amp;fp-y=0.3449&amp;fp-z=2.9525&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=945&amp;mark-y=422&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMDkmaD0xMDkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+... and add some content.
+
+![Step 3 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/daad6528-db93-426c-8b8b-ae67d0a28189/a5767c01-a16e-4c4b-b4a0-5595663b175d.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.5170&amp;fp-y=0.3762&amp;fp-z=1.0470&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=7&amp;mark-y=300&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMTg2Jmg9MTUwJmZpdD1jcm9wJmNvcm5lci1yYWRpdXM9MTA%3D)
+
+### 4. Save your changes
+
+To see your changes live, you need to &quot;commit&quot; them. Click on &quot;Commit changes...&quot; buttom in the top-tight corner.
+
+![Step 4 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/74159a33-2897-4ffb-af3d-ce2fa109e570/0e96f7a4-b4ff-418e-9b44-73573a4354d1.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.9227&amp;fp-y=0.2208&amp;fp-z=2.9167&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=696&amp;mark-y=417&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz00NjgmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+In the &quot;Commit message&quot; field add a concise description of your changes. Optionally, if the commit message is not enough, you can add more info in the &quot;Extended description&quot; field.
+
+![Step 4 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/09130863-221f-436e-bab0-a46bea2fd5c4/bdbd1458-3b5c-4352-a8fb-5921132ee3e4.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.4998&amp;fp-y=0.3476&amp;fp-z=1.4555&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=262&amp;mark-y=447&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzYmaD01OCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+Leave &quot;Commit directly to `main` branch&quot; selected and click on &quot;Commit changes&quot;. Doing that will trigger rebuilding of your site on Vercel.
+
+![Step 4 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/40bf87e4-a2b1-4a99-97da-5e87530d0622/88a19d05-ce63-4da0-9e85-e427b063245e.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.5545&amp;fp-y=0.5989&amp;fp-z=1.3207&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=612&amp;mark-y=616&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yMDcmaD01NSZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 5. See your site getting rebuild
+
+If you want to see the current progress of rebuilding your website after you&apos;ve commited the changes, click on the dot next to your commit message.
+
+&gt; [!note]
+&gt; It will be either a dot (if the site is currently being rebuilt after your changes), a check mark (if the site has finished building) or a cross (if something went wrong when rebuilding it).
+
+![Step 5 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/0d273173-d852-47e4-b41e-418b9196e0fd/fbf1afe6-7af3-4b06-8ab0-d3c41d2923ce.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.5000&amp;fp-y=0.5000&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n)
+
+Click on &quot;Details&quot; to see your project&apos;s deployment status on Vercel.
+
+![Step 5 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/94b4e4ab-458c-4be9-b7a9-e34c7b4185b9/645687a4-b91d-4870-a935-48403b8ce33c.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.5000&amp;fp-y=0.5000&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n)
+
+### 6. Preview your site after changes
+
+Once the site has been rebuilt, click the preview to see your changes live.
+
+![Step 6 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/a1294580-7d0d-492c-a880-32040b4bee48/5e7ddd43-03e3-4545-b1b3-cd631da401d8.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.2207&amp;fp-y=0.3824&amp;fp-z=1.4465&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=43&amp;mark-y=261&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzkmaD00MzEmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+## Add a single Markdown-based page
+
+### 1. Navigate to the &quot;content&quot; folder in your website&apos;s repository
+
+See how to find it in the previous section.
+
+### 2. Create new file
+
+Click on &quot;Add file&quot;...
+
+![Step 2 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/1708e4fa-8234-4393-a8e9-cd972afce770/b986ab26-d53f-4b57-8520-fb87782dfb22.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.9119&amp;fp-y=0.2208&amp;fp-z=2.9167&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=737&amp;mark-y=417&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0zMDkmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+...and &quot;Create new file&quot;.
+
+![Step 2 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/e79d32ef-9385-4903-8ca1-408f78752633/7006ac1c-796c-4bb6-95ef-dd4d9969c9b6.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.8712&amp;fp-y=0.2679&amp;fp-z=2.9167&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=476&amp;mark-y=417&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz01NDcmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+### 3. Type the name of the new file you want to create
+
+![Step 3 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/54c786cb-15d6-4abe-8893-fa95dff3ed0a/c39152b2-f446-4e39-a2f3-9b3cf0e7c193.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.3476&amp;fp-y=0.2214&amp;fp-z=2.1864&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=394&amp;mark-y=418&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz00MTMmaD04NyZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 4. Write the content of the file
+
+![Step 4 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/8ffe1e8c-45f9-42b7-8053-bc8bc61b098c/56489034-d5a9-495e-8fb7-1fbfff62d7f3.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.5170&amp;fp-y=0.3440&amp;fp-z=1.0470&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=7&amp;mark-y=300&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMTg2Jmg9ODYmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+### 5. Save your changes
+
+To see your changes live, you need to &quot;commit&quot; them. Click on &quot;Commit changes...&quot; buttom in the top-tight corner.
+
+![Step 5 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/382d133d-19f3-4aee-a0fa-535fcb361090/fe7b1fc6-c8f0-4f3f-958a-204c4fc65cf8.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.9227&amp;fp-y=0.2208&amp;fp-z=2.9167&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=696&amp;mark-y=417&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz00NjgmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+In the &quot;Commit message&quot; field add a concise description of your changes. Optionally, if the commit message is not enough, you can add more info in the &quot;Extended description&quot; field.
+
+![Step 5 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/13c5873d-4071-4ae2-b641-d6202631076c/53029856-5543-4681-919a-092ed2dacb02.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.4998&amp;fp-y=0.3476&amp;fp-z=1.4555&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=262&amp;mark-y=447&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzYmaD01OCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+Leave &quot;Commit directly to `main` branch&quot; selected and click on &quot;Commit changes&quot;. Doing that will trigger rebuilding of your site on Vercel.
+
+![Step 5 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/68002c21-451a-4536-89b6-8a0d01d327eb/bb71cbb3-7a79-45f3-a71e-2500a380556c.png?crop=focalpoint&amp;fit=crop&amp;fp-x=0.6278&amp;fp-y=0.7315&amp;fp-z=2.3207&amp;w=1200&amp;border=2%2CF4F2F7&amp;border-radius=8%2C8%2C8%2C8&amp;border-radius-inner=8%2C8%2C8%2C8&amp;blend-align=bottom&amp;blend-mode=normal&amp;blend-x=0&amp;blend-w=1200&amp;blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&amp;mark-x=418&amp;mark-y=428&amp;m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0zNjUmaD05NyZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 6. Preview your site after changes
+
+As you already know, Vercel will now start rebuilding your website. When it&apos;s done, you can navigate to `/about` url on your website to see the new file we&apos;ve just added.
+
+## What&apos;s next?
+
+While editing on GitHub UI is acceptable, it has its limitations – it doesn&apos;t support working offline, adding multiple files simultaneously, or previewing many markdown syntax elements supported by Flowershow-based websites. We&apos;ll delve into these issues and solutions to overcome them in our next tutorial. Stay tuned!
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -208,6 +3403,202 @@
     <author>
       <name>Ola Rubaj</name>
     </author>
+    <content type="html">
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/dataview.gif]]
+
+Have you ever wanted to create a catalog of stuff? Maybe it&apos;s a list of personal projects, maybe favourite books or movies, or perhaps the options for the next smartphone you&apos;ll buy. But you&apos;ve found yourself deterred by expensive software, lack of flexibility in capturing and modifying the structure of the data, or lack of control over it?
+
+Markdown files, with their unique combination of 1) rich content, including text, images, links, and more, with 2) structured metadata allowing for data retrieval, are an excellent tool for this task. These features, coupled with the user-friendly interface of Obsidian and the analytical power of the Dataview plugin, make creating a data catalog an easy task. And it&apos;s free!
+
+This tutorial will provide you with an easy yet extendable approach to creating your personal data catalogs using Markdown, in Obsidian.
+
+## What are we going to build?
+
+In this tutorial, we&apos;re going to create a catalog of characters from the Harry Potter series. Each character will have their own markdown file containing some unstructured data like character&apos;s quotes, as well as structured metadata, such as the character&apos;s name, house, creature they own, and status (alive or dead).
+
+## Step 1: Setup
+
+Here are the steps to get you started:
+
+1. Download and install Obsidian from their [official website](https://obsidian.md/).
+2. Create a new Obsidian vault.
+   1. Open the app.
+   2. Click the &quot;New&quot; button to create a new vault.
+   3. Choose a name and a location for your vault. For this tutorial, you might name it &quot;Harry Potter Characters&quot;.
+   4. Click &quot;Create&quot; to create the vault.
+3. Install the [&quot;Dataview&quot; plugin](https://github.com/blacksmithgu/obsidian-dataview) from Obsidian&apos;s community plugins.
+   1. Open the newly created vault in Obsidian.
+   2. Click on the settings icon ⚙️ in the left-hand pane to open the Settings view.
+   3. In the Settings view, find the &quot;Community plugins&quot; section and click on it.
+   4. Click on the button &quot;Turn on community plugins&quot;.
+   5. Click on &quot;Browse&quot; and search for &quot;Dataview&quot; in the plugin browser.
+   6. Click on &quot;Install&quot; to install the Dataview plugin.
+   7. After the plugin is installed, click on &quot;Enable&quot; to enable the plugin in your vault.
+
+## Step 2: Add some data about the characters
+
+Let&apos;s start by creating a subfolder in our Obsidian vault, that will store all the markdown files with our characters data. Let&apos;s name it e.g. `/characters`. Then, we&apos;re going to create three markdown files in it for data about Harry Potter, Hermione, and Malfoy.
+
+Here&apos;s an example file for Harry Potter:
+
+```md
+---
+name: Harry Potter
+house: Gryffindor
+status: Alive
+---
+
+## Quotes
+
+&quot;I solemnly swear I am up to no good.&quot;
+```
+
+Here&apos;s an example file for Hermione:
+
+```md
+---
+name: Hermione Granger
+house: Gryffindor
+status: Alive
+---
+
+## Quotes
+
+&quot;Books! And cleverness! There are more important things - friendship and bravery.&quot;
+```
+
+Here&apos;s an example file for Malfoy:
+
+```md
+---
+name: Draco Malfoy
+house: Slytherin
+status: Alive
+---
+
+Draco Malfoy is Harry&apos;s rival and a member of Slytherin House.
+
+## Quotes
+
+&quot;My father will hear about this!&quot;
+```
+
+By the end of this step you should end up with the following folder structure:
+
+```
+Harry Potter Characters
+└── characters
+    ├── Harry Potter.md
+    ├── Hermione.md
+    └── Malfoy.md
+```
+
+## Step 3: Create a data catalog
+
+Now let&apos;s create a data catalog of our Harry Potter characters!
+
+In the root of our vault, let&apos;s create a file called `Catalog` (but you can name it whatever you want) that&apos;s going to display a table with all our characters and their metadata. Inside it, we&apos;re going to write the following code block with a simple Dataview query:
+
+````md
+```dataview
+table name, house, status
+from &quot;characters&quot;
+sort name asc
+```
+````
+
+Let&apos;s break it down:
+
+- `table name, house, status`: This line instructs Dataview to create a table that includes columns for &quot;name&quot;, &quot;house&quot;, and &quot;status&quot;. These are fields that you should have defined in your markdown files&apos; frontmatter, but you don&apos;t have to. For any missing field Dataview will just display `-`.
+- `from &quot;characters&quot;`: This tells Dataview to pull the data from all markdown files located in the `/characters` folder in your Obsidian vault.
+- `sort name asc`: This command sorts the data based on the &quot;name&quot; field, in ascending order.
+
+After you click somewhere outside of this code block, you should see the following table:
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/table1.png]]
+
+## Step 4: Add more metadata about characters
+
+We can continue to add more information about our characters. For example, let&apos;s add creatures each character owns:
+
+```md=
+---
+name: Harry Potter
+...
+creature: Hedwig (Owl)
+---
+
+...
+
+---
+
+name: Hermione Granger
+...
+creature: Crookshanks (Cat)
+---
+
+...
+
+```
+
+Now, if we want to show this field in our Dataview table, we need to add it to the first line of our dataview code block:
+
+````md
+```dataview
+table name, house, status, creature
+from &quot;characters&quot;
+sort name asc
+```
+````
+
+After clicking somewhere outside the code block, you should see an updated table that includes the column `creature`.
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/table2.png]]
+
+## Step 5: Enrich content with images and links
+
+To enhance your catalog, you can add images of characters, and links to other characters in your markdown content.
+
+#### Add images
+
+To add an image of a character, right-click on the image you want to embed and copy it to clipboard - you can use the image below - and paste it directly in your markdown file.
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/harry_original.png]]
+
+Obsidian will automatically save the file to the root of your vault and create a link to it in your content, so you&apos;ll end up with a link similar to this one:
+
+```md
+![[Pasted image 20230525212302.png]]
+```
+
+Which will render as:
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/harry.png]]
+
+#### Add links to other pages
+
+Obsidian allows you to create links between different notes (or in this case, characters). To add a link to another character, use the double bracket `[[]]` syntax.
+
+For example, if you&apos;re writing about Harry Potter and want to mention that he is friends with Hermione, you can link to Hermione&apos;s markdown file like this:
+
+```md
+He is a friend of [[Hermione]].
+```
+
+When you click on Hermione&apos;s name in the rendered link, Obsidian will take you to Hermione&apos;s file in your vault. If you hover over it, you&apos;ll see a preview of Hermione&apos;s file:
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/link-preview.png]]
+
+## Summary
+
+And there you have it! We&apos;ve walked through the process of creating a personal data catalog using markdown files, the Obsidian application, and its Dataview plugin. We&apos;ve transformed scattered data into a well-organized, easy-to-navigate, and visually pleasing catalog. Whether you&apos;ve used our example of a Harry Potter character catalog or applied these steps to a different topic of your choosing, we hope you&apos;ve found this tutorial helpful and empowering.
+
+Happy data cataloging!
+
+---
+
+You can find the [vault created in this tutorial here](https://github.com/datopian/markdowndb/tree/main/examples/obsidian-dataview).
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -219,6 +3610,271 @@
     <author>
       <name>Ola Rubaj</name>
     </author>
+    <content type="html">
+We&apos;ve just released our first tutorial that covers the fundamentals of [MarkdownDB](https://github.com/datopian/markdowndb) - our new package for treating markdown files as a database. If you&apos;ve been curious about how to manage your markdown files more effectively, this tutorial is an excellent starting point!
+
+![Gif](/static/img/blog/2023-05-26-lean-how-to-use-markdown/markdowndb.gif)
+
+## What is MarkdownDB?
+
+MarkdownDB can parse your markdown files, extract structured data (such as frontmatter, tags, back- and forward links and more), and create an index in a local SQLite database. It also provides a lightweight JavaScript API for querying the database and importing files into your application. With MarkdownDB, you have a powerful tool that allows you to efficiently query your markdown data.
+
+[🔍 Click here to learn more!](https://github.com/datopian/markdowndb)
+
+## What you&apos;re going to learn
+
+This tutorial guides you through the steps of creating a small project catalog. In our case, we used our open-source projects on GitHub - but you could use anything! We use simple markdown files to describe each project and then display them with the MarkdownDB package.
+
+## Step 1: Create a markdown file for each project
+
+First, let&apos;s create a markdown file for each project. You can use real project details or make up some examples. For the sake of this tutorial, we&apos;ll create files for some of the projects we&apos;ve built at Datopian.
+
+```bash
+mkdir projects
+cd projects
+touch markdowndb.md portaljs.md flowershow.md datapipes.md giftless.md data-cli.md
+```
+
+In each file we&apos;ll write some short info about a given project, like so:
+
+```md
+# What is MarkdownDB
+
+MarkdownDB is a javascript library for treating markdown files as a database -- as a &quot;MarkdownDB&quot;. Specifically, it:
+
+- Parses your markdown files to extract structured data (frontmatter, tags, etc) and creates an index in a local SQLite database
+- Provides a lightweight javascript API for querying the database and importing files into your application
+```
+
+## Step 2: Index markdown files into SQLite database
+
+Once we have prepared our markdown files, we can store them (or more precisely - their metadata) in a database, so that we can then query it later for specific project files.
+
+```bash
+# npx mddb &lt;path-to-folder-with-md-files&gt;
+npx mddb ./projects
+```
+
+The above command will output a `markdown.db` file in the directory where it was executed. So, in our case, the folder structure will look like this:
+
+```
+.
+├── markdown.db
+└── projects
+    ├── data-cli.md
+    ├── ...
+    └── portaljs.md
+```
+
+## Step 3: Explore the SQLite database
+
+Now, let&apos;s explore the database. We can do it with any SQLite viewer, e.g. https://sqlitebrowser.org/. When we open the `markdown.db` file in the viewer, we&apos;ll see a list of tables:
+
+- `files`: containing metadata of our markdown,
+- `file_tags`: containing tags set in the frontmatter of our markdown files,
+- `links`: containing wiki links, i.e. links between our markdown files,
+- `tags`: containing all tags used in our markdown files.
+
+In our case, the `files` table will look like this:
+
+![[/static/img/blog/2023-05-26-lean-how-to-use-markdown/sqlite-viewer.png]]
+
+You can also explore the database from the command line, e.g.:
+
+```bash
+sqlite3 markdown.db
+```
+
+And then run SQL queries, e.g.:
+
+```sql
+SELECT * FROM files;
+```
+
+Which will output:
+
+```bash
+27ce406aac24e59af7a9f3c0c0a437c1d024152b|projects/data-cli.md|md|data-cli||{}
+26b1b0b06a4f450646f9e22fc18ec069bf577d8c|projects/datapipes.md|md|datapipes||{}
+dafdd0daf71a1b06db1988c57848dc36947375f4|projects/flowershow.md|md|flowershow||{}
+32c8db33fb8758516bfefb6ab1f22d03b1e53a08|projects/giftless.md|md|giftless||{}
+7e01cae193f12f5a4a9be2b89f22b429761bd313|projects/markdowndb.md|md|markdowndb||{}
+5445349c6822704d6f531a83c2aca2e4f90de864|projects/portaljs.md|md|portaljs||{}
+```
+
+## Step 4: Query the database in the Node.js app
+
+Now, let&apos;s write a simple script that will query the database for our projects and display them on the terminal.
+
+First, let&apos;s create a new Node.js project:
+
+```bash
+mkdir projects-list
+cd projects-list
+npm init -y
+```
+
+Then, let&apos;s install the `mddb` package:
+
+```bash
+npm install mddb
+```
+
+Now, let&apos;s create a new file `index.js` and add the following code:
+
+```js
+import { MarkdownDB } from &apos;mddb&apos;;
+
+// change this to the path to your markdown.db file
+const dbPath = &apos;markdown.db&apos;;
+
+const client = new MarkdownDB({
+  client: &apos;sqlite3&apos;,
+  connection: {
+    filename: dbPath,
+  },
+});
+
+const mddb = await client.init();
+
+// get all projects
+const projects = await mddb.getFiles();
+
+console.log(JSON.stringify(projects, null, 2));
+
+process.exit(0);
+```
+
+Since we&apos;re using ES6 modules, we also need to add `&quot;type&quot;: &quot;module&quot;` to our `package.json` file.
+
+Before we run the above script, we need to make sure that the `dbPath` variable is pointing to our `markdown.db` file. If you want to store the database outside of your project folder, you can update the `dbPath` variable to point to the correct location. If you want to have it inside your project folder, you can copy it there, or simply re-run the `npx mddb &lt;path-to-markdown-folder&gt;` command from within your project folder.
+
+Now, let&apos;s run the script:
+
+```bash
+node index.js
+```
+
+It should output the JSON with all our projects.
+
+```json
+[
+  {
+    &quot;_id&quot;: &quot;7e01cae193f12f5a4a9be2b89f22b429761bd313&quot;,
+    &quot;file_path&quot;: &quot;projects/markdowndb.md&quot;,
+    &quot;extension&quot;: &quot;md&quot;,
+    &quot;url_path&quot;: &quot;markdowndb&quot;,
+    &quot;filetype&quot;: null,
+    &quot;metadata&quot;: {}
+  },
+  ...
+]
+```
+
+## Step 5: Add metadata to project files
+
+Now, let&apos;s add some metadata to our project files. We&apos;ll use frontmatter for that. Since we&apos;re creating a catalog of our GitHub projects, we&apos;ll add the following frontmatter fields to each file:
+
+```md
+---
+name: markdowndb
+description: Javascript library for treating markdown files as a database.
+stars: 6
+forks: 0
+---
+```
+
+After adding the metadata, we need to re-index our markdown files into the database:
+
+```bash
+npx mddb ../projects
+```
+
+Now, if we run our script again, we&apos;ll see that the `metadata` field in the output contains the metadata we&apos;ve added to our project files:
+
+```json
+[
+  {
+    &quot;_id&quot;: &quot;7e01cae193f12f5a4a9be2b89f22b429761bd313&quot;,
+    &quot;file_path&quot;: &quot;projects/markdowndb.md&quot;,
+    &quot;extension&quot;: &quot;md&quot;,
+    &quot;url_path&quot;: &quot;markdowndb&quot;,
+    &quot;metadata&quot;: {
+      &quot;name&quot;: &quot;markdowndb&quot;,
+      &quot;description&quot;: &quot;Javascript library for treating markdown files as a database&quot;,
+      &quot;stars&quot;: 6,
+      &quot;forks&quot;: 0
+    }
+  },
+  ...
+]
+```
+
+## Step 6: Pretty print the output
+
+Now, let&apos;s make the output a bit more readable. We&apos;ll use the `columnify` package for that:
+
+```bash
+npm install columnify
+```
+
+And then we&apos;ll update our `index.js` file:
+
+```js {2,16-38}
+import { MarkdownDB } from &apos;mddb&apos;;
+import columnify from &apos;columnify&apos;;
+
+const dbPath = &apos;markdown.db&apos;;
+
+const client = new MarkdownDB({
+  client: &apos;sqlite3&apos;,
+  connection: {
+    filename: dbPath,
+  },
+});
+
+const mddb = await client.init();
+const projects = await mddb.getFiles();
+
+// console.log(JSON.stringify(projects, null, 2));
+
+const projects2 = projects.map((project) =&gt; {
+  const { file_path, metadata } = project;
+  return {
+    file_path,
+    ...metadata,
+  };
+});
+
+const columns = columnify(projects2, {
+  truncate: true,
+  columnSplitter: &apos; | &apos;,
+  config: {
+    description: {
+      maxWidth: 80,
+    },
+  },
+});
+
+console.log(&apos;\n&apos;);
+console.log(columns);
+console.log(&apos;\n&apos;);
+
+process.exit(0);
+```
+
+The above script will output the following to the terminal:
+
+![[/static/img/blog/2023-05-26-lean-how-to-use-markdown/output.png]]
+
+## Done!
+
+That&apos;s it! We&apos;ve just created a simple catalog of our GitHub projects using markdown files and the MarkdownDB package. You can find the [full code for this tutorial here](https://github.com/datopian/markdowndb/tree/main/examples/basic-example).
+
+We look forward to seeing the amazing applications you&apos;ll build with this tool!
+
+Happy coding!
+</content>
     <summary type="html">We&apos;ve just released our first tutorial that covers the fundamentals of MarkdownDB - our new package for treating markdown files as a database. If you&apos;ve been curious about how to manage your markdown files more effectively, check it out!</summary>
   </entry>
   <entry>
@@ -230,6 +3886,89 @@
     <author>
       <name>Rising Odegua</name>
     </author>
+    <content type="html">
+## Getting Started
+
+This tutorial will help you get started with the Datahub pages, and how you can use it to create data driven webpages from static data. 
+
+Data pages you will create can be deployed with static site hosting providers like Github pages. Cloudfare pages, Netlify, or Vercel. 
+
+Here&apos;s an [example of a hosted Datahub page](https://datahub.io/collections/demographics) showing how data, text and simple charts can be displayed. 
+
+In this tutorial, we aim to keep things simple, so we&apos;ll show you how you can turn a CSV and a ReadMe into a Datahub page. 
+
+## Set up
+
+### Prepare your data folder
+
+* Create new data folder and add your CSV data. We&apos;ll be using a folder called `my-data` and a CSV data called `data.csv`
+* Add a `README.md` file with some markdown content. You can also add and use custom Datahub components like TableGrid, and LineCharts. See [this example](https://github.com/datopian/portal.js/blob/main/examples/data-literate/pages/demo.mdx)
+* For example to display your data as a Table in the page, you can add the following to your `README.md` file:
+
+```markdown
+&lt;TableGrid url=&apos;data.csv&apos; /&gt; 
+```
+
+* At the end you should have a data folder with the following structure:
+
+```bash
+
+├── my-data
+
+     └── data.csv
+
+     └── README.md
+```
+### Initialize Datahub page from template
+
+Now that you have your data folder created and saved. In a new folder, you&apos;re going to initialize your datahub page, using a template we have provided. Follow the steps below to achieve this:
+
+* Run the following command in your terminal to install and create your datahub page from our template. You can always change the name of the folder from `datahub-pages-example`  to anything you like:
+
+```bash
+npx create-next-app@latest --example https://github.com/datopian/portal.js/tree/main/examples/data-literate-template datahub-pages-example
+```
+
+* Navigate into the folder:
+
+```bash
+cd datahub-pages-example
+```
+
+* Next you&apos;ll copy data files from your data folder into Datahub page. We have provided a handy script to automatically do this for you. All you need to do is pass the full/relative path to your data folder
+
+```bash
+node datahub-portal-local-cli.js ./my-data
+```
+## Test Locally
+
+After copying the files with the `datahub-portal-local-cli.js`, you should have the data.csv file in the `public` folder, and the README.md file in the pages folder under the name `index.mdx`. 
+Now we can view the generated page locally by running:
+
+```
+npm run dev  
+```
+
+This will start the development server, and you can view the page by navigating to http://localhost:3000
+
+## Deployment
+
+The generated page from above is a static Next.js webpage. As such you can deploy it anywhere Next.Js sites can be deployed. The following platforms support deployment of Next.js sites, and you can yse anyone of your choice:
+
+* [Vercel](https://nextjs.org/docs/deployment#managed-nextjs-with-vercel)
+* [Cloudfare pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
+* [Netlify](https://www.netlify.com/blog/2021/03/16/try-the-new-essential-next.js-plugin-now-with-auto-install/)
+* [Github pages](https://gregrickaby.blog/article/nextjs-github-pages)
+
+## Conclusion
+
+We are working towards adding new and better features to Datahub pages. You can request or suggest features in your issue tracker on Github [here](https://github.com/datopian/next.datahub.io/issues).
+
+## Resources
+
+* [Portal.js](https://github.com/datopian/portal.js#component-list) provides custom components you can use in your data pages
+* [Demo page](https://datahub.io/collections/air-pollution) a live Datahub page deployed on Cloudfare
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -241,6 +3980,28 @@
     <author>
       <name>sebastien.lavoie</name>
     </author>
+    <content type="html">
+The Frictionless specifications are helping with simplifying data validation for applications in production at the European Union. More specifically, [Costas Simatos](https://joinup.ec.europa.eu/user/73932) introduced the Frictionless Data community to the [Interoperability Test Bed](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository) (ITB), an online platform that can be used to test systems against technical specifications --- curious minds will find a recording of his presentation on the subject [available on YouTube](https://www.youtube.com/watch?v=pJFsJW96fuA). Amongst the tools it offers, there is a [CSV validator](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository/solution/csvvalidator) which relies on the [Table Schema specifications](https://specs.frictionlessdata.io/table-schema/). Those specifications filled a gap that the [RFC 4180](https://datatracker.ietf.org/doc/html/rfc4180) didn&apos;t address by having a structured way of defining the content of individual fields in terms of data types, formats and constraints, which is a clear benefit of the Frictionless specifications as reported back in 2020 [when a beta version of the CSV validator was launched](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository/solution/interoperability-test-bed/news/table-schema-validator).
+
+![Puzzle texture with negative space](/static/img/blog/2021-06-21-frictionless-specs/clark-van-der-beken-596baa0MpyM-unsplash.jpg)
+_Photo by Clark Van Der Beken on Unsplash_
+
+---
+
+Frictionless specifications are flexible while allowing users to define unambiguously the expected content of a given field, therefore they were officially adopted to [realise the validator for the Kohesio pilot phase of 2014-2020](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository/solution/interoperability-test-bed/news/test-bed-support-kohesio-pilot), [Kohesio](https://kohesio.eu/) being the _&quot;Project Information Portal for Cohesion Policy&quot;_. The Table Schema specifications made it easy and convenient for the Interoperability Test Bed to establish constraints and describe the data to be validated in a concise way based on an initial set of [CSV syntax rules](https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/kohesio-validator/specification), converting written and mostly non-technical definitions to their Frictionless equivalent. Using simple JSON objects, Frictionless specifications allowed the ITB to enforce data validation in multiple ways as can be observed from the [schema used for the CSV validator](https://github.com/ISAITB/validator-resources-kohesio/blob/master/resources/schemas/schema.json). The following list of items calls attention to the core aspects of the Table Schema standard that were taken advantage of:
+
+* Dates can be defined with string formatting (e.g. `%d/%m/%Y` stands for `day/month/year`);
+* Constraints can indicate whether a column can contain empty values or not;
+* Constraints can also specify a valid range of values (e.g. `&quot;minimum&quot;: 0.0` and `&quot;maximum&quot;: 100.0`);
+* Constraints can specify an enumeration of valid values to choose from (e.g. `&quot;enum&quot; : [&quot;2014-2020&quot;, &quot;2021-2027&quot;]`).
+* Constraints can be specified in custom ways, such as with [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) for powerful string matching capabilities;
+* Data types can be enforced for any column;
+* Columns can be forced to adapt a specific name and a description can be provided for each one of them.
+
+Because these specifications can be expressed as portable text files, they became part of a multitude of tools to provide greater convenience to users and the validation process has been [documented extensively](https://www.itb.ec.europa.eu/docs/guides/latest/validatingCSV/index.html). JSON code snippets from the documentation highlight the fact that this format conveys all the necessary information in a readable manner and lets users extend the original specifications as needed. In this particular instance, the CSV validator can be used as a [Docker image](https://hub.docker.com/repository/docker/isaitb/validator-kohesio), as part of a [command-line application](https://www.itb.ec.europa.eu/csv-offline/kohesio/validator.zip), inside a [web application](https://www.itb.ec.europa.eu/csv/kohesio/upload) and even as a [SOAP API](https://www.itb.ec.europa.eu/csv/soap/kohesio/validation?wsdl).
+
+In a way, the Frictionless specifications were the missing piece of the puzzle that enabled the ITB to rely on a well-documented set of standards for their data validation needs.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -252,6 +4013,228 @@
     <author>
       <name>Luccas Mateus</name>
     </author>
+    <content type="html">
+We have created a full data portal demo using DataHub PortalJS all backed by a CKAN instance storing data and metadata, you can see below a screenshot of the homepage and of an individual dataset page.
+
+![Datahub Home page](https://i.imgur.com/ai0VLS4.png)
+![individual dataset page](https://i.imgur.com/3RhXOW4.png)
+
+## Create a Portal app for CKAN
+
+To create a Portal app, run the following command in your terminal:
+
+```console
+npx create-next-app -e https://github.com/datopian/datahub/tree/main/examples/ckan
+```
+
+&gt; NB: Under the hood, this uses the tool called create-next-app, which bootstraps an app for you based on our CKAN example.
+
+## Guide
+
+### Styling 🎨
+
+We use Tailwind as a CSS framework. Take a look at `/styles/globals.css` to see what we&apos;re importing from Tailwind bundle. You can also configure Tailwind using `tailwind.config.js` file.
+
+Have a look at Next.js support of CSS and ways of writing CSS:
+
+https://nextjs.org/docs/basic-features/built-in-css-support
+
+### Backend
+
+So far the app is running with mocked data behind. You can connect CMS and DMS backends easily via environment variables:
+
+```console
+$ export DMS=http://ckan:5000
+$ export CMS=http://myblog.wordpress.com
+```
+
+&gt; Note that we don&apos;t yet have implementations for the following CKAN features:
+&gt;
+&gt; - Activities
+&gt; - Auth
+&gt; - Groups
+&gt; - Facets
+
+### Routes
+
+These are the default routes set up in the &quot;starter&quot; app.
+
+- Home `/`
+- Search `/search`
+- Dataset `/@org/dataset`
+- Resource `/@org/dataset/r/resource`
+- Organization `/@org`
+- Collection (aka group in CKAN) (?) - suggest to merge into org
+- Static pages, eg, `/about` etc. from CMS or can do it without external CMS, e.g., in Next.js.
+
+### New Routes
+
+You can create new routes in `/pages` directory where each file is associated with a route based on its name. We suggest using [Next.JS docs][] for more detailed information.
+
+[next.js docs]: https://nextjs.org/docs/basic-features/pages
+
+### Data fetching
+
+We use Apollo client which allows us to query data with GraphQL. We have setup CKAN API for the demo (it uses demo.ckan.org as DMS):
+
+http://portal.datopian1.now.sh/
+
+Note that we don&apos;t have Apollo Server but we connect CKAN API using [`apollo-link-rest`](https://www.apollographql.com/docs/link/links/rest/) module. You can see how it works in [lib/apolloClient.ts](https://github.com/datopian/portal/blob/master/lib/apolloClient.ts) and then have a look at [pages/\_app.tsx](https://github.com/datopian/portal/blob/master/pages/_app.tsx).
+
+For development/debugging purposes, we suggest installing the Chrome extension - https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm.
+
+### I18n configuration
+
+PortalJS is configured by default to support both `English` and `French` subpath for language translation. But for subsequent users, this following steps can be used to configure i18n for other languages;
+
+1.  Update `next.config.js`, to add more languages to the i18n locales
+
+```js
+i18n: {
+  locales: [&apos;en&apos;, &apos;fr&apos;, &apos;nl-NL&apos;], // add more language to the list
+  defaultLocale: &apos;en&apos;,  // set the default language to use
+},
+```
+
+2. Create a folder for the language in `locales` --&gt; `locales/en-Us`
+
+3. In the language folder, different namespace files (json) can be created for each translation. For the `index.js` use-case, I named it `common.json`
+
+```json
+// locales/en/common.json
+{
+   &quot;title&quot; : &quot;Portal js in English&quot;,
+}
+
+// locales/fr/common.json
+{
+   &quot;title&quot; : &quot;Portal js in French&quot;,
+}
+```
+
+4. To use on pages using Server-side Props.
+
+```js
+import { loadNamespaces } from &apos;./_app&apos;;
+import useTranslation from &apos;next-translate/useTranslation&apos;;
+
+const Home: React.FC = ()=&gt; {
+  const { t } = useTranslation();
+  return (
+    &lt;div&gt;{t(`common:title`)}&lt;/div&gt; // we use common and title base on the common.json data
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) =&gt; {
+      ........  ........
+  return {
+    props : {
+      _ns:  await loadNamespaces([&apos;common&apos;], locale),
+    }
+  };
+};
+
+```
+
+5. Go to the browser and view the changes using language subpath like this `http://localhost:3000` and `http://localhost:3000/fr`. **Note** The subpath also activate chrome language Translator
+
+### Pre-fetch data in the server-side
+
+When visiting a dataset page, you may want to fetch the dataset metadata in the server-side. To do so, you can use `getServerSideProps` function from NextJS:
+
+```javascript
+import { GetServerSideProps } from &apos;next&apos;;
+import { initializeApollo } from &apos;../lib/apolloClient&apos;;
+import gql from &apos;graphql-tag&apos;;
+
+const QUERY = gql`
+  query dataset($id: String) {
+    dataset(id: $id) @rest(type: &quot;Response&quot;, path: &quot;package_show?{args}&quot;) {
+      result
+    }
+  }
+`;
+
+...
+
+export const getServerSideProps: GetServerSideProps = async (context) =&gt; {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: QUERY,
+    variables: {
+      id: &apos;my-dataset&apos;
+    },
+  });
+
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+  };
+};
+```
+
+This would fetch the data from DMS and save it in the Apollo cache so that we can query it again from the components.
+
+### Access data from a component
+
+Consider situation when rendering a component for org info on the dataset page. We already have pre-fetched dataset metadata that includes `organization` property with attributes such as `name`, `title` etc. We can now query only organization part for our `Org` component:
+
+```javascript
+import { useQuery } from &apos;@apollo/react-hooks&apos;;
+import gql from &apos;graphql-tag&apos;;
+
+export const GET_ORG_QUERY = gql`
+  query dataset($id: String) {
+    dataset(id: $id) @rest(type: &quot;Response&quot;, path: &quot;package_show?{args}&quot;) {
+      result {
+        organization {
+          name
+          title
+          image_url
+        }
+      }
+    }
+  }
+`;
+
+export default function Org({ variables }) {
+  const { loading, error, data } = useQuery(
+    GET_ORG_QUERY,
+    {
+      variables: { id: &apos;my-dataset&apos; }
+    }
+  );
+
+  ...
+
+  const { organization } = data.dataset.result;
+
+  return (
+    &lt;&gt;
+      {organization ? (
+        &lt;&gt;
+        {}
+          &lt;img
+            src={
+              organization.image_url
+            }
+            className=&quot;h-5 w-5 mr-2 inline-block&quot;
+            alt={`${oragnization.name} logo`}
+          /&gt;
+          &lt;Link href={`/@${organization.name}`} className=&quot;font-semibold text-primary underline&quot;&gt;
+              {organization.title || organization.name}
+          &lt;/Link&gt;
+        &lt;/&gt;
+      ) : (
+        &apos;&apos;
+      )}
+    &lt;/&gt;
+  );
+}
+```
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -263,6 +4246,69 @@
     <author>
       <name>rufuspollock</name>
     </author>
+    <content type="html">
+The severity of the current SARS-CoV-2 epidemic is undeniable: since the latest months of 2019, the COVID-19 outbreak is having a significant impact in the world at the macro level, starting its spread from China, then to the Asia-Pacific and then around the rest of the globe.
+
+![Man sleeping on a bus during the COVID-19 outbreak in London](/static/img/blog/2020-05-05-covid19-models/edward-howell-IDhks1n8GYM-unsplash.jpg)
+
+_Photo by Edward Howell on Unsplash_
+
+---
+
+## Models
+
+### Introduction
+
+More than 41 articles were published about COVID-19 just from the beginning of 2020, more than 10,000 GitHub forks of [CSSEGISandData](https://github.com/CSSEGISandData) were made, various open data sets (including [on GitHub](https://github.com/nties/COVID19-open-research-dataset) and [on Kaggle](https://www.kaggle.com/sudalairajkumar/novel-corona-virus-2019-dataset)) shared the number of cases and the number of people affected as well as other metrics.
+
+Many scientists around the globe participated in a global hackathon, trying to address current issues (lockdowns, lack of resources, etc.), trying to fit, predict and estimate the impact. Which models from these ones are close to the reality and which ones have a chance to be implemented as solutions for humanitarian response?
+
+### Basic Mathematical Models
+
+There are various types of models in epidemiology, which are used for prediction of prevalence (total number of people infected), the duration of an epidemic spreading processes and other variables.
+
+One of the most commonly used types are compartmental models, developed in the 1920s from the Kermack–McKendrick theory. In compartmental models, the population is divided into compartments of people with the same properties: people who are susceptible to the virus; those who have recovered; etc. There are three main types of compartmental models in epidemiology based on which many other models can be built upon:
+
+- Susceptible-Infectious (SI), where each person can be in one of two states, either susceptible (S) or infectious (I);
+- Susceptible-Infectious-Susceptible (SIS), where a person can be in one of two states, susceptible (S) or infectious (I), but can then become susceptible again;
+- Susceptible-Infectious-Recovered (SIR), where a person can be in one of three states: susceptible (S), infectious (I) or recovered \(R\).
+
+In the SIR model, one can study the number of people in each of three compartments: susceptible, infectious and recovered, denoted by the variables S, I and R correspondingly. The SIR system can be expressed by the set of ordinary differential equations proposed by O. Kermack and Anderson Gray McKendrick.
+
+Another model, which has been proven to be much more realistic for some epidemics spreading models is the [SEIR model](https://www.medrxiv.org/content/10.1101/2020.03.20.20040048v1). The main idea of this model is that for many important infections, there is a significant incubation period during which individuals have been infected but are not yet infectious themselves. During this period, the individual is in a special state E (exposed), an additional state to three states in the SIR model.
+
+![sirmodel-beta-mu-parameters](/static/img/blog/2020-05-05-covid19-models/sirmodel_beta_mu_parameters.png)
+
+Some models described here are also explained [on this page](https://github.com/datasets/awesome-data/blob/master/coronavirus.md).
+
+### &quot;Fitting the Curve&quot; - Issues to Consider
+
+During COVID-19 many open data sources were gathered, which explains the temptation of fitting the curve to empirical data or inferring parameters of spreading models. Here, we list some of the main issues with simply trying to do &quot;curve fitting&quot; approach:
+
+1. One of the first and simplest epidemiological model is the SI model. If you are in an infected state within this model, you stay infected forever. This one-way transition S → I is already not so realistic, at the same time the increasing number of infected cases can be obviously fit to the curves with the increasing number of cases, for example from this [time series](https://datahub.io/core/covid-19).
+2. Issues with more complex models, such as SIR or SEIR are more delicate. If we assume that in the beginning of an epidemic the fraction of susceptible individuals is still around 1 and that the number of infected people is exponentially growing as &lt;img src=&quot;/static/img/blog/2020-05-05-covid19-models/math_expr1.png&quot; alt=&quot;math-expr-1&quot;/&gt;, we need to estimate the [basic reproduction number](https://en.wikipedia.org/wiki/Basic_reproduction_number) of the virus as &lt;img src=&quot;/static/img/blog/2020-05-05-covid19-models/math_expr2.png&quot; alt=&quot;math-expr-2&quot;/&gt;. The intuitive explanation of the basic reproduction number is the following: if each person is able to spread the disease to at least one other person before recovering, then the epidemic can continue, otherwise, if &lt;img src=&quot;/static/img/blog/2020-05-05-covid19-models/math_expr3.png&quot; alt=&quot;math-expr-3&quot;/&gt;, the epidemic dies off. The problem here is that in reality, the population is very heterogeneous: there is no such thing as a single type of infectious individual since immune systems are varying from one person to another. Hence even if estimated from the empirical data, the true value &lt;img src=&quot;/static/img/blog/2020-05-05-covid19-models/math_expr4.png&quot; alt=&quot;math-expr-4&quot;/&gt; will still need to be estimated with the confidence interval. For COVID-19 the estimates show that &lt;img src=&quot;/static/img/blog/2020-05-05-covid19-models/math_expr5.png&quot; alt=&quot;math-expr-5&quot;/&gt;.
+3. In reality, one needs to take into account the information about so-called *incubation period*, the time elapsed between exposure to a pathogen, and when symptoms and signs start to appear. At the same time the effects from the mitigation policies, such as lockdown procedures, can be miscalculated using the simplest SIR models, since there total lockdown would correspond to &lt;img src=&quot;/static/img/blog/2020-05-05-covid19-models/math_expr6.png&quot; alt=&quot;math-expr-6&quot;/&gt;, which gives unrealistic results.
+
+For more publications on COVID-19 please see recent peer-reviewed articles, such as [Fergusson et al.](https://www.medrxiv.org/content/10.1101/2020.03.09.20033357v1)
+
+Find more illustrations and code by B.Goncalves at [Epidemiology101](https://github.com/DataForScience/Epidemiology101).
+
+## Predictions of next waves and role of mobility data
+
+Prediction of next waves of COVID19 can be made using various models, 
+including classical simple SIR model or its variations. One can already see the effect of curve flattening by changing the parameters, such as mobility index or average number of interactions between people. For spatial statistics one may need to use spatially embedded models, such as more generic and complex models [Gleamviz model](http://www.gleamviz.org/).
+For calibrating these models, 
+one need to use expert-curated healthcare datasets available to COVID-19 researchers and data scientists.  Mobility trends are important components for prediction of epidemics spreading, therefore we are working on making finding open mobility datasets.
+Below we collected some references of datasets and peer-reviewed publications:
+
+1. Mobility data on the effect of confinement on mobility: [mobility data](https://github.com/datasciencecampus/google-mobility-reports-data/) on
+mobility of people in residential, non-residential areas;
+2. Mobility data and predictions from the perspective of so-called &quot;mobility index&quot; can be found on the website of Cuebiq and illustrated in [Gleamproject](https://covid19.gleamproject.org/mobility);
+3. Recent work and overview of predictive modeling of spreading COVID19 made and explained simply by B.Gonsalves, network scientist and physicist [here](https://medium.com/data-for-science/visualizing-the-spread-of-covid-19-a4ea21ee8e46);
+4. References resource of more than 128,000 scholarly articles about the novel coronavirus for use by the global research community: [coronawhy](https://www.coronawhy.org/cord19).
+
+
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -274,6 +4320,17 @@
     <author>
       <name>michael.polidori</name>
     </author>
+    <content type="html">
+Here at DataHub and [Datopian](https://www.datopian.com/), we recently celebrated [Open Data Day 2020](https://opendataday.org/). If you&apos;re not familiar with Open Data Day, it&apos;s an annual worldwide celebration of open data.
+
+For part of our day, we decided to clean up and package some data on COVID-19 (coronavirus). The data includes **province/state**, **country/region**, **latitude**, **longitude**, **date**, **confirmed**, **recovered**, and **deaths**. Our source was from the [Data Repository by Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19), which is updated daily by [Johns Hopkins Whiting School of Engineering](https://systems.jhu.edu/).
+
+To clean up the data, we used a Python library called dataflows, which is available in the [PyPI](https://pypi.org/project/dataflows/), and on [GitHub](https://github.com/datahq/dataflows). We used this library to unpivot the data, accumulate the daily cases, and consolidate our 3 sources (Johns Hopkins has separate CSV files for cases: [confirmed](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Confirmed.csv), [recovered](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Recovered.csv), and [deaths](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Deaths.csv)).
+
+The source code and results can be found on [GitHub](https://github.com/datasets/covid-19), and a published dataset can be found here on [DataHub](https://datahub.io/core/covid-19). Our next step is to release a visualization.
+
+Whether or not you&apos;ve participated in Open Data Day before, we hope to see you participate next year!
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -285,6 +4342,111 @@
     <author>
       <name>rufuspollock</name>
     </author>
+    <content type="html">
+Comparotron allows users to quickly create simple comparative visualizations.
+
+There are already many graphing and apps out there so what&apos;s different about comparotron? 
+
+The essence of the idea is simplicity and the power (and freedom) of constraints: comparotron is *only* about comparisons and limits you to just one or two numbers. That&apos;s it. No more, no less. We think that this constraint is powerful -- and fun! And lends itself to quick, creative story-telling.
+
+As pictures 📷 are worth a thousand words let&apos;s dive in with some mockups that give a sense of the idea.
+
+[[toc]]
+
+## Comparotron Illustrated
+
+### The first mockup of the idea (by David McCandless) in 2010
+
+The first mockup of the idea (by David McCandless) done for the [Where Does My Money Go][wdmmg] project (2010)
+
+![The first mockup of the idea (by David McCandless) done for the Where Does My Money Go](https://f.cloud.github.com/assets/180658/750549/198722d0-e4d0-11e2-8a57-998f68acfeaf.png)
+
+### New mockups created as part of Open Data Day 2020
+
+This is all real data by the way!
+
+![Coronavirus (COVID-19) vs Flu Mortality Rates](/static/img/blog/comparotron-v0.2-march-2020-coronavirus-vs-flu.svg)
+
+![US Spending on Military vs Aid](/static/img/blog/comparotron-v0.2-march-2020-military-vs-aid.svg)
+
+ ## History
+
+The concept originated in 2010 as part of [Where Does My Money Go][wdmmg] when looking for ways to present government spending effectively. Giving a real sense of this kind of data can be hard because of the size, variety and abstractness of the figures -- what does $3bn of aid spending really *mean*?
+
+Introducing comparison can help provide context, tangibility and &quot;meaning&quot;. For example, we can compare aid spending to other spending items  such as spending on the military which will given a relative sense to the aid number.
+
+Or, alternatively, we could compare aid expenditure to some external more &quot;every-day&quot; figure; for example, the cost of a loaf of bread of a teacher&apos;s salary yielding a comparison like &quot;aid spending is equivalent to employing 10,000 teachers for a year&quot;.
+
+[wdmmg]: https://app.wheredoesmymoneygo.org/
+
+## Work on Open Data Day 2020
+
+Here at [DataHub][] and [Datopian][] we were delighted to take part of [Open Data Day][] -- and [to help sponsor it][sponsor]. We&apos;ve been part of [open data][] from the beginning -- our President started [Open Knowledge Foundation][okf] and helped kick-off Open Data Day as an event!
+
+[Comparotron][] is one of the projects we worked on this [Open Data Day][]. Along with getting on top of the [initial effort][] from nearly eight years ago (how time flies!) we:
+
+* Created example comparisons by hand -- see above
+* Outlined the MVP -- see below
+* And ... created a plan of work for it
+
+Phew, that&apos;s quite a bit! 🚀
+
+[DataHub]: https://datahub.io/
+[Datopian]: https://datopian.com/
+[sponsor]: https://www.datopian.com/2020/01/15/a-data-platform-for-open-data-day-2020/
+[open data]: https://okfn.org/opendata/
+[Open Data Day]: https://opendataday.org/
+[okf]: https://okfn.org/
+[Comparotron]: https://comparotron.datahub.io/
+[initial effort]: https://github.com/datopian/comparotron/releases/tag/v0.1
+
+## Getting to an MVP
+
+A central part of the [original conception][original] was a rich experience for user&apos;s to find/select the data points they wanted to use. This made sense if you already had a database of government spending data. Even when I moved away from this idea to allow all kinds of numeric data (in comparotron v0.1 in 2012), this assumption continued to inform the approach and I spent most of my effort on the functionality and UX for searching for and selecting data ptoints (indeed, I spent plenty oof time wondering about where data would be stored and come from e.g. would it be in elastic search, where would I source GDP per capita from etc).
+
+[original]: https://github.com/datopian/comparotron/issues/1
+
+But thinking about this, we can simplify a lot:
+
+* Simplication 1: we can assume the user will find the data points and enter that info themselves =&gt; no need for fancy search or data sourcing
+* Simplication 2: that still leaves us with an editor (and backend) for people to create &quot;compares&quot; ... but what about just using static website tech and storing this in markdown+frontmapper =&gt; no need for an editor, backend or APIs -- just use your text editor, markdown files and git(hub) as backend
+
+Thanks to MVP approach we&apos;re gradually moving from building a complex 🚗 to making a much more manageable 🛹 Yeah 👌
+
+### Essential user flows
+
+What are the essential user flows? There are just two:
+
+* **Create**: create a &quot;compare&quot; by entering one or more &quot;factoids&quot; (plus a title)
+* **Show**: display the comparison in a beautiful and elegant way
+
+MVP approach to these:
+
+* **Create**: use a simple markdown file with frontmatter, edit it in a text editor, and push it to github (Even simpler: hand-craft this in a drawing app!)
+* **Show**: let&apos;s use a static site generator to build the site and some basic JS (or even CSS) for the visualization
+
+## Initial Examples
+
+Here&apos;s the hand-crafted examples with we did (with real data)!
+
+### US Spending on Military vs Aid
+
+![US Spending on Military vs Aid](/static/img/blog/comparotron-v0.2-march-2020-military-vs-aid.svg)
+
+### Coronavirus (COVID-19) vs Flu Mortality Rates
+
+![Coronavirus (COVID-19) vs Flu Mortality Rates](/static/img/blog/comparotron-v0.2-march-2020-coronavirus-vs-flu.svg)
+
+## Next Steps
+
+We&apos;re continuing to work on the project and you can follow the progress (and contribute!) on github here:
+
+https://github.com/datopian/comparotron
+
+First steps will be getting a stub website live at https://comparotron.datahub.io
+
+Check back soon for more updates! 👌
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -296,6 +4458,16 @@
     <author>
       <name>branko-dj</name>
     </author>
+    <content type="html">
+We are happy to present new datasets extracted from [open-ml](https://www.openml.org/home) website. You can find them at our machine-learning datasets [page](https://www.datahub.io/machine-learning). OpenML is a hub for sharing interesting open source machine learning datasets. It links data to algorithms and people, so you can build on the state of the art and learn to teach machines to learn better. Some of the most popular datasets among our users for you to take a look at:
+
+* [Vehicle silhouettes](https://www.datahub.io/machine-learning/vehicle)
+* [Diabetes](https://www.datahub.io/machine-learning/diabetes)
+* [Musk](https://www.datahub.io/machine-learning/musk) 
+
+
+We extracted 100 most downloaded datasets from OpenML for you to practice and solve problems. We hope that you will find them useful and informative.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -307,6 +4479,28 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+Check out a list of core datasets that are updated on a regular basis. From financial to reference data - it is the best place to find a wide range of up to date datasets.
+
+## Financial data
+
+* [VIX - CBOE Volatility Index](/core/finance-vix) :clock1: updated daily
+* [Natural gas prices](/core/natural-gas) :clock1: updated daily
+* [Oil prices](/core/oil-prices) :clock1: updated weekly
+* [10 year US Government Bond Yields](/core/bond-yields-us-10y) :clock1: updated monthly
+* [10 year UK Government Bond Yields](/core/bond-yields-uk-10y) :clock1: updated quarterly
+
+## Reference data
+
+* [Airport codes](/core/airport-codes) :clock1: updated daily
+* [Language codes](/core/language-codes) :clock1: updated monthly
+
+## Other
+
+* [Population growth estimates and projections](/core/population-growth-estimates-and-projections) :clock1: updated annually
+
+There will be more automated datasets on :datahub: so join our [community chat on :discord: Discord](https://discord.gg/KrRzMKU) and our Newsletter (insert link) to receive the latest news!
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -318,6 +4512,26 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+Great news! We&apos;ve expanded our range of datasets to include sports data. You can find football data that includes all the major European leagues and ATP tennis data. The football datasets are updated on weekly basis. Check out the publisher page for the `sports-data` now:
+
+https://datahub.io/sports-data
+
+For the sports betting enthusiasts and pros, we offer a Premium Data service (read more on [pricing page](/pricing)). We can customize the data, include additional data and have more regular updates and guarantee those updates with an SLA amongst other services.
+
+There will be more data in the future so don&apos;t forget to bookmark the link :smile:
+
+## New sports dataset available on :datahub:
+
+Below is the list of datasets that are published and available for you to use:
+
+* [ATP World Tour tennis data](/sports-data/atp-world-tour-tennis-data)
+* [English Premier League (football)](/sports-data/english-premier-league)
+* [Spanish La Liga (football)](/sports-data/spanish-la-liga)
+* [Italian Serie A (football)](/sports-data/italian-serie-a)
+* [German Bundesliga (football)](/sports-data/german-bundesliga)
+* [French Ligue 1 (football)](/sports-data/french-ligue-1)
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -329,6 +4543,57 @@
     <author>
       <name>branko-dj</name>
     </author>
+    <content type="html">
+We are happy to present a short description of ARFF format that is very useful for those interested in machine learning. In this post we shall explain some features of this format.
+
+## What is ARFF?
+
+ARFF stands for Attribute-Relation File Format. It is an ASCII text file that describes a list of instances sharing a set of attributes. ARFF files were developed by the Machine Learning Project at the Department of Computer Science of The University of Waikato for use with the Weka machine learning software. This document descibes the version of ARFF used with Weka versions 3.2 to 3.3; this is an extension of the ARFF format as described in the data mining book written by Ian H. Witten and Eibe Frank (the new additions are string attributes, date attributes, and sparse instances).
+
+This explanation was cobbled together by Gordon Paynter (gordon.paynter at ucr.edu) from the Weka 2.1 ARFF description, email from Len Trigg (lenbok at myrealbox.com) and Eibe Frank (eibe at cs.waikato.ac.nz), and some datasets. It has been edited by Richard Kirkby (rkirkby at cs.waikato.ac.nz). Contact Len if you&apos;re interested in seeing the ARFF 3 proposal.
+
+## Overview
+ARFF files have two distinct sections. The first section is the **Header** information, which is followed by the **Data** information.
+
+The Header of the ARFF file contains the name of the relation, a list of the attributes (the columns in the data), and their types. An example header on the standard IRIS dataset looks like this:
+
+   % 1. Title: Iris Plants Database
+   %
+   % 2. Sources:
+   %      (a) Creator: R.A. Fisher
+   %      (b) Donor: Michael Marshall (MARSHALL%PLU@io.arc.nasa.gov)
+   %      (c) Date: July, 1988
+   %
+   @RELATION iris
+
+   @ATTRIBUTE sepallength  NUMERIC
+   @ATTRIBUTE sepalwidth   NUMERIC
+   @ATTRIBUTE petallength  NUMERIC
+   @ATTRIBUTE petalwidth   NUMERIC
+   @ATTRIBUTE class        Iris-setosa,Iris-versicolor,Iris-virginica
+
+The Data of the ARFF file looks like the following:
+
+   @DATA
+   5.1,3.5,1.4,0.2,Iris-setosa
+   4.9,3.0,1.4,0.2,Iris-setosa
+   4.7,3.2,1.3,0.2,Iris-setosa
+   4.6,3.1,1.5,0.2,Iris-setosa
+   5.0,3.6,1.4,0.2,Iris-setosa
+   5.4,3.9,1.7,0.4,Iris-setosa
+   4.6,3.4,1.4,0.3,Iris-setosa
+   5.0,3.4,1.5,0.2,Iris-setosa
+   4.4,2.9,1.4,0.2,Iris-setosa
+   4.9,3.1,1.5,0.1,Iris-setosa
+
+Lines that begin with a % are comments. The @RELATION, @ATTRIBUTE and @DATA declarations are case insensitive.
+
+## Datahub examples
+You can find ARFF files in resources for our machine-learning datasets datahub.io/machine-learning that we extracted from [openml](https://www.openml.org/search?type=data) website. We hope that you will find them useful for your projects in macahine learning and data science.
+
+
+*Branko graduated physics at the University of Belgrade and his current work focuses on finding, extracting, formatting and publishing data on DataHub. In his free time he enjoys reading, coding and long walks on the beach in his landlocked home country of Serbia*
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -340,6 +4605,66 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+If you are using `data` CLI tool for both personal and professional purposes, you would need to have more than 1 account. Below we explain how account configurations work and how you can manage them - it is simple and straightforward!
+
+## Accounts and config files
+
+You have config file per account, which is stored in `~/.config/datahub/` directory. By default, its name is `config.json` - try to &apos;cat&apos; it to have a sense about how it looks like:
+
+```bash
+cat ~/.config/datahub/config.json
+```
+
+and you&apos;d get following output:
+
+```json
+{
+    &quot;token&quot;: &quot;your-token&quot;,
+    &quot;profile&quot;: {
+        &quot;avatar_url&quot;: &quot;...&quot;,
+        &quot;email&quot;: &quot;...&quot;,
+        &quot;id&quot;: &quot;...&quot;,
+        &quot;join_date&quot;: &quot;...&quot;,
+        &quot;name&quot;: &quot;...&quot;,
+        &quot;provider_id&quot;: &quot;...&quot;,
+        &quot;username&quot;: &quot;...&quot;
+    }
+}
+```
+
+If you have multiple accounts, it is suggested to store config files in the same location so you always can list and quickly find them. For example, you can rename your personal config file to `my.json`, while your organization account configs would have `org.json` name. If you list files in your configs directory:
+
+```bash
+ls ~/.config/datahub/
+```
+
+you&apos;d get:
+
+```bash
+my.json    org.json
+```
+
+## Switch between your accounts
+
+Once you have all config files locally with appropriate names, it is easy to switch between them. It can be done by setting `DATAHUB_JSON` environment variable. The CLI tool will use value of this variable to authenticate you in the system. Simply set it up for the current session, e.g., let&apos;s use your org account:
+
+```bash
+export DATAHUB_JSON=~/.config/datahub/org.json
+```
+
+## Check current account
+
+Although the `data` CLI tool doesn&apos;t have a command for checking which account you&apos;re using, you can print current value of your `DATAHUB_JSON` variable:
+
+```bash
+echo $DATAHUB_JSON
+```
+
+---
+
+*Originally published at https://datahub.io/docs/tutorials/how-to-use-multiple-datahub-accounts*
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -351,6 +4676,34 @@
     <author>
       <name>branko-dj</name>
     </author>
+    <content type="html">
+We have extracted 307 indicators from The World Bank and published them on DataHub:
+
+https://datahub.io/world-bank
+
+The World Bank Open Data website offers free access to comprehensive, downloadable indicators about development in countries around the globe. Most of the country-level, time-series data—including indicators in the WDI section are accessible through the standard World Bank data API. By using this API we have extracted and published all of the 307 datasets for world bank indicators from page https://data.worldbank.org/indicator?tab=all. Indicators are sorted in 20 different categories:
+
+- Agriculture &amp; Rural Development
+- Aid Effectiveness
+- Climate Change
+- Economy &amp; Growth
+- Education
+- Energy &amp; Mining
+- Environment
+- External Debt
+- Financial Sector
+- Gender
+- Health
+- Infrastructure
+- Poverty
+- Private Sector
+- Public Sector
+- Science &amp; Technology
+- Social Development
+- Social Protection &amp; Labor
+- Trade
+- Urban Development
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -362,6 +4715,114 @@
     <author>
       <name>branko-dj</name>
     </author>
+    <content type="html">
+As a platform dedicated to providing access to high quality data and tooling we need to measure how useful our users find DataHub&apos;s services. Measurable values like how many users we have, site traffic, how many people run our `data` CLI tool, how many of our datasets are published etc. are all key performance indicators (KPIs) that demonstrate how effectively we do as a company in terms of achieving our key business objectives.
+
+In order to monitor our KPIs, we want to do the followings:
+
+* collect KPIs from Google Analytics and internal APIs so we can keep all stats in the one place;
+* package the CSV data and publish it to DataHub so we have a standardized, cleaned and validated dataset of our KPIs;
+* add visualizations to easily and quickly see insights.
+
+## The problem of KPIs tracking
+
+In order to keep up-to-date with the usage of our website and services, we collect stats from various sources - our SQL database, our search API, Google Analytics for datahub.io, etc. This process of collection had been done manually at first which presented significant problems for us - it was time consuming and prone to human error as it required tediously scrolling pages and clicking buttons for a long period of time that got longer the more stats we decided to collect.
+
+## Solution that we created to tackle tracking challenges
+
+To address these issues we have created a scalable model for stats collection outlined in a github repo [datahub-metrics](https://github.com/datahq/datahub-metrics) with the task of collecting daily, weekly and biweekly stats for datahub.io and its services. The script is written in Python and it is ran automatically via cronjob on Travis. After collecting these stats, CSV data files are created.
+
+Once we&apos;ve automated KPIs collection, we wanted to output it on DataHub so our team can easily get insights.
+
+### Publish on DataHub
+
+First we needed to package CSV data files so they have a standard metadata. We then wanted to publish it on DataHub so the team can access cleaned, normalized and validated data.
+
+With our `data` CLI tool we can add metadata for our CSV files by running `data init`. This creates a JSON file `datapackage.json`, which contains information about the name, format and data type of the columns, encoding, missing values etc.:
+
+```json
+{
+    &quot;name&quot;: &quot;datahub-metrics&quot;,
+    &quot;title&quot;: &quot;Datahub metrics&quot;,
+    &quot;resources&quot;: [...]
+}
+```
+
+*See full `datapackage.json` [here](https://github.com/datahq/datahub-metrics/blob/master/datapackage.json).*
+
+Once the data is packaged, we just need to upload it to DataHub. By running `data push` command from the root directory of the dataset we have following link of our published data:
+
+https://datahub.io/datahq/datahub-metrics
+
+### Visualization of the funnels
+
+Now we want to identify and visualize the funnels that gives us an idea about where we should improve.
+
+We have defined couple of initial funnels that we think is important. We consider ratio of important KPIs against total unique visitors. This way we can tell if decrease in certain area caused by our latest implementations. We will visualize following KPIs:
+
+1. New sign ups
+2. Number of CLI downloads from the website
+
+Below we have written how &quot;views&quot; property would look like in the `datapackage.json` file:
+
+:::info
+In order to define how the graphs should look like we add a &quot;views&quot; property to `datapackage.json` file that will tell DataHub platform to create graphs on our page. By just editing a few lines in &quot;views&quot; property we can easily change the appearance of our graphs on the whim. Things like which stats to create graph for, which time period to display, average and max values etc.
+:::
+
+```json
+{
+    &quot;name&quot;: &quot;datahub-metrics&quot;,
+    &quot;title&quot;: &quot;Datahub metrics&quot;,
+    &quot;resources&quot;: [&quot;...&quot;],
+    &quot;views&quot;: [
+      {
+        &quot;name&quot;: &quot;funnels&quot;,
+        &quot;title&quot;: &quot;Funnels&quot;,
+        &quot;resources&quot;: [
+            {
+              &quot;name&quot;: &quot;biweekly_stats&quot;,
+              &quot;transform&quot;: [
+                {
+                  &quot;type&quot;: &quot;formula&quot;,
+                  &quot;expressions&quot;: [
+                    &quot;data[&apos;Total new users&apos;] * 100 / data[&apos;Total Unique Visitors&apos;]&quot;,
+                    &quot;data[&apos;Downloads CLI (GA)&apos;] * 100 / data[&apos;Total Unique Visitors&apos;]&quot;
+                  ],
+                  &quot;asFields&quot;: [
+                    &quot;Percentage of total new users in the sprint&quot;,
+                    &quot;Percentage of total CLI downloads from website in the sprint&quot;
+                  ]
+                }
+              ]
+            }
+        ],
+        &quot;specType&quot;: &quot;simple&quot;,
+        &quot;spec&quot;: {
+          &quot;group&quot;: &quot;Date&quot;,
+          &quot;series&quot;: [
+            &quot;Percentage of total new users in the sprint&quot;,
+            &quot;Percentage of total CLI downloads from website in the sprint&quot;
+          ],
+          &quot;type&quot;: &quot;line&quot;,
+          &quot;ySuffix&quot;: &quot;%&quot;
+        }
+      }
+    ]
+}
+```
+
+These specifications are rendered as below on the DataHub:
+
+&lt;iframe src=&quot;https://datahub.io/datahq/datahub-metrics/view/0&quot; width=&quot;100%&quot; height=&quot;475px&quot; frameborder=&quot;0&quot;&gt;&lt;/iframe&gt;
+
+By taking a look at this graph, we could say that number of CLI downloads significantly decreased since May 3, while number of sign ups remain at the same level. This must be due to redesign that we have implemented in the beginning of the May.
+
+## Summary
+
+By creating &apos;datahub-metrics&apos; and automating it via Travis CI we drastically shortened the time needed for collecting stats. That which would take at least a half an hour on a daily basis is now being done in no time and at assigned times with no possibility of human error. Once the stats are assembled in clean CSV files we use data-cli to package and publish it. The `datapackage.json` file is thus created and by adding a view section to it we can create and format customized visualizations on our dataset page. Every time the stats files are updated, so are the graphs.
+
+By doing this we have created a scalable model for stats collection and created reusable python modules for interacting with google analytics, sql database, google sheets etc. You can use our platform to keep track of stats for your website and services the same way we did. We hope that you will find our approach informative and useful in your projects where tracking user interactions with your website and services is paramount.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -373,6 +4834,49 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+Awesome pages are collections of data from DataHub and the web that are grouped and analyzed for your usage. Our goal is to cover all important subjects and users always can [suggest](#contribute) a new theme to consider. Visit and explore revamped awesome collections now:
+
+https://datahub.io/awesome
+
+## Find data sets by subject
+
+Below are some of awesome collections you may find useful.
+
+### Economic data
+
+Summary of all available economic indicators on DataHub:
+
+https://datahub.io/awesome/economic-data
+
+### Reference data
+
+This page is the place where you can find all reference data available on DataHub. Each dataset is easy-to-use and includes instructions on how to use it in different tools and programming languages:
+
+https://datahub.io/awesome/reference-data
+
+### Demographics
+
+Population data and data analytics:
+
+https://datahub.io/awesome/demographics
+
+### Stock market data
+
+Find and Explore ready-to-use Stock Market Datasets:
+
+https://datahub.io/awesome/stock-market-data
+
+### Other collections
+
+There are more collections available - to find out more please go to:
+
+https://datahub.io/awesome
+
+## Contribute
+
+You may notice a button on the right for editing existing awesome collection. Basically, you can open a pull request on https://github.com/datahq/awesome-data repository and our team will review and add your work.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -384,6 +4888,123 @@
     <author>
       <name>svetozarstojkovic</name>
     </author>
+    <content type="html">
+We have created a number of `machine learning` datasets that can be interesting for professionals and students from the field.
+
+You can see our current machine-learning datasets at https://datahub.io/machine-learning
+
+## Introduction
+
+Machine learning is the science of making computers learn like humans do and to also improve their capabilities to learn to act without being explicitly programmed. It is used as a general term for computational data analysis: using data to make inferences and predictions. It combines computational statistics, data analytics, data mining and a good portion of data science. Machine learning algorithms are often categorized as supervised or unsupervised (“data mining”).
+
+For more information please visit:
+https://datahub.io/awesome#machine-learning-statistical
+
+Example dataset:
+
+| Column 1 | Column 2 | Column 3 | Class |
+|----------|----------|----------|-------|
+| 0        | 1        | 2        | 0     |
+| 3        | 4        | 5        | 1     |
+| 6        | 7        | 8        | 2     |
+| 9        | 10       | 11       | 3     |
+| 12       | 13       | 14       | 4     |
+
+Using columns as input, machine learning algorithms can &quot;learn&quot; how to predict the appropriate output for any input.
+
+Some of the more famous algorithms for supervised learning include:
+* Neural networks
+* Naive Bayes
+* K - nearest neighbor
+* Decision tree
+* Support Vector Machines
+
+Some of the more famous algorithms for unsupervised learning include:
+* DB Scan
+* K - means
+
+All above algorithms can be applied on datasets that are located under the machine-learning user.
+
+## Available datasets
+
+Some interesting datasets you can take a look at:
+* [Seismic bumps](https://datahub.io/machine-learning/seismic-bumps)
+* [Hepatitis](https://datahub.io/machine-learning/hepatitis)
+* [Cervical cancer](https://datahub.io/machine-learning/cervical-cancer)
+* [Primary tumor](https://datahub.io/machine-learning/primary-tumor)
+* [Fertility](https://datahub.io/machine-learning/fertility)
+* [Breast cancer](https://datahub.io/machine-learning/breast-cancer)
+* [Speed dating](https://datahub.io/machine-learning/speed-dating)
+* [Dermatology](https://datahub.io/machine-learning/dermatology)
+* [Lymph](https://datahub.io/machine-learning/lymph)
+* [Tic Tac Toe Endgame](https://datahub.io/machine-learning/tic-tac-toe-endgame)
+* [EEG Eye State](https://datahub.io/machine-learning/eeg-eye-state)
+
+## Usage
+
+* For those new to data science and machine learning you can dive in with analysis and practicing on our prepared datasets. No need to modify the raw unprocessed online data, we have already taken care of that.
+
+* For those advanced in the study of machine learning you can get a wide range of well-prepared datasets (including well known ones) that you can practice on so that you can improve and focus your efforts on improving your understanding.
+
+* For machine learning practitioners you can find up to date datasets that you can use for implementing newest classificators so that you can contribute to machine learning community or create projects for any organization you may work with.
+
+Starting with machine learning will be shown on `hepatitis` dataset and in Python language:
+https://datahub.io/machine-learning/hepatitis#python
+
+### Getting a dataset
+First thing to do is install datapackage library
+
+```bash
+pip install datapackage
+```
+
+Then you need to get your dataset using the &quot;Import into your tool&quot; (option at the bottom of the page)
+
+```python
+from datapackage import Package
+
+package = Package(&apos;https://datahub.io/machine-learning/hepatitis/datapackage.json&apos;)
+
+# print list of all resources:
+print(package.resource_names)
+
+# print processed tabular data (if exists any)
+for resource in package.resources:
+    if resource.descriptor[&apos;datahub&apos;][&apos;type&apos;] == &apos;derived/csv&apos;:
+        print(resource.read())
+```
+
+### Input and output matrices
+
+In the `hepatitis` dataset last column represents the class attribute which holds the information about whether the patient lived or died.
+
+We will mark the number of columns with letter **m**, and number of instances with letter **n**
+
+Input matrix will contain all elements from all columns except class which means that it&apos;s dimension will be **n** x **m-1**.
+
+| n        | Column 1 | Column 2 | ...      | Column m-1 |
+|----------|----------|----------|----------|----------
+| 1        | x        | x        | ...      |  x
+| 2        | x        | x        | ...      |  x
+| ...      | ...      | ...      | ...      |  ...
+| n        | x        | x        | ...      |  x
+
+Output matrix will contain elements from class attribute and it&apos;s dimension will be **n**x**1**
+
+| n        | Column 1(class) |
+|----------|-----------------|
+| 1        | x               |
+| 2        | x               |
+| ...      | ...             |
+| n        | x               |
+
+By using those matrices you will be able to pass them as a parameter to any classifier method.
+
+
+## Summary
+
+By using DataHub you can easily get the datasets you need and just start working on them without necessary data-wrangling and focus on creating machine learning algorithms. We hope you find them useful and interesting.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -395,6 +5016,47 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+In this tutorial, we provide instructions on how to automate publishing your dataset via [Travis-CI]. If you prefer hosting and controlling your dataset on GitHub, you&apos;d find this tutorial useful. Before reading further, please, make sure you&apos;re familiar with GitHub and Travis-CI as you&apos;ll need to enable builds for your repository.
+
+[Travis-CI]: https://travis-ci.org/
+
+Let&apos;s consider the request we&apos;ve received recently for auto-publishing the dataset from the following repository:
+
+https://github.com/datasets/dac-crs-codes
+
+Please, read through the issue thread here to understand the problem: https://github.com/datahq/datahub-qa/issues/213.
+
+## Setup
+
+Our goal is to trigger a publishing on every commit to &apos;master&apos; branch. To do so we&apos;ll use the [data] CLI tool for interacting with DataHub, which is available via [NPM]. Below is how the configuration file (`.travis.yml`) for Travis-CI would look like:
+
+```yaml
+language: node_js
+node_js:
+  - &quot;8&quot;
+install: npm install -g data-cli
+script: data push --public
+branches:
+  only:
+  - master
+```
+
+This instructs Travis-CI to install &apos;data&apos; CLI tool via NPM and publish the dataset with &apos;public&apos; option which makes it publicly available. It assumes that there is a `datapackage.json` file in the root directory of the repository.
+
+[data]: https://datahub.io/download
+[NPM]: https://www.npmjs.com/package/data-cli
+
+## Credentials
+
+If you try to trigger a build, it wouldn&apos;t publish anything to DataHub since you need to set credentials. Provide `token`, `id` and `username` values of your DataHub account as environment variables - go to your Travis-CI settings and add the required key-value pairs. We recommend not displaying values in build log for security reasons. Additionally, you may need to setup `env` variable with `test` value to overcome some Travis specific errors.
+
+![setting env variable test to overcome some travise specific errors](https://raw.githubusercontent.com/datahq/datahub-content/master/assets/img/travis-ci-env-vars.png)
+
+## Final steps
+
+Now, you should be able to trigger a Travis-CI build by pushing a commit into &apos;master&apos; branch. If builds are not starting, make sure that &apos;Build pushed branches&apos; option is enabled in the settings.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -406,6 +5068,64 @@
     <author>
       <name>acckiygerman</name>
     </author>
+    <content type="html">
+Here we explain how you can use JavaScript SDK for data deployment purposes. If you need a detailed step-by-step tutorial, please, go to this article:
+
+https://datahub.io/docs/tutorials/js-sdk-tutorial
+
+## Prerequisites
+
+1. You need to have NodeJS (`&gt;= 7.6`) and NPM.
+2. Installed `datahub-client` and `data.js` NPM packages:
+
+      `npm install datahub-client data.js --save`
+
+## Example of usage
+
+Following code snippet is a working example for basic usage. It uses credentials stored in `~/.config/datahub/config.json`, which is created when you login using [the CLI tool](https://datahub.io/download).
+
+```javascript
+const {DataHub, config, authenticate} = require(&apos;datahub-client&apos;)
+const {Dataset} = require(&apos;data.js&apos;)
+
+async function pushDataset(datasetPath) {
+  // First, authenticate user
+  const apiUrl = config.get(&apos;api&apos;)
+  const token = config.get(&apos;token&apos;)
+  const response = await authenticate(apiUrl, token)
+  if (!response.authenticated) {
+    console.error(&apos;Your credentials expired or missing.&apos;)
+    return
+  }
+  // Load dataset that we want to push
+  const dataset = await Dataset.load(datasetPath)
+  // Create an instance of the DataHub class, using the data from the user config
+  const configs = {
+   apiUrl,
+   token,
+   ownerid: config.get(&apos;profile&apos;) ? config.get(&apos;profile&apos;).id : config.get(&apos;id&apos;)
+  }
+  const datahub = new DataHub(configs)
+
+  // Now use the datahub instance to push the data
+  const res = await datahub.push(dataset, {findability: &apos;unlisted&apos;})
+  console.log(res)
+}
+
+pushDataset(&apos;path/to/dataset&apos;)
+```
+
+This is an example of correct console output:
+
+```
+{ dataset_id: &apos;username/finance-vix&apos;,
+  errors: [],
+  flow_id: &apos;username/finance-vix/1&apos;,
+  success: true }
+```
+
+That is all needed to get your dataset deployed in DataHub!
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -417,6 +5137,80 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+In this article we explain how easy is adding a `datapackage.json` file for your data. You need to have `data` tool installed - [download it](https://datahub.io/download) and follow these [instructions](https://datahub.io/docs/getting-started/installing-data).
+
+:::info
+If you&apos;re not familiar with `datapackage.json`, please, read this article - https://datahub.io/docs/data-packages.
+:::
+
+Below is how our project looks like initially:
+
+```cli-output
+$ ls
+
+README.md   sample.csv   sample.json
+```
+
+We will use `data init` command to create a `datapackage.json` file for this project below.
+
+## Default mode
+
+By default, `data init` command runs in non-interactive mode. No arguments and options are required, it will scan current working directory and all nested directories for the available files:
+
+```cli-output
+$ data init
+
+\&gt; This process initializes a new datapackage.json file.
+
+\&gt; Once there is a datapackage.json file, you can still run &apos;data init&apos; to update/extend it.
+
+\&gt; Press ^C at any time to quit.
+
+\&gt; Detected special file: README.md
+
+\&gt; sample.csv is just added to resources
+
+\&gt; sample.json is just added to resources
+
+\&gt; Default &quot;ODC-PDDL&quot; license is added. If you would like to add a different license, run &apos;data init -i&apos; or edit &apos;datapackage.json&apos; manually.
+
+\&gt; 💾 Descriptor is saved in &quot;datapackage.json&quot;
+```
+
+and now the project contains `datapackage.json`:
+
+```cli-output
+$ ls
+
+README.md  datapackage.json  sample.csv  sample.json
+```
+
+If you take a look at `datapackage.json`, you&apos;d mention that:
+
+* it uses name of the current working directory as `name` property and generates `title` from it
+* it adds `sample.csv` and `sample.json` files into `resources` list with schema for tabular data
+* it detects `README.md` and uses its content in `readme` property; `description` property is the first 100 characters of the readme
+* it adds default `ODC-PDDL` license
+
+## Interactive mode
+
+If you need more control, e.g., you want to add only certain files, scan certain directories and add a different license, you can use `init` command in interactive mode:
+
+```
+$ data init -i
+```
+
+## What&apos;s next?
+
+You can now deploy your dataset to DataHub:
+
+```
+$ data push
+```
+
+Want to learn more? Visit our docs page - https://datahub.io/docs
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -428,6 +5222,35 @@
     <author>
       <name>acckiygerman</name>
     </author>
+    <content type="html">
+To help users with creation of Data Packages we have implemented a descriptor validation tool:
+
+https://datahub.io/tools/validate
+
+Now users can check the Data Package descriptor to be sure they have no errors in it.
+
+## How to use it
+
+The descriptor should be stored online, e.g. on the github.
+
+You should provide the URL to the descriptor (datapackage.json) file and press &apos;Validate&apos; button.
+
+:::info
+Online validator tool validates only the descriptor file.
+
+Here you can read about the [full data validation on the DataHub](https://datahub.io/blog/data-validation-in-the-datahub).
+:::
+
+## How we validate
+
+We try to create a Data Package object using [datapackage-js](https://github.com/frictionlessdata/datapackage-js) and then show user any errors the Data Package has with `Package.valid` and `Package.errors` methods. For example, here we validate following [datapackage.json](https://raw.githubusercontent.com/frictionlessdata/test-data/master/packages/invalid-descriptor/datapackage.json) file that has invalid `name` property:
+
+![online-validation-tool-invalid-package](/static/img/docs/online-validation-tool-invalid-package.png)
+
+To create a valid Data Package, please read full datapackage.json specs here:
+
+https://frictionlessdata.io/docs/data-package/
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -439,6 +5262,72 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+We&apos;re sharing an update on all the progress we made in the first quarter of 2018. We massively improved our `data` command line tool, sped up data deployment 5-100x and introduced embeddable shareable data tables and visualizations.  We welcome feedback and ideas on how to keep improving the platform.
+
+## Polishing `data` command line tool and QA
+
+Q1 focused on polishing the `data push` flow and starting to improve the funnel of take up. We also improved `data` tool generally and added a few new features in the frontend such as embeddable tables and views.
+
+On `data` tool we did a lot of work on QA. We put in place a new QA process including a full breakdown of key processes, a new, more comprehensive testing system plus a new method for tracking issues in github.
+
+Summary of QA stats (as for 29 Mar 2018):
+
+* Total test cases: 203
+* Automated: ~50
+* Manual: ~150
+* Opened issues: ~100
+* Closed issues: ~70
+
+&lt;iframe src=&quot;https://datahub.io/examples/datahub-qa-issues-tracker/view/0&quot; width=&quot;100%&quot; height=&quot;475px&quot; frameborder=&quot;0&quot;&gt;&lt;/iframe&gt;
+
+*The graph above illustrates number of open issues by severity.*
+
+Issue trackers:
+
+* QA repo (and the main issue tracker) is now located at :github: https://github.com/datahq/datahub-qa/issues
+* We also have issue tracker dataset - :datahub: https://datahub.io/examples/datahub-qa-issues-tracker
+
+## Fixes and features
+
+### Data Factory
+
+* Processing speed improvements i.e. processing of 1MB CSV file was decreased from 45s to 29s and we&apos;re still working on it to make it even faster. During this process it validates and normalizes the dataset + generates cleaned CSV and JSON version of each tabular data file and ZIP version of a data package which also contains validaiton report.
+* Excel processing improvements - fixes for various bugs related to different coercion of data types in JS vs Python. This fix should enable publishers to work with most of data types in the Excel.
+
+### `data` command line tool and associated JS libraries
+
+* Windows version of the CLI and improved release management.
+* Progress bar on push so publishers have better UX while their files are being uploaded: ![Progress bar on push so publishers have better UX while their files are being uploaded](/static/img/docs/upload-progress-bar.png)
+* Parsing and ingest:
+  * support for various CSV delimiters such as semicolons, colons, pipes, tabs etc.
+  * support for various encodings
+* Skipping uploading files if already uploaded which dramatically improves push performance on repeated deployments.
+* `validate` command improvements: users now see process details, e.g., which file is being validated - useful when your data package has lots of files: ![`validate` command improvements: useful when your data package has lots of files](/static/img/docs/validate-details.png)
+* `info` command improvements: support for non-tabular files and improved information about datasets: ![`info` command improvements: support for non-tabular files and improved information about datasets](/static/img/docs/info-output.png)
+* `get` command works with files from GitHub and DataHub + getting datasets from Datahub now downloads zip version and unzips it for you.
+* `cat` command works with streamed data, e.g., from `stdin`: ![`cat` command works with streamed data](/static/img/docs/cat-streamed-data.png)
+* Error handling and messaging improvements throughout the CLI app.
+
+### Frontend
+
+* Shareable and embeddable views + HTML tables, read more about it here https://datahub.io/blog/new-features-and-improvements
+* Search improvements, e.g., now we&apos;re ignoring stop words.
+* Extended and improved instructions for using datasets from different programming languages and tools - now we have ready to use instructions for `data-cli`, `curl`, `R`, `Python`, `Pandas` and `JavaScript`.
+* Pagination on search and publisher pages as number of datasets on DataHub have increased.
+* Search in publisher page - now you can search datasets from specific publisher (e.g., core datasets - https://datahub.io/core).
+* Support for custom axis titles and suffixes in the ticks, which is important when you&apos;re creating graphs, read more about it here https://datahub.io/docs/features/views#axis-titles-and-suffixes-for-axis-ticks
+
+### Docs
+
+* Ability to give feedback or contribute to the docs, e.g., see https://datahub.io/docs/getting-started/installing-data - you can easily improve this docs article now.
+* Improved docs with GIFs so users understand how things work, e.g., see https://datahub.io/docs/getting-started/publishing-data
+* Improved and extended documentation about different commands
+
+## Summary
+
+In the Q1, the DataHub team focused on making the tools stable and useful for people - it was productive and exciting start of the year! There is a lot to be done in the Q2 so stay tuned for new updates and features!
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -450,6 +5339,46 @@
     <author>
       <name>acckiygerman</name>
     </author>
+    <content type="html">
+Good day, dear data miners, scientists and statisticians!
+
+During the last month we were focused on polishing the existing product - DataHub platform and the **data-cli** tool. Also we added number of new features.
+
+## New ways to share data
+
+Say, you are creating PhD thesis or a blog article. And you need to share some data in a pretty-looking form? That&apos;s so easy with the DataHub - just [upload your data](https://datahub.io/docs/getting-started/publishing-data)  and follow steps below.
+
+### Share data tables
+
+Each dataset on the datahub.io has preview tables for tabular data. Now you can share or embed them:
+
+![preview tables for tabular data. Now you can share or embed them](/static/img/docs/share-embed-tables.png)
+
+The **Share link** opens the table in the full-screen mode. Your colleague can easily find data and copy the entire table (or some part of it) to the clipboard and paste into the excel file, google sheets etc.
+
+The **Embed snippet** allows you to integrate the table into your HTML document or a web-site:
+
+&lt;iframe src=&quot;https://datahub.io/core/gini-index/r/0.html&quot; width=&quot;100%&quot; height=&quot;300px&quot; frameborder=&quot;0&quot;&gt;&lt;/iframe&gt;
+
+**Note:** preview table contains only 2000 rows of original data to avoid possible browser crash cause of the big data.
+
+### Share views and graphs
+
+The same idea works with graphs - each view for a dataset could be easily shared or embedded into your web-page using the links under the view:
+
+![each view for a dataset could be easily shared or embedded into your web-page using the links](/static/img/docs/share-embed-graphs.png)
+
+and here is the embedded version right here:
+
+&lt;iframe src=&quot;https://datahub.io/core/gini-index/view/0&quot; width=&quot;100%&quot; height=&quot;475px&quot; frameborder=&quot;0&quot;&gt;&lt;/iframe&gt;
+
+## Other small features
+
+- Data push command now shows a progress-bar when uploading files
+- User can add custom titles and axis suffixes to the views
+- TSV files are supported now
+- DataHub [API documentation](https://datahub.io/docs/features/api) has been added.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -461,6 +5390,40 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+We&apos;ve integrated our pipelines system with the website to display more insights to our users. Any dataset you publish on DataHub could be in one of three states: **processing**, **succeeded** or **failed**. Below we explain each state in detail.
+
+## Processing
+
+While your dataset is being processed, you can see a dataset page with information about currently running steps. For instance, it might be creating a JSON version of your tabular data or validating it against a table schema:
+
+![dataset page with information about currently running steps](/static/img/docs/processing-dataset.gif)
+
+## Succeeded
+
+This is just a regular dataset page you have seen before:
+
+![Regular dataset page](/static/img/docs/succeeded-dataset.png)
+
+## Failed
+
+If processing a dataset has failed, you would see a notice about it with a pipeline title that caused the error. You can also expand the error to read the logs and find out the reason for the failure:
+
+![failed processing of dataset](/static/img/docs/failed-dataset.gif)
+
+
+## Different versions of your dataset
+
+Each time you publish your dataset, a revision process is triggered for it. You can consider a revision as a version of your dataset, e.g., if it is the first time you have published a particular dataset, it would have version 1 (and the next revision would increment version by 1 so it&apos;d be 2):
+
+`https://datahub.io/&lt;username&gt;/&lt;dataset&gt;/v/1`
+
+It becomes useful when you&apos;ve re-published your dataset several times and you want to get your data in a specific stage.
+
+:::info
+A version is a natural number (integer larger than 0) and you can access the specific version of a dataset by `/v/{number}`.
+:::
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -472,6 +5435,57 @@
     <author>
       <name>rufuspollock</name>
     </author>
+    <content type="html">
+Users can now use the DataHub to validate their tabular data, for example checking that dates really are dates or that a column of daily revenue is always positive.
+
+Data validation is also integrated as part of the data publishing flow making it easier to debug general errors -- the most common issue we&apos;ve found in our own publishing experience is a typo in a data value that then breaks graphing or other data presentation and processing.
+
+## How to use it
+
+Data Validation now happens automatically for you whenever you push data to the DataHub so to validate data in a file or data package just push it to the DataHub:
+
+```
+# Note: in this case DataHub will auto-infer the types of the columns
+data push myfile.csv
+
+# a data package
+cd my-data-datapackage
+data push
+```
+
+:::info
+You can find more about pushing data to the DataHub [here](http://datahub.io/docs/getting-started/publishing-data).
+:::
+
+You may need to customize the schema for your file -- perhaps DataHub has guessed the types wrong.
+
+## How we validate
+
+We use the Table Schema for your data file along with the powerful [goodtables library](https://github.com/frictionlessdata/goodtables-py) to validate your data and generate a JSON validation report.
+
+This report is then used in your dataset page to show you a human-readable version of the errors (a JSON version is also available).
+
+## Validation reporting on the Showcase Page
+
+Results of the report will be displayed in an easy to understand form. Specifically, if there are errors you will see a detailed report like this:
+
+![Results of the Validation report](/static/img/docs/validation-report-vix-daily.png)
+
+This table displays errors in a validation report. You can see that in the example above we have 3 badges indicating key details (`INVALID` `SCHEMA` `985`) and `Type or Format Error` message. It means 985 values have type or format errors when validating against the schema. Details can be expanded by clicking on &quot;Error details&quot; link on the right. You also can find values causing this error on the table - they have a red background colour. By default, we show first 10 rows but you can open more of them by clicking on &quot;Show next 10 rows&quot; link.
+
+In the screenshot below, you can see how a validation report looks like for &quot;Minimum Constraint&quot; error. Revenue value cannot be negative so we&apos;ve set `constraints` property with a `minimum` attribute as 0 and validation process identified which value is not meeting that requirement:
+
+![validation report revenue](/static/img/docs/validation-report-revenue.png)
+
+Below are properties that you can use in a table schema for validation of your data:
+
+* `constraints` - you may use this property to validate field values, e.g., a column with &quot;Daily Revenue&quot; or &quot;Sales&quot; must be a positive number so you&apos;d have a `minimum` attribute set to 0.
+* `type` is a string indicating the type of this field, e.g., `string` or `number`.
+* `format` is a string indicating a format for the field type, e.g., you can have `email` format for `string` type so it validates if values in the field are emails.
+* other properties such as `missing values` can be used to indicate a special value for empty entries, e.g., `-` or `N/A`.
+
+You can find full table schema specs here https://frictionlessdata.io/specs/table-schema.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -483,6 +5497,32 @@
     <author>
       <name>mikanebu</name>
     </author>
+    <content type="html">
+There are several graphs that illustrate pharmaceutical drug spendings from the list OECD countries. Data is clean and available in several formats such as csv, json, zip.
+
+&gt; Pharmaceutical spending covers expenditure on prescription medicines and self-medication, often referred to as over-the-counter products. In some countries, other medical non-durable goods are also included - [click here to read more](https://data.oecd.org/healthres/pharmaceutical-spending.htm).
+
+
+This chart illustrates total spending by country in 2015:
+
+![This chart illustrates total spending by country in 2015](/static/img/docs/pharma-dataset1.png)
+
+For comparison, you can take a look at spendings per capita in the same year: 
+
+![spendings per capita in the same year](/static/img/docs/pharma-dataset2.png)
+
+As you can see Americans spend the most on drugs compared to the rest of the world, and below you can see a chart that breaks down total spendings in the United States since 2000 and it is growing gradually:
+
+![chart that breaks down total spendings in the United States since 2000 and it is growing gradually](/static/img/docs/pharma-dataset3.png)
+
+
+The table below describes Pharmaceutical Drug Spending dataset by countries with indicators such as a share of total health spending, in USD per capita (using economy-wide Purchasing Power Parity or PPP), as a share of GDP and total spending since 1970.
+
+![table describes Pharmaceutical Drug Spending dataset by countries in USD per capita as a share of GDP and total spending since 1970.](/static/img/docs/pharma-dataset4.png)
+
+
+
+The dataset is live on [DataHub]( https://datahub.io/core/pharmaceutical-drug-spending). Also, you can find other well-formatted, high-quality core datasets in [DataHub](http://datahub.io/search?q=core).</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -494,6 +5534,48 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+Today we are releasing support for **private** datasets on the DataHub. Private datasets are exactly that: private and visible and accessible only to their owners.
+
+This feature is designed to support several use cases. First, simply storing (and sharing) private data. Second, keeping data private prior to publication -- now users have a way to push data, check it and only make it public when they are ready.
+
+The private datasets feature is available on a trial basis to all DataHub users. If you want to use it on an ongoing basis you&apos;ll want to sign up for premium membership:
+
+https://datahub.io/pricing
+
+## How to publish private datasets?
+
+You can use either the command line tool or the &quot;Data&quot; desktop app. Please, visit our download page to find out more about available tools:
+
+https://datahub.io/download
+
+### Publish using the &quot;Data&quot; app
+
+Once you are ready to publish your data, just select &quot;private&quot; option and then press &quot;Go&quot; button:
+
+![just select &quot;private&quot; option and then press &quot;Go&quot; button](/static/img/docs/push-private.png)
+
+:::info
+Learn more about using the &quot;Data&quot; app [here](http://datahub.io/blog/data-desktop-app-alpha-release).
+:::
+
+### Publish using the command line tool
+
+Simply pass `--private` flag when you &quot;push&quot; your data so once it is processed and online only you can view it:
+
+```
+$ data push myData --private
+```
+
+:::info
+Learn more about how to publish datasets using the CLI [here](http://datahub.io/docs/getting-started/publishing-data).
+:::
+
+
+## Making a Private Dataset Public
+
+Just publish the dataset again but set the findability to public.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -505,6 +5587,41 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+We are pleased to announce the launch of our new desktop application for DataHub users. The app brings drag and drop publishing of data. In addition, users can preview and validate their data prior to upload. Currently the app is in alpha and only available for MacOS -- but we plan Linux and Windows soon! Get the app now from:
+
+https://datahub.io/download
+
+## Drag and drop files
+
+Simply drag and drop any files (e.g. CSV) or Data Packages (datapackage.json) into the tray icon and you will start the publishing process.
+
+![drag and drop any files (e.g. CSV) or Data Packages (datapackage.json) into the tray icon](/static/img/docs/drag-n-drop.gif)
+
+## Preview showcase page and edit properties
+
+First, you&apos;ll get a preview of your dataset. Here you can preview how it would look like online and edit name and title properties for it:
+
+![A preview of your dataset. Here you can preview how it would look like online and edit name and title properties for it.](/static/img/docs/app-showcase.png)
+
+## Table Schema editor and validation info
+
+Scroll down the page and you can see &quot;Field Information&quot; table that contains details from table schema for the data. You can see validity information for each field and edit field type if necessary. Once you have made a change, it will re-validate and update validity message:
+
+![&quot;Field Information&quot; table that contains details from table schema for the data](/static/img/docs/app-field-info.png)
+
+## Publish it!
+
+Ready to publish your data? Just hit the &quot;Go!&quot; button on the top of the page and it will be published at given path on datahub.io website. Once publish process is finished, you will get a notification - click on it to open online showcase page in your default browser:
+
+![publish your data with go button](/static/img/docs/app-publish.png)
+
+## Command line tool is always up-to-date
+
+In addition, to drag and drop publishing the desktop app auto-installs the command line program and will automatically keep it up to date for you:
+
+![to drag and drop publishing the desktop app auto-installs the command line program](/static/img/docs/app-cli-update.png)
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -516,6 +5633,47 @@
     <author>
       <name>mikanebu</name>
     </author>
+    <content type="html">
+This tutorial demonstrates how to use Data Packages from R. We assume that you already know about [Data Packages](https://datahub.io/docs/data-packages) and its [specifications](https://frictionlessdata.io/specs/data-packages/).
+
+## Example
+
+Let&apos;s consider &quot;VIX - CBOE Volatility Index&quot; data here. The VIX dataset is a key measure of market expectations of near-term volatility conveyed by S&amp;P 500 stock index option prices introduced in 1993:
+
+https://datahub.io/core/finance-vix
+
+There are several ways to get data in R, but in this tutorial, we are going to use robust, high performance JSON Parser `jsonlite` library:
+
+```r
+library(&quot;jsonlite&quot;)
+
+json_file &lt;- &apos;https://datahub.io/core/finance-vix/datapackage.json&apos;
+json_data &lt;- fromJSON(paste(readLines(json_file), collapse=&quot;&quot;))
+
+# get list of all resources:
+print(json_data$resources$name)
+```
+
+and you would get following table printed:
+
+![list of all resources](/static/img/docs/r-screenshot-resources.png)
+
+
+Our data is now available in different formats such as CSV, JSON, ZIP. To get it in the CSV format:
+
+```r
+# print all tabular data(if exists any)
+for(i in 1:length(json_data$resources$datahub$type)){
+  if(json_data$resources$datahub$type[i]==&apos;derived/csv&apos;){
+    path_to_file = json_data$resources$path[i]
+    data &lt;- read.csv(url(path_to_file))
+    print(data)
+  }
+}
+```
+
+![all tabular printed data](/static/img/docs/r-screenshot-data.png)
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -527,6 +5685,55 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+Users can now import online data files directly into the DataHub using the `data` command line tool -- and setup scheduled re-imports at the same time.
+
+We&apos;re very excited about this feature as it is the first step in supporting automated scraping and doing this on a regular schedule. This is something we ourselves have long wanted for our [Core Data work][core data] and we&apos;re already using the feature ourselves.
+
+[core data]: https://datahub.io/core
+
+## An example
+
+We&apos;ll use an example of the &quot;Energy consumption by sector&quot; from the US Energy Information Administration. This data is updated on monthly basis so we want it to be re-imported every 30 days (~1 month):
+
+```
+data push https://www.eia.gov/totalenergy/data/browser/csv.php?tbl=T02.01 --schedule=&quot;every 30d&quot; --format=csv
+```
+
+:::info
+By default, when you push datasets to DataHub, they are &quot;unlisted&quot; so only people with the link can see it. If you wish to make your dataset &quot;published&quot;, you need to pass `--published` option: `data push URL --published`.
+:::
+
+Once the process is completed open your browser and check it out! It would generate a URL using your username, which will be copied to clipboard so you can just open a browser and paste it. You should see something similar to this page:
+
+![page generated with your name url](/static/img/docs/scheduled-data.png)
+
+Note: We&apos;ve decided to still use the push command, even though unlike local data you are not &quot;pushing&quot; it but rather importing it. [Read more about the `push` command in our getting started guide][getting-started].
+
+[getting-started]: http://datahub.io/docs/getting-started/publishing-data
+
+### Set up a Schedule
+
+You can  setup a schedule so the DataHub will automatically re-import the remote file on a regular basis. E.g., `every 90s`, `every 5m`, `every 2d` etc. The number is always an integer, selector is `s/m/h/d/w` (second -&gt; week) and you can’t schedule for less than 60 seconds.
+
+In our example above the dataset is updated on monthly basis so we have the schedule that runs every 30 days:
+
+```bash
+--schedule=&quot;every 30d&quot;
+```
+
+This data file will then re-imported monthly.
+
+To read more including full details of the schedule format see our [full docs on importing online data to the DataHub].
+
+### Provide file format explicitly
+
+If the file URL does not contain conventional file name, you need to provide its format explicitly by using `--format` option. See how we did it in our example above:
+
+```bash
+--format=csv
+```
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -538,6 +5745,216 @@
     <author>
       <name>rufuspollock</name>
     </author>
+    <content type="html">
+The &quot;Core Data&quot; project provides essential data for the data wranglers and data science community. Its online home is on the DataHub:
+
+https://datahub.io/core
+
+https://datahub.io/docs/core-data
+
+This post introduces you to the Core Data, presents a couple of examples and shows you how you can access and use core data easily from your own tools and systems including R, Python, Pandas and more.
+
+[[toc]]
+
+## Why Core Data
+
+If you build data driven applications or data driven insight you regularly find yourself wanting common &quot;core&quot; data, things like lists of countries, populations, geographic boundaries and more.
+
+However, finding good quality data has always been challenging. Professionals can spend lots of time finding and preparing data before they get to do any real work analysing or presenting it.
+
+To address this, a few years ago we started the &quot;core data&quot; project as part of the Frictionless Data initiative. Its purpose was to curate important, commonly used datasets including reference data like country codes, indicators like population and GDP, and geodata like country boundaries. It provides them in a high-quality, easy-to-use, and standard form.
+
+Recently the Core Data project has got even better with a new home on the newly upgraded DataHub and has expanded thanks to new partners like Datopian and John Snow Labs (more on this in a future post!).
+
+## Examples
+
+There are dozens of core datasets already available and many more being worked on, including a list of countries and their 2 digit codes, and a more extensive version.
+
+### List of Countries
+
+Ever needed to build a drop-down list of countries in a web application? Or ever needed to add country name labels for a graph and only had country codes?
+
+Then these datasets are for you!
+
+First up is the very simple &quot;country-list&quot; dataset:
+
+https://datahub.io/core/country-list
+
+You can see a preview table for the dataset on the showcase page:
+
+![preview table for the dataset on the showcase page](/static/img/docs/country-list-preview-table.png)
+
+You can download it in either CSV or JSON formats:
+
+![download it in either CSV or JSON formats](/static//docs/country-list-downloads.png)
+
+* CSV: https://datahub.io/core/country-list/r/data.csv
+* JSON: https://datahub.io/core/country-list/r/data.json
+
+### Country Codes
+
+Maybe the simple list of countries is not enough for you. Perhaps you need phone codes for each country, or want to know their currencies?
+
+We&apos;ve got you covered with the more extensive country codes dataset:
+
+https://datahub.io/core/country-codes
+
+All the countries from Country List including number of associated codes - ISO 3166 codes, ITU dialing codes, ISO 4217 currency codes, and many others. This dataset includes **26** different codes and associated information.
+
+You can also preview the data and download in different formats just like it is described for Country List dataset above:
+
+* CSV: https://datahub.io/core/country-codes/r/country-codes.csv
+* JSON: https://datahub.io/core/country-codes/r/country-codes.json
+
+### Population
+
+This is another useful dataset for people: you regularly need population in order to do normalisations and calculate per capita figures as part of a statistical analysis.
+
+This dataset includes population figures for countries, regions (e.g. Asia) and the world. Data comes originally from World Bank and has been converted into standard tabular data package with CSV data and a table schema:
+
+https://datahub.io/core/population
+
+Preview the data on the showcase page:
+
+![Preview the population data on the showcase page](/static/img/docs/population-preview-table.png)
+
+Get the data in CSV or JSON formats just like for any other Core Datasets:
+
+* CSV: https://datahub.io/core/population/r/population.csv
+* JSON: https://datahub.io/core/population/r/population.json
+
+## Use Core Data from your favorite language or tool
+
+We have made Core Data easy-to-use from various programming languages and tools. We will walk through using our Country List example. But you can apply these instructions to any other Core Data in the DataHub.
+
+### CSV and JSON
+
+If you just need to get data, you have a direct link usable from any tool or app e.g. for the country list:
+
+* CSV - https://datahub.io/core/country-list/r/data.csv
+* JSON - https://datahub.io/core/country-list/r/data.json
+
+:::info
+For more read our &quot;Getting Data&quot; tutorial:
+
+https://datahub.io/docs/getting-started/getting-data
+:::
+
+
+### cURL
+
+Following commands help you to get the data using &quot;cURL&quot; tool. Use `-L` flag so &quot;cURL&quot; follows redirects:
+
+```bash
+# Get the data:
+curl -L https://datahub.io/core/country-list/r/data.csv
+
+# datapackage.json provides metadata and a list of all data files
+curl -L https://datahub.io/core/country-list/datapackage.json
+
+# See just the available data files (resources):
+curl -L https://datahub.io/core/country-list/datapackage.json | jq &quot;.resources&quot;
+```
+
+### R
+
+If you are using R here&apos;s how to get the data you want  quickly loaded:
+
+```r
+install.packages(&quot;jsonlite&quot;)
+library(&quot;jsonlite&quot;)
+
+json_file &lt;- &apos;https://datahub.io/core/country-list/datapackage.json&apos;
+json_data &lt;- fromJSON(paste(readLines(json_file), collapse=&quot;&quot;))
+
+# get list of all resources:
+print(json_data$resources$name)
+
+# print all tabular data(if exists any)
+for(i in 1:length(json_data$resources$datahub$type)){
+  if(json_data$resources$datahub$type[i]==&apos;derived/csv&apos;){
+    path_to_file = json_data$resources$path[i]
+    data &lt;- read.csv(url(path_to_file))
+    print(data)
+  }
+}
+```
+
+### Python
+
+Here we take a look at how to get Country List in Python programming language:
+
+For Python, first install the `datapackage` library (all the datasets on DataHub are Data Packages):
+
+```bash
+pip install datapackage
+```
+
+Again, we&apos;ll use the `country-list` dataset:
+
+```python
+from datapackage import Package
+
+package = Package(&apos;https://datahub.io/core/country-list/datapackage.json&apos;)
+
+# get list of all resources:
+resources = package.descriptor[&apos;resources&apos;]
+resourceList = [resources[x][&apos;name&apos;] for x in range(0, len(resources))]
+print(resourceList)
+
+# print all tabular data(if exists any)
+resources = package.resources
+for resource in resources:
+    if resource.tabular:
+        print(resource.read())
+```
+
+### Pandas
+
+In order to work with Data Packages in Pandas you need to install the Frictionless Data data package library and the pandas:
+
+```bash
+pip install datapackage
+pip install pandas
+```
+
+To get the data run following code:
+
+```python
+import datapackage
+import pandas as pd
+
+data_url = &apos;https://datahub.io/core/country-list/datapackage.json&apos;
+
+# to load Data Package into storage
+package = datapackage.Package(data_url)
+
+# to load only tabular data
+resources = package.resources
+for resource in resources:
+    if resource.tabular:
+        data = pd.read_csv(resource.descriptor[&apos;path&apos;])
+        print (data)
+```
+
+### JavaScript and many more
+
+We also have support for JavaScript, SQL, and PHP. See our &quot;Getting Data&quot; tutorial for more:
+
+https://datahub.io/docs/getting-started/getting-data
+
+## Conclusion
+
+This post has shown how you can import datasets in a high quality, standard form quickly and easily.
+
+There are many more datasets to explore than the three we showed you here. You can find a full list here:
+
+https://datahub.io/core
+
+Finally, we would love collaborators to help us curate even more core datasets. If you&apos;re interested you can find out more about the Core Data Curator program here:
+
+https://datahub.io/docs/core-data/curators
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -549,6 +5966,21 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+You can now see publisher and dataset related events. As we are tracking processes happening in our system, users have ability to discover which publishers have been active or datasets are updated frequently.
+
+In the dashboard page, users can monitor their own private activity as well as their datasets&apos; statuses:
+
+![dashboard page, users can monitor their own private activity as well as their datasets&apos; statuses](/static/img/docs/dashboard-events.png)
+
+Publisher page has information about recent operations related to his/her datasets:
+
+![Publisher page has information about recent operations related to his/her datasets](/static/img/docs/publisher-events.png)
+
+If you want to see events for the specific dataset, you can check &quot;events&quot; page for it. Simply concatenate `/events` path for your dataset&apos;s URL - `https://datahub.io/{publisher}/{dataset}/events`. E.g., here is the &quot;events&quot; page for &quot;finance-vix&quot; dataset - https://datahub.io/core/finance-vix/events - it includes the most recent events for the dataset:
+
+![most recent events for the dataset](/static/img/docs/events-page.png)
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -560,6 +5992,13 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+We are now generating compressed versions of datasets so users can download a dataset as a single file. You can find it in the “Data Files” table in the showcase page. For example, you can have a look at [finance-vix dataset][finance-vix]:
+
+![finance-vix dataset](/static/img/docs/data-files.png)
+
+[finance-vix]: /core/finance-vix
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -571,6 +6010,13 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+We are now generating preview versions of large datasets so your web browser does not crash by loading large amount of data. The preview versions consist of first 5k rows of datasets (if a dataset is small enough, we skip generation of a preview version). For instance, take a look at [finance-vix dataset][finance-vix] preview table:
+
+![finance-vix dataset](/static/img/docs/preview-table.png)
+
+[finance-vix]: /core/finance-vix
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -582,6 +6028,14 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+As you know publishers can create various views using Vega visualizations in DataHub (learn more about views [here][views]). We have just upgraded our platform to use Vega specs v3, which means you can use the latest specifications to describe your views! A graph below is created by using Vega and taken from [this example dataset][example]:
+
+![vega graph example](/static/img/docs/vega-graph-example.png)
+
+[views]: /docs/features/views
+[example]: /examples/vega-views-tutorial-lines
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -593,6 +6047,101 @@
     <author>
       <name>anuveyatsu</name>
     </author>
+    <content type="html">
+In this tutorial, we will explain how to push Excel data to the DataHub. When an Excel file is pushed, we can extract data from selected sheets for previewing and downloading in alternative formats. By default, our CLI tool would process only first sheet of the Excel, but publishers can specify any sheets they want.
+
+## Get some Excel data
+
+If you have an Excel file you can use it for this tutorial. Otherwise, we have prepared an example file, which you can simply get by using the CLI tool:
+
+```
+data get https://github.com/datapackage-examples/excel/raw/master/excel.xlsx
+```
+
+which saves the file in the current working directory. You can inspect the contents before pushing:
+
+```
+data cat excel.xlsx
+```
+
+and it would prompt you to select a sheet. Let&apos;s select the first sheet so it will output a table with its content in the standard out:
+
+```cli-output
+| Mean   | Uncertainty |
+| ------ | ----------- |
+| 338.8  | 0.1         |
+| 339.99 | 0.1         |
+| 340.76 | 0.1         |
+
+...
+```
+
+## Push the data
+
+Now we can push the file to the DataHub:
+
+```bash
+data push excel.xlsx
+```
+
+By default, only first sheet is processed. You should get success message like this:
+
+```cli-output
+🙌  your data is published!
+
+🔗  https://datahub.io/{your-username}/{dataset-name} (copied to clipboard)
+```
+
+You can just open your browser and paste the link, which is already copied to your clipboard.
+
+## Your data&apos;s online!
+
+Once your data is online, you will see the following page:
+
+![your online data](/static/img/docs/showcase-excel-1.png)
+
+:::info
+DataHub may still be processing your data. In this case you will see an appropriate message on the page. Just allow it couple of moments and it will be there!
+:::
+
+We have converted the first sheet to CSV. If you take a look at downloads table, there are options to get data in CSV or JSON versions. Also, you still can download your original data:
+
+![download your original data in csv or json](/static/img/docs/showcase-downloads-excel-1.png)
+
+Scrolling down, you can find a preview table of your data:
+
+![preview table of your data](/static/img/docs/showcase-preview-excel-1.png)
+
+## Processing multiple sheets
+
+Sometimes, you need to process multiple sheets from your Excel file or you just need a sheet other than the first one. In such situations, you can use `--sheets` option when pushing your data to DataHub. In our sample data, we have 2 sheets and in the example above we have pushed only the first one. Now, let&apos;s push both of them:
+
+```bash
+data push excel.xlsx --sheets=all
+```
+
+We have used `--sheets=all` option to specify that we want to push &quot;all&quot; sheets. You also can list sheet numbers, e.g., `--sheets=1,2`. If you wanted to push only the second sheet, you would do `--sheets=2`.
+
+**Note:** *sheet number starts from 1.*
+
+Again, you should get a success message with the link to your data:
+
+```cli-output
+🙌  your data is published!
+
+🔗  https://datahub.io/{your-username}/{dataset-name} (copied to clipboard)
+```
+
+By opening the link, you would see the following page:
+
+![By opening the link, you would see the following page](/static/img/docs/showcase-excel-2.png)
+
+We have converted all sheets of the file to CSV so now you can download each of them in CSV or JSON formats:
+
+![converted all sheets of the file to CSV so now you can download each of them in CSV or JSON formats](/static/img/docs/showcase-downloads-excel-2.png)
+
+You also can find preview tables for each sheet by scrolling down the page.
+</content>
     <summary type="html">Read more...</summary>
   </entry>
   <entry>
@@ -604,6 +6153,319 @@
     <author>
       <name>mikanebu</name>
     </author>
+    <content type="html">
+This post walks you through the major changes in the Data Package v1 specs compared to pre-v1. It covers changes in the full suite of Data Package specifications including Data Resources and Table Schema. It is particularly valuable if:
+
+* you were using Data Packages pre v1 and want to know how to upgrade your datasets
+* if you are implementing Data Package related tooling and want to know how to upgrade your tools or want to support or auto-upgrade pre-v1 Data Packages for backwards compatibility
+
+It also includes a script we have created (in JavaScript) that we&apos;ve been using ourselves to automate upgrades of the [Core Data][core-data].
+
+## The Changes
+
+Two major changes in v1 were presentational:
+
+* Creating Data Resource as a separate spec from Data Package. This did not change anything substantive in terms of how data packages worked but is important presentationally. In parallel, we also split out a Tabular Data Resource from the Tabular Data Package.
+* Renaming JSON Table Schema to just Table Schema
+
+In addition, there were a fair number of substantive changes. We summarize these in the sections below. For more detailed info see the [current specifications][specs] and [the old site containing the pre spec v1 specifications][prev1].
+
+### Table Schema
+
+Link to spec: https://specs.frictionlessdata.io/table-schema/
+
+&lt;table class=&quot;table table-striped table-bordered&quot;&gt;
+&lt;thead&gt;
+&lt;th&gt;Property&lt;/th&gt;
+&lt;th&gt;Pre v1&lt;/th&gt;
+&lt;th&gt;v1 Spec&lt;/th&gt;
+&lt;th&gt;Notes&lt;/th&gt;
+&lt;th&gt;Issue&lt;/th&gt;
+&lt;/thead&gt;
+&lt;tbody&gt;
+&lt;tr&gt;
+&lt;td&gt;id/name&lt;/td&gt;
+&lt;td&gt;id&lt;/td&gt;
+&lt;td&gt;name&lt;/td&gt;
+&lt;td&gt;Renamed id to name to be consistent across specs&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;type/number&lt;/td&gt;
+&lt;td&gt;format: currency&lt;/td&gt;
+&lt;td&gt;format: currency - removed
+format: bareNumber
+format: decimalChar and groupChar&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/509&quot;&gt;#509&lt;/a&gt; &lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/246&quot;&gt;#246&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;type/integer&lt;/td&gt;
+&lt;td&gt;No additional properties&lt;/td&gt;
+&lt;td&gt;Additional properties: bareNumber&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/509&quot;&gt;#509&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;type/boolean&lt;/td&gt;
+&lt;td&gt;true: [yes, y, true, t, 1],false: [no, n, false, f, 0]&lt;/td&gt;
+&lt;td&gt;true: [ true, True, TRUE, 1],false: [false, False, FALSE, 0]&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/415&quot;&gt;#415&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;type/year + yearmonth&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;year and yearmonth NB: these were temporarily gyear and gyearmonth&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/346&quot;&gt;#346&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;type/duration&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;duration&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/210&quot;&gt;#210&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;type/rdfType&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;rdfType&lt;/td&gt;
+&lt;td&gt;Support rich &quot;semantic web&quot; types for fields&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/217&quot;&gt;#217&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;type/null&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;removed (see missingValue)&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/262&quot;&gt;#262&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;missingValues&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;missingValues&lt;/td&gt;
+&lt;td&gt;Missing values support did not exist pre v1.&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/97&quot;&gt;#97&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;/tbody&gt;
+&lt;/table&gt;
+
+
+### Data Resource
+
+Link to spec: https://specs.frictionlessdata.io/data-resource/
+
+*Note: Data Resource did not exist as a separate spec pre-v1 so strictly we are comparing the Data Resource section of the old Data Package spec with the new Data Resource spec.*
+
+&lt;table class=&quot;table table-striped table-bordered&quot;&gt;
+&lt;thead&gt;
+&lt;th&gt;Property&lt;/th&gt;
+&lt;th&gt;Pre v1&lt;/th&gt;
+&lt;th&gt;v1 Spec&lt;/th&gt;
+&lt;th&gt;Notes&lt;/th&gt;
+&lt;th&gt;Issue&lt;/th&gt;
+&lt;/thead&gt;
+&lt;tbody&gt;
+&lt;tr&gt;
+&lt;td&gt;path&lt;/td&gt;
+&lt;td&gt;path and url&lt;/td&gt;
+&lt;td&gt;path only&lt;/td&gt;
+&lt;td&gt;url merged into path and path can now be a url or local path&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/250&quot;&gt;#250&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;path&lt;/td&gt;
+&lt;td&gt;string&lt;/td&gt;
+&lt;td&gt;string or array&lt;/td&gt;
+&lt;td&gt;path can be an array to support a single resource split across multiple files&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/228&quot;&gt;#228&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;name&lt;/td&gt;
+&lt;td&gt;recommended&lt;/td&gt;
+&lt;td&gt;required&lt;/td&gt;
+&lt;td&gt;Made name required to enable access to resources by name consistently across tools&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;profile&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;recommended&lt;/td&gt;
+&lt;td&gt;See profiles discussion&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;sources, licenses ...&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;Inherited metadata from Data Package like sources or licenses upgraded inline with changes in Data Package&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;/tbody&gt;
+&lt;/table&gt;
+
+
+### Tabular Data Resource
+
+Link to spec: https://specs.frictionlessdata.io/data-resource/
+
+Just as Data Resource split out from Data Package so Tabular Data Resource split out from the old Tabular Data Package spec.
+
+There were no significant changes here beyond those in Data Resource.
+
+### Data Package
+
+Link to spec: https://specs.frictionlessdata.io/data-package/
+
+&lt;table class=&quot;table table-striped table-bordered&quot;&gt;
+&lt;thead&gt;
+&lt;th&gt;Property&lt;/th&gt;
+&lt;th&gt;Pre v1&lt;/th&gt;
+&lt;th&gt;v1 Spec&lt;/th&gt;
+&lt;th&gt;Notes&lt;/th&gt;
+&lt;th&gt;Issue&lt;/th&gt;
+&lt;/thead&gt;
+&lt;tbody&gt;
+&lt;tr&gt;
+&lt;td&gt;name&lt;/td&gt;
+&lt;td&gt;required&lt;/td&gt;
+&lt;td&gt;recommended&lt;/td&gt;
+&lt;td&gt;Unique names are not essential to any part of the present tooling so we have have moved to recommended.&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/237&quot;&gt;#237&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;id&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;id property-globally unique&lt;/td&gt;
+&lt;td&gt;Globally unique id property&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/237&quot;&gt;#237&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;licenses&lt;/td&gt;
+&lt;td&gt;license - object or string. The object structure must contain a type property and a url property linking to the actual text&lt;/td&gt;
+&lt;td&gt;licenses - is an array. Each item in the array is a License. Each must be an object. The object must contain a name property and/or a path property. It may contain a title property.&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;author&lt;/td&gt;
+&lt;td&gt;author&lt;/td&gt;
+&lt;td&gt;author is removed in favour of contributors&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;contributor&lt;/td&gt;
+&lt;td&gt;name, email, web properties with name required&lt;/td&gt;
+&lt;td&gt;title property required with roles, role property values must be one of - author, publisher, maintainer, wrangler, and contributor. Defaults to contributor.&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;sources&lt;/td&gt;
+&lt;td&gt;name, web and email and none required&lt;/td&gt;
+&lt;td&gt;title, path and email and title is required&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;resources&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;resources array is required&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/434&quot;&gt;#434&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;dataDependencies&lt;/td&gt;
+&lt;td&gt;dataDependencies&lt;/td&gt;
+&lt;td&gt;&lt;/td&gt;
+&lt;td&gt;Moved to a pattern until we have greater clarity on need.&lt;/td&gt;
+&lt;td&gt;&lt;a href=&quot;https://github.com/frictionlessdata/specs/issues/341&quot;&gt;#341&lt;/a&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;/tbody&gt;
+&lt;/table&gt;
+
+
+### Tabular Data Package
+
+Link to spec: https://specs.frictionlessdata.io/tabular-data-package/
+
+Tabular Data Package is unchanged.
+
+### Profiles
+
+Profiles arrived in v1:
+
+http://specs.frictionlessdata.io/profiles/
+
+Profiles are the first step on supporting a rich ecosystem of &quot;micro-schemas&quot; for data. They provide a very simple way to quickly state that your data follows a specific structure and/or schema. From the docs:
+
+&gt; Different kinds of data need different formats for their data and metadata. To support these different data and metadata formats we need to extend and specialise the generic Data Package. These specialized types of Data Package (or Data Resource) are termed profiles.
+&gt;
+&gt; For example, there is a Tabular Data Package profile that specializes Data Packages specifically for tabular data. And there is a &quot;Fiscal&quot; Data Package profile designed for government financial data that includes requirements that certain columns are present in the data e.g. Amount or Date and that they contain data of certain types.
+
+We think profiles are an easy, lightweight way to starting adding more structure to your data.
+
+Profiles can be specified on both resources and packages.
+
+[core-data]: https://github.com/datahq/datapackage-normalize-js
+[specs]: https://specs.frictionlessdata.io/
+[prev1]: https://pre-v1.frictionlessdata.io/
+[normalization]: https://github.com/datahq/datapackage-normalize-js
+[ghrepo]: https://github.com/frictionlessdata/specs/
+
+
+
+## Automate upgrading your descriptor according to the spec v1
+
+We have created a [data package normalization script][norm-script] that you can use to automate the process of upgrading a `datapackage.json` or Table Schema from pre-v1 to v1.
+
+The script enables you to automate updating your `datapackage.json` for the following properties: `path`, `contributors`, `resources`, `sources` and `licenses`.
+
+[norm-script]: https://github.com/datahq/datapackage-normalize-js
+
+This is a simple script that you can download directly from here:
+
+https://raw.githubusercontent.com/datahq/datapackage-normalize-js/master/normalize.js
+
+e.g. using wget:
+```bash
+wget https://raw.githubusercontent.com/datahq/datapackage-normalize-js/master/normalize.js
+```
+
+```bash
+# path (optional) is the path to datapackage.json
+# if not provided looks in current directory
+normalize.js [path]
+
+# prints out updated datapackage.json
+```
+
+You can also use as a library:
+
+```bash
+# install it from npm
+npm install datapackage-normalize
+```
+
+so you can use it in your javascript:
+
+```javascript
+const normalize = require(&apos;datapackage-normalize&apos;)
+
+const path = &apos;path/to/datapackage.json&apos;
+normalize(path)
+```
+
+## Conclusion
+
+The above summarizes the main changes for v1 of Data Package suite of specs and instructions on how to upgrade.
+
+If you want to see specification for more details, please visit [Data Package specifications][specs]. You can also visit the [Frictionless Data initiative for more information about Data Packages][fd].
+
+[fd]: http://frictionlessdata.io/
+</content>
     <summary type="html">Read more...</summary>
   </entry>
 </feed>

--- a/site/public/rss.xml
+++ b/site/public/rss.xml
@@ -1,1 +1,5809 @@
-<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title><![CDATA[PortalJS Blog]]></title><description><![CDATA[Latest insights, updates and stories from the PortalJS team]]></description><link>https://portaljs.com</link><generator>RSS for Node</generator><lastBuildDate>Thu, 10 Jul 2025 07:07:22 GMT</lastBuildDate><atom:link href="https://portaljs.com/rss.xml" rel="self" type="application/rss+xml"/><pubDate>Thu, 10 Jul 2025 07:07:22 GMT</pubDate><copyright><![CDATA[Copyright 2025 Datopian]]></copyright><language><![CDATA[en-US]]></language><managingEditor><![CDATA[contact@datopian.com (Datopian)]]></managingEditor><webMaster><![CDATA[contact@datopian.com (Datopian)]]></webMaster><ttl>60</ttl><item><title><![CDATA[The Metadata Standards Landscape: Making Data Discoverable Across Organizations]]></title><description><![CDATA[Navigate the world of metadata standards from Dublin Core to DCAT to Frictionless Data. Learn which standards work best for government, academic, and enterprise data portals, and how to choose the right approach for your organization.]]></description><link>https://portaljs.com/blog/the-metadata-standards-landscape-making-data-discoverable-across-organizations</link><guid isPermaLink="false">https://portaljs.com/blog/the-metadata-standards-landscape-making-data-discoverable-across-organizations</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 08 Jul 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[How Rich Metadata Powers Data Discovery in Modern Data Catalogs]]></title><description><![CDATA[Learn how metadata transforms data discovery at scale—from search engines like Solr and Elasticsearch to standardized schemas that help users find exactly what they need among thousands of datasets.]]></description><link>https://portaljs.com/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs</link><guid isPermaLink="false">https://portaljs.com/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 25 Jun 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Basics of Metadata: How It Helps Understand Your Data]]></title><description><![CDATA[Learn the basics of metadata—from built-in CSV attributes like filename and media type to simple external files—and see how it makes your data discoverable.]]></description><link>https://portaljs.com/blog/basics-of-metadata-how-it-helps-to-understand-your-data</link><guid isPermaLink="false">https://portaljs.com/blog/basics-of-metadata-how-it-helps-to-understand-your-data</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 02 Jun 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Why We Decoupled CKAN’s Frontend — And What We Gained with PortalJS]]></title><description><![CDATA[We explain why we chose to decouple CKAN’s frontend and how PortalJS made our data portal faster, more flexible, and easier to maintain. A practical look at SSG, serverless scaling, and modern dev workflows with CKAN.]]></description><link>https://portaljs.com/blog/why-we-decoupled-CKAN-frontend</link><guid isPermaLink="false">https://portaljs.com/blog/why-we-decoupled-CKAN-frontend</guid><dc:creator><![CDATA[popovayoana]]></dc:creator><pubDate>Wed, 28 May 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Why NASA — and Anyone Using CKAN — Should Consider a Decoupled Front-End with PortalJS]]></title><description><![CDATA[NASA’s open data portal is powered by CKAN—but what if its user experience could match its scientific depth? This post explores how a decoupled frontend using PortalJS can transform performance, design flexibility, and scalability—without changing the backend. Learn how CKAN and PortalJS can work together to deliver a faster, smarter, and more user-friendly data experience.]]></description><link>https://portaljs.com/blog/why-NASA-and-anyone-using-CKAN-should-consider-a-decoupled-front-end-with-PortalJS</link><guid isPermaLink="false">https://portaljs.com/blog/why-NASA-and-anyone-using-CKAN-should-consider-a-decoupled-front-end-with-PortalJS</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 19 May 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[The New Look of PortalJS Cloud]]></title><description><![CDATA[Discover how the redesigned PortalJS Cloud helps you launch a modern, WCAG 2.1/2.2-compliant open data portal—fully responsive, customizable, and optimized for lightning-fast search and data sharing. Built for governments, non-profits, academic institutions, and private organizations, it's the easiest way to deploy a user-friendly data platform in minutes.]]></description><link>https://portaljs.com/blog/the-new-look-of-portaljs-cloud</link><guid isPermaLink="false">https://portaljs.com/blog/the-new-look-of-portaljs-cloud</guid><dc:creator><![CDATA[williamlima]]></dc:creator><pubDate>Tue, 01 Apr 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to Reduce Data Portal Costs by 90% or More]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/how-to-reduce-data-portal-costs-by-90-percent</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-reduce-data-portal-costs-by-90-percent</guid><dc:creator><![CDATA[Yoana Popova]]></dc:creator><pubDate>Fri, 14 Mar 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Enhancing CKAN Resource Uploads via API with Cloudflare R2, Workers, and Queues.]]></title><description><![CDATA[Integrating Cloudflare R2 with CKAN revolutionizes resource uploads by enabling direct API-based file storage. Using pre-signed URLs, event-driven processing, and automated metadata updates via Workers and Queues, this approach streamlines uploads, enhances data consistency, and eliminates manual intervention.]]></description><link>https://portaljs.com/blog/ckan-resource-uploads-via-api</link><guid isPermaLink="false">https://portaljs.com/blog/ckan-resource-uploads-via-api</guid><dc:creator><![CDATA[shreyas]]></dc:creator><pubDate>Wed, 26 Feb 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Effortless User Management in PortalJS]]></title><description><![CDATA[The latest PortalJS user management update makes this process more intuitive.]]></description><link>https://portaljs.com/blog/effortless-user-management-portaljs</link><guid isPermaLink="false">https://portaljs.com/blog/effortless-user-management-portaljs</guid><dc:creator><![CDATA[popovayoana]]></dc:creator><pubDate>Tue, 28 Jan 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Making PortalJS Cloud Admin Panel Accessible: The Digital Ramp Everyone Deserves]]></title><description><![CDATA[Learn how PortalJS Cloud’s commitment to accessibility enhances the user experience for everyone.]]></description><link>https://portaljs.com/blog/making-portalJS-cloud-admin-panel-accessible</link><guid isPermaLink="false">https://portaljs.com/blog/making-portalJS-cloud-admin-panel-accessible</guid><dc:creator><![CDATA[popovayoana]]></dc:creator><pubDate>Sun, 26 Jan 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Why PortalJS is the Future of Decoupled Frontend for Data Portals]]></title><description><![CDATA[Let’s take a look at how PortalJS based decoupled frontend can improve your data portal, its performance, user experience and more.]]></description><link>https://portaljs.com/blog/why-portaljs-is-the-future-of-decoupled-frontend-for-data-portals</link><guid isPermaLink="false">https://portaljs.com/blog/why-portaljs-is-the-future-of-decoupled-frontend-for-data-portals</guid><dc:creator><![CDATA[Anuar Ustayev]]></dc:creator><pubDate>Fri, 06 Dec 2024 00:00:00 GMT</pubDate></item><item><title><![CDATA[The OpenSpending Revamp: Behind the Scenes]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/the-open-spending-revamp-behind-the-scenes</link><guid isPermaLink="false">https://portaljs.com/blog/the-open-spending-revamp-behind-the-scenes</guid><dc:creator><![CDATA[Luccas Mateus]]></dc:creator><pubDate>Fri, 13 Oct 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Announcing MarkdownDB: an open source tool to create an SQL API to your markdown files! 🚀]]></title><description><![CDATA[MarkdownDB - an open source library to transform markdown content into sql-queryable data. Build rich markdown-powered sites easily and reliably. New dedicated website at markdowndb.com]]></description><link>https://portaljs.com/blog/markdowndb-launch</link><guid isPermaLink="false">https://portaljs.com/blog/markdowndb-launch</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Wed, 11 Oct 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[What We Shipped in Jul-Aug 2023]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/summer-updates-2023</link><guid isPermaLink="false">https://portaljs.com/blog/summer-updates-2023</guid><dc:creator><![CDATA[ola-rubaj]]></dc:creator><pubDate>Fri, 01 Sep 2023 18:00:00 GMT</pubDate></item><item><title><![CDATA[Adding Maps to PortalJS: Enhancing Geospatial Data Visualization with PortalJS]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/enhancing-geospatial-data-visualization-with-portaljs</link><guid isPermaLink="false">https://portaljs.com/blog/enhancing-geospatial-data-visualization-with-portaljs</guid><dc:creator><![CDATA[João Demenech]]></dc:creator><pubDate>Tue, 18 Jul 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Tutorial 2: Edit your Flowershow website locally on your computer]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/edit-a-website-locally</link><guid isPermaLink="false">https://portaljs.com/blog/edit-a-website-locally</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Thu, 22 Jun 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Tutorial 1: Create a website from scratch using Markdown and Flowershow]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/create-a-website-from-scratch</link><guid isPermaLink="false">https://portaljs.com/blog/create-a-website-from-scratch</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Tue, 20 Jun 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Create a catalog of anything using Markdown files in Obsidian]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/create-a-simple-catalog-of-anything-using-markdown</link><guid isPermaLink="false">https://portaljs.com/blog/create-a-simple-catalog-of-anything-using-markdown</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Tue, 30 May 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Learn how to use MarkdownDB with our First Tutorial!]]></title><description><![CDATA[We've just released our first tutorial that covers the fundamentals of MarkdownDB - our new package for treating markdown files as a database. If you've been curious about how to manage your markdown files more effectively, check it out!]]></description><link>https://portaljs.com/blog/markdowndb-basics-tutorial-2023</link><guid isPermaLink="false">https://portaljs.com/blog/markdowndb-basics-tutorial-2023</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Fri, 26 May 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Generate an interactive webpage from CSV data and markdown]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/generate-an-interactive-webpage-from-csv-data-and-markdown</link><guid isPermaLink="false">https://portaljs.com/blog/generate-an-interactive-webpage-from-csv-data-and-markdown</guid><dc:creator><![CDATA[Rising Odegua]]></dc:creator><pubDate>Mon, 14 Mar 2022 00:00:00 GMT</pubDate></item><item><title><![CDATA[A Short Case Study Involving Table Schema Frictionless Specs at the European Union]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/frictionless-specs-european-commission</link><guid isPermaLink="false">https://portaljs.com/blog/frictionless-specs-european-commission</guid><dc:creator><![CDATA[sebastien.lavoie]]></dc:creator><pubDate>Tue, 22 Jun 2021 00:00:00 GMT</pubDate></item><item><title><![CDATA[Setup Guide: How to create a full-featured custom data portal frontend for CKAN with PortalJS]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/example-ckan-2021</link><guid isPermaLink="false">https://portaljs.com/blog/example-ckan-2021</guid><dc:creator><![CDATA[Luccas Mateus]]></dc:creator><pubDate>Tue, 20 Apr 2021 00:00:00 GMT</pubDate></item><item><title><![CDATA[COVID-19 and Compartmental Models in Epidemiology]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/covid19-and-compartmental-models-in-epidemiology</link><guid isPermaLink="false">https://portaljs.com/blog/covid19-and-compartmental-models-in-epidemiology</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Fri, 08 May 2020 00:00:00 GMT</pubDate></item><item><title><![CDATA[Open Data Day 2020 and COVID-19 data]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/open-data-day-covid-19</link><guid isPermaLink="false">https://portaljs.com/blog/open-data-day-covid-19</guid><dc:creator><![CDATA[michael.polidori]]></dc:creator><pubDate>Tue, 17 Mar 2020 00:00:00 GMT</pubDate></item><item><title><![CDATA[Comparotron: A simple way to visualize and share comparisons]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/comparotron-a-simple-way-to-visualize-and-share-comparisons</link><guid isPermaLink="false">https://portaljs.com/blog/comparotron-a-simple-way-to-visualize-and-share-comparisons</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Sun, 08 Mar 2020 00:00:00 GMT</pubDate></item><item><title><![CDATA[New Machine Learning Datasets]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/new-machine-learning-datasets</link><guid isPermaLink="false">https://portaljs.com/blog/new-machine-learning-datasets</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Mon, 10 Sep 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Automatically updated core datasets on DataHub]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/automatically-updated-core-datasets-on-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/automatically-updated-core-datasets-on-datahub</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 05 Sep 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Sports data on DataHub]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/sports-data-on-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/sports-data-on-datahub</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Fri, 31 Aug 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Attribute Relation File Format (ARFF)]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/attribute-relation-file-format-arff</link><guid isPermaLink="false">https://portaljs.com/blog/attribute-relation-file-format-arff</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Thu, 23 Aug 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to use multiple DataHub accounts]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/how-to-use-multiple-datahub-accounts</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-use-multiple-datahub-accounts</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 18 Jul 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[World Bank Indicators on DataHub]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/world-bank-indicators-on-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/world-bank-indicators-on-datahub</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Mon, 16 Jul 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Automated KPIs collection and visualization of the funnels]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/automated-kpis-collection-and-visualization-of-the-funnels</link><guid isPermaLink="false">https://portaljs.com/blog/automated-kpis-collection-and-visualization-of-the-funnels</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Tue, 10 Jul 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Revamped awesome collections: data sets that are grouped by subject]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/revamped-awesome-collections-data-sets-that-are-grouped-by-subject</link><guid isPermaLink="false">https://portaljs.com/blog/revamped-awesome-collections-data-sets-that-are-grouped-by-subject</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 11 Jun 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Machine learning datasets]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/machine-learning-datasets</link><guid isPermaLink="false">https://portaljs.com/blog/machine-learning-datasets</guid><dc:creator><![CDATA[svetozarstojkovic]]></dc:creator><pubDate>Fri, 25 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Auto-publish your datasets using Travis-CI]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/auto-publish-your-datasets-using-travis-ci</link><guid isPermaLink="false">https://portaljs.com/blog/auto-publish-your-datasets-using-travis-ci</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 23 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[JavaScript SDK for data deployment]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/javascript-sdk-for-data-deployment</link><guid isPermaLink="false">https://portaljs.com/blog/javascript-sdk-for-data-deployment</guid><dc:creator><![CDATA[acckiygerman]]></dc:creator><pubDate>Tue, 15 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to initialize a data package using data tool]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/how-to-initialize-a-data-package-using-data-tool</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-initialize-a-data-package-using-data-tool</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 14 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Validate your Data Package descriptor online]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/online-validation-tool</link><guid isPermaLink="false">https://portaljs.com/blog/online-validation-tool</guid><dc:creator><![CDATA[acckiygerman]]></dc:creator><pubDate>Thu, 19 Apr 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Q1 2018 Review]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/q1-2018-review</link><guid isPermaLink="false">https://portaljs.com/blog/q1-2018-review</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 11 Apr 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[New Features and Improvements]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/new-features-and-improvements</link><guid isPermaLink="false">https://portaljs.com/blog/new-features-and-improvements</guid><dc:creator><![CDATA[acckiygerman]]></dc:creator><pubDate>Mon, 26 Mar 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Improved Reporting and Debugging of Data Publishing]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/improved-reporting-and-debugging-of-data-publishing</link><guid isPermaLink="false">https://portaljs.com/blog/improved-reporting-and-debugging-of-data-publishing</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 29 Jan 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Data Validation in the DataHub]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/data-validation-in-the-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/data-validation-in-the-datahub</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Wed, 24 Jan 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Which country spends the most on pharmaceutical drugs?]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/pharmaceutical-drug-spending</link><guid isPermaLink="false">https://portaljs.com/blog/pharmaceutical-drug-spending</guid><dc:creator><![CDATA[mikanebu]]></dc:creator><pubDate>Tue, 23 Jan 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Introducing private datasets on the DataHub]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/introducing-private-datasets-on-the-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/introducing-private-datasets-on-the-datahub</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 13 Dec 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Data desktop app - alpha release with drag and drop data publishing support]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/data-desktop-app-alpha-release</link><guid isPermaLink="false">https://portaljs.com/blog/data-desktop-app-alpha-release</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Fri, 01 Dec 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to use Data Packages from R]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/how-to-use-data-packages-from-r</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-use-data-packages-from-r</guid><dc:creator><![CDATA[mikanebu]]></dc:creator><pubDate>Thu, 16 Nov 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Import online data files directly with scheduling]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/import-online-data-files-directly-with-scheduling</link><guid isPermaLink="false">https://portaljs.com/blog/import-online-data-files-directly-with-scheduling</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 14 Nov 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Core Data: Essential Datasets for Data Wranglers and Data Scientists]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/core-data-essential-datasets-for-data-wranglers-and-data-scientists</link><guid isPermaLink="false">https://portaljs.com/blog/core-data-essential-datasets-for-data-wranglers-and-data-scientists</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Fri, 03 Nov 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[See events and activity related to datasets or publishers]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/see-events-and-activity-related-to-datasets-or-publishers</link><guid isPermaLink="false">https://portaljs.com/blog/see-events-and-activity-related-to-datasets-or-publishers</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 31 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Datasets in zip format]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/datasets-in-zip-format</link><guid isPermaLink="false">https://portaljs.com/blog/datasets-in-zip-format</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Thu, 19 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Previews for large datasets]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/previews-for-large-datasets</link><guid isPermaLink="false">https://portaljs.com/blog/previews-for-large-datasets</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 18 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Vega views upgrade - now using v3]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/vega-upgrade-spec-v3</link><guid isPermaLink="false">https://portaljs.com/blog/vega-upgrade-spec-v3</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 17 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Excel Files on the DataHub: Automated Previews and Data Extraction]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/excel-files-on-the-datahub-automated-previews-and-data-extraction</link><guid isPermaLink="false">https://portaljs.com/blog/excel-files-on-the-datahub-automated-previews-and-data-extraction</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 16 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Data Package v1 Specifications. What has Changed and how to Upgrade]]></title><description><![CDATA[Read more...]]></description><link>https://portaljs.com/blog/upgrade-to-data-package-specs-v1</link><guid isPermaLink="false">https://portaljs.com/blog/upgrade-to-data-package-specs-v1</guid><dc:creator><![CDATA[mikanebu]]></dc:creator><pubDate>Wed, 11 Oct 2017 00:00:00 GMT</pubDate></item></channel></rss>
+<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title><![CDATA[PortalJS Blog]]></title><description><![CDATA[Latest insights, updates and stories from the PortalJS team]]></description><link>https://portaljs.com</link><generator>RSS for Node</generator><lastBuildDate>Thu, 10 Jul 2025 09:00:46 GMT</lastBuildDate><atom:link href="https://portaljs.com/rss.xml" rel="self" type="application/rss+xml"/><pubDate>Thu, 10 Jul 2025 09:00:46 GMT</pubDate><copyright><![CDATA[Copyright 2025 Datopian]]></copyright><language><![CDATA[en-US]]></language><managingEditor><![CDATA[contact@datopian.com (Datopian)]]></managingEditor><webMaster><![CDATA[contact@datopian.com (Datopian)]]></webMaster><ttl>60</ttl><item><title><![CDATA[The Metadata Standards Landscape: Making Data Discoverable Across Organizations]]></title><description><![CDATA[
+## Introduction
+
+In our [previous exploration of metadata and data discovery](/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs), we saw how rich metadata transforms search and discovery in data catalogs. But here's the challenge: rich metadata without standards creates chaos. When every organization describes data differently, you get the digital equivalent of Tower of Babel—lots of information, zero interoperability.
+
+Consider this scenario: A data portal contains datasets from various departments within a government agency. Without metadata standards, the transportation department describes their datasets using fields like "author," "created_date," and "topic." The health department uses "publisher," "last_modified," and "subject_area." The education department uses "creator," "updated," and "category." All contain the same core information, but without standardized metadata fields, users can't consistently search, filter, or understand what's available across the portal.
+
+This is where metadata standards come in—providing the consistent structure that makes data discoverable and manageable within your portal, while also enabling interoperability across the broader data ecosystem.
+
+## The Major Players: Core Metadata Standards
+
+The metadata standards landscape might seem overwhelming at first, but it's built around a few foundational standards that work together rather than compete. Let's explore the key players and how they complement each other.
+
+### Dublin Core: The Universal Foundation
+
+Dublin Core is the veteran of metadata standards with its 15 basic elements that can describe virtually any resource. Published as ISO Standard 15836, it's domain-agnostic and internationally recognized.
+
+**The 15 Core Elements:**
+
+```yaml
+# Dublin Core basics
+title: "NYC 311 Service Requests - 2023 Q1"
+creator: "NYC Department of Information Technology"
+subject: "citizen services, municipal data, complaints"
+description: "Citizen complaints and service requests from NYC's 311 system"
+publisher: "NYC Open Data"
+contributor: "NYC 311 Contact Center"
+date: "2023-04-01"
+type: "Dataset"
+format: "CSV"
+identifier: "https://data.cityofnewyork.us/311-2023-q1"
+source: "NYC 311 System"
+language: "en"
+relation: "Part of NYC Open Data Portal"
+coverage: "New York City, 2023 Q1"
+rights: "Public Domain"
+```
+
+**Why Dublin Core Works:**
+
+- **Universal applicability** - Works for datasets, documents, images, anything
+- **Low barrier to entry** - Easy to understand and implement
+- **Foundation for other standards** - DCAT, MODS, and others build on Dublin Core
+- **Proven longevity** - 25+ years of development and refinement
+
+### DCAT: Purpose-Built for Data Catalogs
+
+Data Catalog Vocabulary (DCAT) is Dublin Core's specialized cousin, designed specifically for describing datasets in data catalogs. As a W3C Recommendation, it's the gold standard for data portal interoperability.
+
+**DCAT's Key Additions:**
+
+```yaml
+# DCAT builds on Dublin Core with data-specific concepts
+dataset:
+  title: "NYC 311 Service Requests - 2023 Q1"
+  description: "Citizen complaints and service requests..."
+  publisher: "NYC Department of Information Technology"
+  theme: "Government, Public Services"
+  keyword: ["311", "citizen services", "complaints"]
+  landingPage: "https://data.cityofnewyork.us/311-2023-q1"
+
+  # Data-specific metadata Dublin Core lacks
+  distribution:
+    - downloadURL: "https://data.cityofnewyork.us/311-2023-q1.csv"
+      mediaType: "text/csv"
+      format: "CSV"
+    - downloadURL: "https://data.cityofnewyork.us/311-2023-q1.json"
+      mediaType: "application/json"
+      format: "JSON"
+
+  temporal: "2023-01-01/2023-03-31"
+  spatial: "New York City, NY, USA"
+  accrualPeriodicity: "quarterly"
+  contactPoint:
+    fn: "NYC Open Data Team"
+    hasEmail: "opendata@cityhall.nyc.gov"
+```
+
+**DCAT's Power:**
+
+- **Federated search** - Multiple catalogs can be searched as one
+- **Automated harvesting** - Systems can automatically collect metadata from DCAT-compliant catalogs
+- **Distribution management** - Tracks multiple formats (CSV, JSON, API) of the same dataset
+- **Data catalog-specific concepts** - Update frequency, spatial/temporal coverage, data quality
+
+### Schema.org Dataset: Web-Native Discovery
+
+Schema.org Dataset brings metadata into the web era, designed specifically for search engine optimization and web-based discovery.
+
+**Schema.org in Practice:**
+
+```html
+<!-- Embedded in webpage HTML for search engines -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "NYC 311 Service Requests - 2023 Q1",
+  "description": "Citizen complaints and service requests from NYC's 311 system during January-March 2023",
+  "url": "https://data.cityofnewyork.us/311-2023-q1",
+  "creator": {
+    "@type": "Organization",
+    "name": "NYC Department of Information Technology"
+  },
+  "temporalCoverage": "2023-01-01/2023-03-31",
+  "spatialCoverage": "New York City, NY, USA",
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "CSV",
+      "contentUrl": "https://data.cityofnewyork.us/311-2023-q1.csv"
+    }
+  ]
+}
+</script>
+```
+
+**Schema.org's Advantage:**
+
+- **Google Dataset Search** - Direct integration with Google's dataset discovery platform – https://datasetsearch.research.google.com/
+- **SEO benefits** - Search engines understand and rank your data
+- **Web-standard JSON-LD** - Fits naturally into web development workflows
+- **Rich snippets** - Enhanced search results with download links and previews
+
+## Standards in Practice: Who Uses What
+
+Different sectors have gravitated toward different standards based on their specific needs, organizational culture, and regulatory requirements.
+
+### Government Sector: Transparency and Interoperability
+
+Government data portals prioritize standardization and cross-agency interoperability, leading to strong adoption of DCAT-based approaches.
+
+**United States Federal Government:**
+
+The Project Open Data Metadata Schema, mandated for federal agencies, builds directly on DCAT:
+
+```yaml
+# Project Open Data Schema (DCAT-based)
+title: "Federal Student Aid Recipients by State"
+description: "Annual data on federal student aid recipients and amounts by state and program type"
+keyword: ["education", "financial aid", "students", "federal programs"]
+modified: "2023-09-15"
+publisher: "Department of Education"
+contactPoint:
+  fn: "Federal Student Aid Data Team"
+  hasEmail: "data@ed.gov"
+mbox: "data@ed.gov"
+identifier: "ED-FSA-2023-001"
+accessLevel: "public"
+bureauCode: ["018:00"]
+programCode: ["018:001"]
+license: "https://creativecommons.org/publicdomain/zero/1.0/"
+spatial: "United States"
+temporal: "2022-07-01/2023-06-30"
+```
+
+**European Union:**
+
+DCAT-AP (DCAT Application Profile) extends DCAT with European-specific requirements:
+
+```yaml
+# DCAT-AP adds EU-specific fields
+dataset:
+  # Standard DCAT fields
+  title: "EU Carbon Emissions by Sector"
+  description: "Annual greenhouse gas emissions data by economic sector across EU member states"
+
+  # DCAT-AP extensions
+  conformsTo: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32019R2152"
+  page: "https://ec.europa.eu/eurostat/carbon-data"
+  versionInfo: "2.1"
+  hasVersion: "https://data.europa.eu/carbon-emissions-v2.1"
+  language: ["en", "fr", "de"]
+  provenance: "Collected from national statistical offices via standardized reporting"
+```
+
+**Benefits for Government:**
+
+- **Cross-agency compatibility** - Datasets from different agencies can be easily combined
+- **Automated compliance checking** - Tools can validate metadata completeness
+- **Public transparency** - Citizens can find and understand government data
+- **International data sharing** - Compatible metadata enables collaboration between countries
+
+### Academic and Research: Preservation and Scholarly Discovery
+
+Academic institutions balance standardization with discipline-specific needs, often layering specialized standards on Dublin Core foundations.
+
+**Research Data Repositories:**
+
+```yaml
+# Dublin Core + research-specific extensions
+title: "Longitudinal Study of Urban Heat Islands - Chicago 2015-2023"
+creator: ["Dr. Sarah Chen", "Dr. Michael Rodriguez", "Climate Research Lab"]
+subject: "climatology, urban planning, environmental science"
+description: "Temperature measurements from 150 sensors across Chicago measuring urban heat island effects over 8 years"
+publisher: "University Research Data Repository"
+date: "2023-08-15"
+type: "Dataset"
+format: ["CSV", "NetCDF"]
+
+# Research-specific additions
+fundingAgency: "National Science Foundation"
+grantNumber: "NSF-GEO-1847392"
+methodology: "Fixed sensor networks with 15-minute measurement intervals"
+relatedPublication: "doi:10.1038/climate.2023.456"
+ethicsApproval: "IRB-2015-378"
+dataCollectionPeriod: "2015-06-01/2023-05-31"
+spatialResolution: "100m grid"
+temporalResolution: "15 minutes"
+```
+
+**Social Science Data (DDI Standard):**
+The Data Documentation Initiative provides rich metadata for survey and social science data:
+
+```yaml
+# DDI (Data Documentation Initiative) for social science
+study:
+  citation:
+    title: "American Community Survey 2023"
+    creator: "U.S. Census Bureau"
+    producer: "U.S. Census Bureau"
+    distributionDate: "2024-03-15"
+
+  dataCollection:
+    methodology: "Probability sample survey"
+    samplingProcedure: "Stratified systematic sampling"
+    collectionMode: "Mail, telephone, and in-person interviews"
+    responseRate: 97.2
+
+  variableGroups:
+    demographics:
+      variables: ["age", "gender", "race", "ethnicity"]
+    economic:
+      variables: ["income", "employment_status", "occupation"]
+    housing:
+      variables: ["housing_type", "tenure", "housing_costs"]
+```
+
+**Academic Priorities:**
+
+- **Long-term preservation** - Metadata must support data archiving for decades
+- **Citation tracking** - Clear links between datasets and publications
+- **Methodology documentation** - Detailed information about data collection methods
+- **Interdisciplinary discovery** - Subject classifications that work across fields
+
+### Nonprofits: Balancing Standards and Resources
+
+Nonprofit organizations often follow government standards for compatibility while adapting to resource constraints and mission-specific needs.
+
+```yaml
+# Nonprofit metadata - simplified DCAT approach
+title: "Global Health Initiative: Vaccination Rates 2020-2023"
+description: "Country-level vaccination coverage data collected through partnerships with WHO and national health ministries"
+publisher: "Global Health Alliance"
+theme: "Health, International Development"
+keyword: ["vaccination", "global health", "immunization", "public health"]
+license: "CC-BY-4.0"
+contactPoint:
+  fn: "Data Team"
+  hasEmail: "data@globalhealthalliance.org"
+
+# Mission-specific fields
+programArea: "Vaccine Equity Initiative"
+partnerOrganizations: ["WHO", "UNICEF", "Gavi Alliance"]
+impactMetrics:
+  - "Lives saved through improved vaccination access"
+  - "Healthcare systems strengthened"
+fundingSource: "Private foundation grants"
+dataUseAgreement: "Must acknowledge source and share derivative works"
+```
+
+## Enterprise vs. Public Portals: Different Needs, Different Standards
+
+The choice of metadata standards often depends on whether your data portal serves internal enterprise needs or public discovery. Each context brings distinct requirements and constraints.
+
+### Public Data Portals: Standardization First
+
+Public-facing data portals prioritize interoperability and discoverability, leading to strict adherence to established standards.
+
+**Characteristics of Public Portal Metadata:**
+
+- **Strict DCAT compliance** - Enables cross-portal search and data harvesting
+- **Schema.org integration** - Ensures Google and other search engines can index datasets
+- **Quality assurance at scale** - Automated validation of metadata completeness and accuracy
+- **Multi-language support** - Metadata in multiple languages for international accessibility
+
+```yaml
+# Public portal: strict standards compliance
+dataset:
+  # Required DCAT fields - enforced by validation
+  title: "Public Transit Routes and Schedules"
+  description: "Real-time and scheduled route information for city public transportation"
+  publisher: "Metropolitan Transit Authority"
+  issued: "2023-01-15"
+  modified: "2023-06-29"
+
+  # Standardized vocabularies
+  theme: "http://publications.europa.eu/resource/authority/data-theme/TRAN"
+  keyword: ["transportation", "public transit", "GTFS", "real-time"]
+
+  # Interoperability requirements
+  conformsTo: "https://gtfs.org/reference/static"
+  accessRights: "http://publications.europa.eu/resource/authority/access-right/PUBLIC"
+  license: "https://creativecommons.org/licenses/by/4.0/"
+
+  # Multiple format support
+  distribution:
+    - downloadURL: "https://transit.city.gov/gtfs/routes.zip"
+      mediaType: "application/zip"
+      format: "GTFS"
+    - accessURL: "https://api.transit.city.gov/routes"
+      mediaType: "application/json"
+      format: "JSON API"
+```
+
+### Internal Enterprise Portals: Flexibility and Integration
+
+Enterprise data portals start with standards but customize heavily for business needs, integration requirements, and organizational workflows.
+
+**Enterprise Portal Adaptations:**
+
+```yaml
+# Enterprise portal: standards + business context
+dataset:
+  # Standard fields (DCAT-based)
+  title: "Customer Purchase History - Q2 2023"
+  description: "Anonymized customer transaction data for business intelligence and analytics"
+  publisher: "Data Engineering Team"
+
+  # Business-specific extensions
+  businessDomain: "Customer Analytics"
+  dataOwner: "VP Customer Experience"
+  technicalContact: "data-engineering@company.com"
+  businessContact: "customer-analytics@company.com"
+
+  # Governance and compliance
+  dataClassification: "Internal - Confidential"
+  retentionPeriod: "7 years"
+  complianceFramework: ["GDPR", "CCPA", "SOX"]
+  approvalStatus: "Approved for Business Use"
+  lastAuditDate: "2023-06-15"
+
+  # Technical integration
+  sourceSystem: "SAP Customer Management"
+  refreshFrequency: "Daily at 2:00 AM UTC"
+  dataLineage: "Customer DB -> ETL Pipeline -> Data Warehouse -> Analytics View"
+  qualityScore: 94.2
+  slaTarget: "99.5% availability, <4 hour data latency"
+
+  # Access control (enterprise-specific)
+  accessLevel: "Department Level"
+  approvedRoles: ["Customer Analytics Team", "Marketing Analysts", "Product Managers"]
+  dataUseAgreement: "Internal use only, no external sharing without Data Office approval"
+```
+
+### Key Differences in Practice
+
+**1. Governance Requirements**
+
+*Public Portals:*
+
+- Transparency and open access focus
+- Standardized licenses (CC, Public Domain)
+- Public accountability for data quality
+
+*Enterprise Portals:*
+
+- Complex access controls and permissions
+- Business approval workflows
+- Integration with identity management systems
+
+**2. Discovery Mechanisms**
+
+*Public Portals:*
+
+- SEO optimization for web search engines
+- Cross-portal federation and harvesting
+- Social media and link sharing
+
+*Enterprise Portals:*
+
+- Integration with business intelligence tools
+- Internal search and recommendation systems
+- Context-aware suggestions based on user role
+
+**3. Quality and Validation**
+
+*Public Portals:*
+
+- Automated quality checks against standards
+- Public feedback and error reporting
+- Reputation and trust metrics
+
+*Enterprise Portals:*
+
+- Business rule validation
+- Integration with data quality tools
+- SLA monitoring and alerting
+
+## Frictionless Data: Datopian's Approach to Simplicity
+
+While standards like DCAT and Dublin Core provide excellent frameworks, implementing them in real-world systems often becomes complex. This is where Frictionless Data shines—offering a pragmatic approach that bridges the gap between standards and practical implementation.
+
+### The Philosophy: Progressive and Practical
+
+Frictionless Data, developed through a joint stewardship between the Open Knowledge Foundation and Datopian, embodies a "progressive, incrementally adoptable" philosophy. Rather than forcing organizations to adopt complex standards all at once, it provides a pathway to better metadata that grows with your needs.
+
+**Core Design Principles:**
+
+- **Simplicity over complexity** - Start simple, add sophistication gradually
+- **Developer-friendly** - Easy to implement and maintain
+- **Standards-compatible** - Works alongside and bridges to other standards
+- **Real-world tested** - 10+ years of iteration with open data communities
+
+### Core Specifications: Building Blocks for Any System
+
+Frictionless Data provides four core specifications that work together or independently:
+
+**1. Data Package: The Container**
+
+```json
+{
+  "name": "customer-transactions-q2-2023",
+  "title": "Customer Transactions Q2 2023",
+  "description": "Anonymized customer purchase data for Q2 business analysis",
+  "version": "1.2.0",
+  "licenses": [
+    {
+      "name": "CC-BY-4.0",
+      "title": "Creative Commons Attribution 4.0",
+      "path": "https://creativecommons.org/licenses/by/4.0/"
+    }
+  ],
+  "resources": [
+    {
+      "name": "transactions",
+      "path": "transactions.csv",
+      "title": "Customer Transaction Records",
+      "description": "Individual transaction records with product and customer details",
+      "schema": "schema/transactions-schema.json"
+    }
+  ],
+  "contributors": [
+    {
+      "title": "Data Engineering Team",
+      "email": "data@company.com",
+      "role": "author"
+    }
+  ],
+  "created": "2023-07-01"
+}
+```
+
+**2. Table Schema: Structure Definition**
+
+```json
+{
+  "fields": [
+    {
+      "name": "transaction_id",
+      "type": "string",
+      "title": "Transaction ID",
+      "description": "Unique identifier for each transaction",
+      "constraints": {
+        "required": true,
+        "unique": true
+      }
+    },
+    {
+      "name": "purchase_date",
+      "type": "date",
+      "title": "Purchase Date",
+      "description": "Date when the transaction occurred",
+      "format": "%Y-%m-%d"
+    },
+    {
+      "name": "amount",
+      "type": "number",
+      "title": "Transaction Amount",
+      "description": "Total transaction amount in USD",
+      "constraints": {
+        "minimum": 0
+      }
+    },
+    {
+      "name": "product_category",
+      "type": "string",
+      "title": "Product Category",
+      "description": "High-level product category",
+      "constraints": {
+        "enum": ["Electronics", "Clothing", "Home", "Books", "Sports"]
+      }
+    }
+  ]
+}
+```
+
+**3. Data Resource: Individual Asset Metadata**
+
+```json
+{
+  "name": "sales-summary",
+  "path": "https://data.company.com/sales/summary.json",
+  "title": "Monthly Sales Summary",
+  "description": "Aggregated sales data by product category and region",
+  "format": "json",
+  "mediatype": "application/json",
+  "encoding": "utf-8",
+  "schema": {
+    "fields": [
+      {
+        "name": "month",
+        "type": "date",
+        "format": "%Y-%m"
+      },
+      {
+        "name": "region",
+        "type": "string"
+      },
+      {
+        "name": "total_sales",
+        "type": "number"
+      }
+    ]
+  }
+}
+```
+
+### Why Frictionless Data Matters for Implementation
+
+**1. Standards Bridge**
+Frictionless Data doesn't compete with DCAT or Dublin Core—it complements them. You can easily map Frictionless metadata to other standards:
+
+```python
+# Python example: Frictionless to DCAT mapping
+from frictionless import Package
+
+# Load Frictionless Data Package
+package = Package('datapackage.json')
+
+# Map to DCAT
+dcat_metadata = {
+    'dcat:Dataset': {
+        'dct:title': package.title,
+        'dct:description': package.description,
+        'dcat:keyword': package.keywords,
+        'dct:issued': package.created,
+        'dcat:distribution': [
+            {
+                'dcat:downloadURL': resource.path,
+                'dct:format': resource.format,
+                'dcat:mediaType': resource.mediatype
+            }
+            for resource in package.resources
+        ]
+    }
+}
+```
+
+**2. Incremental Adoption**
+Start with basic Frictionless Data Package, then add sophistication:
+
+```json
+// Week 1: Basic package
+{
+  "name": "sales-data",
+  "resources": [
+    {"name": "sales", "path": "sales.csv"}
+  ]
+}
+
+// Month 1: Add schema validation
+{
+  "name": "sales-data",
+  "resources": [
+    {
+      "name": "sales",
+      "path": "sales.csv",
+      "schema": "sales-schema.json"
+    }
+  ]
+}
+
+// Month 3: Full metadata
+{
+  "name": "sales-data",
+  "title": "Monthly Sales Data",
+  "description": "Comprehensive sales analytics dataset",
+  "contributors": [...],
+  "licenses": [...],
+  "resources": [
+    {
+      "name": "sales",
+      "path": "sales.csv",
+      "schema": "sales-schema.json",
+      "title": "Sales Transactions",
+      "description": "Individual sales records with customer and product details"
+    }
+  ]
+}
+```
+
+**3. Developer Experience**
+Frictionless provides libraries in multiple languages with consistent APIs:
+
+```python
+# Python
+from frictionless import validate, Package
+package = Package('datapackage.json')
+report = validate(package)
+
+# Validation happens automatically
+if report.valid:
+    print("Data package is valid!")
+else:
+    for error in report.errors:
+        print(f"Error: {error.message}")
+```
+
+```javascript
+// JavaScript
+import { Package } from 'frictionless-js'
+
+const package = await Package.load('datapackage.json')
+const report = await package.validate()
+
+if (report.valid) {
+  console.log('Data package is valid!')
+} else {
+  report.errors.forEach(error => {
+    console.log(`Error: ${error.message}`)
+  })
+}
+```
+
+### Real-World Applications
+
+**Government Portal Enhancement:**
+
+```json
+{
+  "name": "city-budget-2024",
+  "title": "City Budget 2024",
+  "description": "Complete municipal budget data with departmental breakdowns",
+
+  // Frictionless simplicity
+  "resources": [
+    {
+      "name": "budget-summary",
+      "path": "budget-summary.csv",
+      "schema": "budget-schema.json"
+    }
+  ],
+
+  // Easy mapping to government standards
+  "custom": {
+    "dcat": {
+      "theme": "http://publications.europa.eu/resource/authority/data-theme/GOVE",
+      "accrualPeriodicity": "annual"
+    },
+    "project-open-data": {
+      "bureauCode": ["019:20"],
+      "programCode": ["019:006"]
+    }
+  }
+}
+```
+
+**Enterprise Data Catalog:**
+
+```json
+{
+  "name": "customer-analytics-datasets",
+  "title": "Customer Analytics Data Collection",
+  "description": "Curated datasets for customer behavior analysis and segmentation",
+
+  "resources": [
+    {
+      "name": "customer-profiles",
+      "path": "s3://data-lake/customer-profiles/",
+      "format": "parquet",
+      "schema": "schemas/customer-profile.json"
+    },
+    {
+      "name": "purchase-history",
+      "path": "s3://data-lake/purchases/",
+      "format": "parquet",
+      "schema": "schemas/purchase-history.json"
+    }
+  ],
+
+  // Enterprise-specific metadata alongside standard fields
+  "custom": {
+    "governance": {
+      "dataOwner": "customer-analytics@company.com",
+      "classification": "internal-confidential",
+      "retentionPeriod": "7-years"
+    },
+    "technical": {
+      "refreshSchedule": "daily-2am",
+      "sourceSystem": "customer-db-prod",
+      "qualityChecks": ["completeness", "accuracy", "timeliness"]
+    }
+  }
+}
+```
+
+## Choosing Your Standard: A Decision Framework
+
+With multiple standards available, how do you choose the right approach for your organization? The answer often isn't picking one standard, but rather understanding how to layer them effectively.
+
+### The Progressive Standards Approach
+
+**Layer 1: Dublin Core Foundation**
+Start with Dublin Core's 15 elements for any metadata initiative:
+
+```yaml
+# Minimum viable metadata - Dublin Core
+title: "Quarterly Sales Report Q2 2023"
+creator: "Sales Analytics Team"
+subject: "sales, revenue, performance"
+description: "Comprehensive sales performance data for Q2 2023 including regional breakdowns"
+publisher: "Acme Corporation"
+date: "2023-07-15"
+type: "Dataset"
+format: "CSV"
+language: "en"
+rights: "Internal use only"
+```
+
+**Layer 2: Domain-Specific Standards**
+Add specialized vocabulary based on your sector:
+
+*Government/Public Data → DCAT:*
+
+```yaml
+# Dublin Core + DCAT for government
+title: "Municipal Budget 2024"
+description: "Complete city budget with departmental allocations"
+publisher: "City Finance Department"
+
+# DCAT additions
+theme: "Government Finance"
+accrualPeriodicity: "annual"
+spatial: "Springfield, IL"
+contactPoint:
+  fn: "Budget Office"
+  hasEmail: "budget@springfield.gov"
+distribution:
+  - downloadURL: "https://data.springfield.gov/budget-2024.csv"
+    mediaType: "text/csv"
+```
+
+*Research/Academic → Dublin Core + DDI:*
+
+```yaml
+# Dublin Core + research extensions
+title: "Climate Change Perception Survey 2023"
+creator: "Dr. Sarah Johnson, Climate Research Institute"
+description: "National survey on public perception of climate change"
+
+# Research-specific additions
+methodology: "Random digit dialing telephone survey"
+sampleSize: 2847
+responseRate: 34.2
+fundingSource: "National Science Foundation Grant #NSF-1234567"
+ethicsApproval: "IRB-2023-045"
+```
+
+**Layer 3: Technical Implementation**
+Choose implementation format based on your technical needs:
+
+*Web-based Discovery → Schema.org:*
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Municipal Budget 2024",
+  "description": "Complete city budget with departmental allocations",
+  "url": "https://data.springfield.gov/budget-2024"
+}
+</script>
+```
+
+*Developer-Friendly → Frictionless Data:*
+
+```json
+{
+  "name": "municipal-budget-2024",
+  "title": "Municipal Budget 2024",
+  "description": "Complete city budget with departmental allocations",
+  "resources": [
+    {
+      "name": "budget",
+      "path": "budget-2024.csv",
+      "schema": "budget-schema.json"
+    }
+  ]
+}
+```
+
+### Decision Factors
+
+**1. Organizational Context**
+
+*Government/Public Sector:*
+
+- **Primary choice:** DCAT (often with regional extensions)
+- **Web presence:** Add Schema.org for SEO
+- **Implementation:** Consider Frictionless for technical flexibility
+
+*Academic/Research:*
+
+- **Foundation:** Dublin Core
+- **Discipline-specific:** DDI (social science), DataCite (research data), MODS (libraries)
+- **Implementation:** Frictionless for data packages, Schema.org for discoverability
+
+*Enterprise/Corporate:*
+
+- **Start with:** Dublin Core basics
+- **Business integration:** Custom extensions for governance, lineage, quality
+- **Implementation:** Frictionless for flexibility, Schema.org if public-facing
+
+**2. Technical Capabilities**
+
+*High Technical Resources:*
+
+- Can implement multiple standards simultaneously
+- Custom mapping between standards
+- Advanced validation and quality checking
+
+*Limited Technical Resources:*
+
+- Start with Frictionless Data for simplicity
+- Use hosted platforms that handle standards compliance
+- Focus on content quality over technical sophistication
+
+**3. Interoperability Requirements**
+
+*High Interoperability Needs:*
+
+- Strict DCAT compliance for government portals
+- Schema.org for web discoverability
+- Clear mapping to partner organization standards
+
+*Internal Focus:*
+
+- Prioritize business-specific metadata
+- Use standards as a foundation but customize heavily
+- Focus on integration with existing tools and workflows
+
+### Implementation Roadmap
+
+**Month 1-2: Foundation**
+
+```yaml
+# Minimum viable metadata
+title: "Required - Human readable name"
+description: "Required - 2-3 sentences explaining the data"
+creator: "Required - Who created this data"
+date: "Required - When was this created/published"
+format: "Required - File format (CSV, JSON, etc.)"
+```
+
+**Month 3-6: Standardization**
+
+```yaml
+# Add standard vocabulary
+title: "Quarterly Sales Performance Data"
+description: "Revenue, units sold, and performance metrics by product category and region"
+creator: "Sales Analytics Team, Acme Corp"
+subject: ["sales", "revenue", "business intelligence"]  # Controlled vocabulary
+type: "Dataset"  # Standard resource type
+format: "CSV"
+license: "Internal Use Only"  # Clear usage terms
+identifier: "acme-sales-q2-2023"  # Unique ID
+```
+
+**Month 6-12: Enhancement**
+
+```yaml
+# Full metadata with domain-specific extensions
+title: "Quarterly Sales Performance Data Q2 2023"
+description: "Revenue, units sold, and performance metrics by product category and region for Q2 2023 business analysis"
+
+# Standard Dublin Core
+creator: "Sales Analytics Team"
+publisher: "Acme Corporation"
+subject: ["sales", "revenue", "business intelligence", "performance metrics"]
+type: "Dataset"
+format: ["CSV", "JSON"]
+date: "2023-07-15"
+language: "en"
+rights: "Internal Use - Business Confidential"
+
+# Business-specific extensions
+businessDomain: "Sales Analytics"
+dataOwner: "VP Sales Operations"
+refreshFrequency: "Monthly"
+qualityScore: 94.7
+approvalStatus: "Approved for Business Use"
+retentionPeriod: "7 years"
+sourceSystem: "Salesforce CRM"
+```
+
+## The Future of Metadata Standards
+
+The metadata standards landscape continues evolving, driven by new technologies, changing organizational needs, and lessons learned from large-scale implementations.
+
+### Emerging Trends
+
+**1. AI and Machine Learning Integration**
+Modern data catalogs increasingly use AI to enhance metadata:
+
+```yaml
+# AI-enhanced metadata example
+title: "Customer Transaction Data Q2 2023"
+description: "Payment processing data for customer analytics"
+
+# Traditional metadata
+format: "CSV"
+size: "2.3 GB"
+records: 1847293
+
+# AI-generated additions
+aiGenerated:
+  qualityScore: 94.2
+  completenessProfile:
+    customerID: 100%
+    transactionAmount: 99.8%
+    merchantCategory: 87.3%
+  dataProfile:
+    numericalColumns: 12
+    categoricalColumns: 8
+    dateColumns: 3
+  suggestedTags: ["ecommerce", "payments", "customer-behavior"]
+  similarDatasets: ["customer-profiles-2023", "payment-methods-analysis"]
+  potentialIssues: ["Some merchant categories missing", "Date format inconsistency in 0.2% of records"]
+```
+
+**2. Real-time and Dynamic Metadata**
+Static metadata gives way to dynamic, real-time information:
+
+```yaml
+dataset:
+  title: "Live Traffic Sensor Data"
+  description: "Real-time traffic speed and volume from city sensors"
+
+  # Static metadata
+  publisher: "Department of Transportation"
+  license: "CC-BY-4.0"
+
+  # Dynamic metadata (updated automatically)
+  lastUpdated: "2023-06-29T14:23:47Z"
+  recordCount: 45729841  # Updates in real-time
+  dataFreshness: "3 seconds"  # How recent is the latest data
+  systemStatus: "operational"
+  avgUpdateFrequency: "every 30 seconds"
+  currentDataRange: "2023-06-29T14:20:00Z to 2023-06-29T14:23:00Z"
+```
+
+**3. Privacy and Governance Integration**
+Metadata standards evolve to include privacy and compliance information:
+
+```yaml
+dataset:
+  title: "Customer Analytics Dataset"
+  description: "Customer behavior and preference data for personalization"
+
+  # Traditional metadata
+  publisher: "Marketing Analytics Team"
+  format: "Parquet"
+
+  # Privacy-aware metadata
+  privacyLevel: "PII-containing"
+  gdprCompliant: true
+  dataSubjects: "EU and US customers"
+  legalBasis: "Legitimate interest for service improvement"
+  retentionPeriod: "2 years"
+  anonymizationMethod: "k-anonymity with k=5"
+  sensitiveFields: ["customer_id", "email_hash", "location_zip"]
+  accessControls:
+    - role: "Marketing Analysts"
+      permissions: ["read", "aggregate"]
+    - role: "Data Scientists"
+      permissions: ["read", "model"]
+  auditLog: "All access logged for 7 years"
+```
+
+### Convergence and Interoperability
+
+The future points toward greater convergence between standards rather than fragmentation:
+
+**Cross-Standard Mapping**
+Tools and platforms increasingly support automatic translation between standards:
+
+```python
+# Hypothetical future API
+from metadata_converter import StandardsConverter
+
+converter = StandardsConverter()
+
+# Load data in any standard
+metadata = converter.load('datapackage.json', format='frictionless')
+
+# Convert to any other standard
+dcat_output = converter.convert(metadata, target='dcat')
+schema_org_output = converter.convert(metadata, target='schema.org')
+dublin_core_output = converter.convert(metadata, target='dublin_core')
+
+# Validate against multiple standards simultaneously
+validation_report = converter.validate(metadata, standards=['dcat', 'schema.org'])
+```
+
+**Universal Metadata APIs**
+Future data platforms may expose unified metadata APIs that work with any standard:
+
+```http
+GET /api/metadata/dataset/12345?format=dcat
+GET /api/metadata/dataset/12345?format=schema.org
+GET /api/metadata/dataset/12345?format=frictionless
+```
+
+### Recommendations for Future-Proofing
+
+**1. Build on Stable Foundations**
+
+- Start with Dublin Core elements—they've remained stable for 25+ years
+- Use DCAT for data catalog applications—W3C backing provides long-term stability
+- Implement Schema.org for web presence—Google's support ensures longevity
+
+**2. Design for Flexibility**
+
+- Use JSON-based formats for easier parsing and transformation
+- Implement clear separation between core metadata and extensions
+- Plan for automated migration between standards
+
+**3. Embrace Tooling**
+
+- Invest in metadata management platforms that support multiple standards
+- Use validation tools to ensure quality and compliance
+- Implement automated metadata generation where possible
+
+## Conclusion
+
+Navigating the metadata standards landscape doesn't require choosing a single "winner"—it requires understanding how different standards work together to solve different problems. Dublin Core provides the universal foundation, DCAT adds data catalog sophistication, Schema.org enables web discovery, and Frictionless Data offers practical implementation flexibility.
+
+The key insight is that metadata standards should serve your organizational goals, not constrain them. Start with basic Dublin Core elements, add domain-specific standards as needed, and use tools like Frictionless Data to bridge the gap between standards and practical implementation.
+
+Most importantly, remember that the best metadata standard is the one that gets used consistently. A simple, well-maintained Dublin Core implementation beats a complex DCAT setup that no one maintains. Focus on creating metadata that serves your users' discovery needs, and let standards provide the framework for consistency and interoperability.
+
+As the data ecosystem continues to mature, organizations that invest in flexible, standards-based metadata approaches will find themselves better positioned to share data, collaborate across boundaries, and adapt to new technological developments. The metadata standards landscape may seem complex, but with the right approach, it becomes a powerful foundation for making data truly discoverable across organizations.
+
+Whether you're building a government open data portal, an academic research repository, or an enterprise data catalog, the principles remain the same: start simple, build consistently, and let standards amplify the value of your data through improved discovery and interoperability.
+]]></description><link>https://portaljs.com/blog/the-metadata-standards-landscape-making-data-discoverable-across-organizations</link><guid isPermaLink="false">https://portaljs.com/blog/the-metadata-standards-landscape-making-data-discoverable-across-organizations</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 08 Jul 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[How Rich Metadata Powers Data Discovery in Modern Data Catalogs]]></title><description><![CDATA[
+## Introduction
+
+In our [previous post](/blog/basics-of-metadata-how-it-helps-to-understand-your-data), we explored what metadata is and how it transforms raw data files into understandable resources. But metadata's true power emerges when you're managing not just one CSV file, but hundreds or thousands of datasets in a data catalog or portal.
+
+Imagine you’re a researcher looking for climate data about New York City in a government data portal with 5,000 datasets. Without good metadata and search capabilities, you’d need to browse through endless pages of cryptically named files. With rich metadata powering a search engine, you can simply type “climate data New York” and instantly find relevant datasets ranked by relevance. This doesn’t yet account for using natural language queries to discover data, which we’ll explore in upcoming posts on modern data catalogs and portals.
+
+## The Scale Challenge: From Dozens to Thousands of Datasets
+
+### When Browsing Breaks Down
+
+Small data collections work fine with simple browsing. A research team with 20 datasets can organize them in folders or basic categories. Users can scan through everything and find what they need.
+
+But data catalogs grow quickly:
+
+* **Municipal open data portals**: Often contain 50-2,000 datasets covering everything from parking violations to budget data.
+* **Enterprise data catalogs**: Can house 500-50,000 datasets across departments and systems.
+* **Research repositories**: May contain hundreds of thousands of datasets from different studies and institutions.
+
+At this scale, browsing becomes impossible. Users need search capabilities—and search engines need rich, consistent metadata to deliver relevant results.
+
+![Metadata search discovey illustration](/static/img/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs/metadata-search-discovery-illustration.png)
+
+> [!info] A common question:
+> Can our search engine query the actual data rows within tables?
+> **Answer:**
+> Not directly. Indexing every data row—especially for tables with millions of time-series records—would be prohibitively large and memory-intensive for engines like Elasticsearch. Instead, we index structured metadata (e.g., table schemas, column descriptions, data dictionaries) and generate salient “key points” or summaries. This approach keeps the search index lean and performant while still guiding users to the most relevant tables.
+
+### The Standardization Imperative
+
+When you have thousands of datasets, inconsistent or insufficient metadata creates chaos:
+
+```text
+// Inconsistent or insufficient metadata across datasets:
+Dataset 1: "nyc_311_jan2023.csv"
+Dataset 2: "New York City 311 Service Requests - January 2023.xlsx"
+Dataset 3: "January 2023 NYC Citizen Complaints and Service Calls.pdf"
+```
+
+Search engines can't effectively match these three related datasets to a user query like "NYC 311 data" because the metadata varies wildly.
+
+The solution is a **metadata schema**—a standardized list of metadata fields that all datasets must follow, a simple example would be:
+
+```yaml
+# Example metadata schema
+required_fields:
+  - title          # Human-readable dataset name
+  - description    # 2-3 sentence explanation
+  - owner          # Dataset maintainer/publisher
+  - license        # Usage permissions
+  - last_updated   # When data was last modified
+
+recommended_fields:
+  - tags           # Keywords for discovery
+  - category       # Thematic classification
+  - format         # File format (CSV, JSON, etc.)
+  - temporal_coverage  # Date range covered
+
+optional_fields:
+  - geographic_coverage  # Spatial extent
+  - update_frequency    # How often data changes
+  - data_quality_score  # Completeness/accuracy rating
+```
+
+This schema enables three critical capabilities:
+
+1. **Systematic indexing**: Search engines can reliably index the same fields across all datasets, ensuring consistent search behavior.
+
+2. **Enforced quality**: Required fields ensure every dataset has minimum discoverable information before publication.
+
+3. **Guided creation**: Data publishers know exactly what metadata to provide, with clear distinctions between required, recommended, and optional fields.
+
+> [!info] Note about our simple yet powerful metadata standard and tooling
+> [Frictionless Data](https://frictionlessdata.io/) is a progressive open-source framework for building data infrastructure – data management, data integration, data flows, etc. It includes various data standards and provides software to work with data.
+
+## Search Engines: The Discovery Engine Behind Data Catalogs
+
+### Popular Platform Combinations
+
+Modern data catalogs pair with powerful search engines to handle discovery at scale:
+
+* **CKAN + Apache Solr**: CKAN uses Solr's faceted search and text analysis capabilities to index dataset metadata, enabling complex filtering by organization, tags, formats, and date ranges.
+
+* **OpenMetadata + Elasticsearch**: OpenMetadata leverages Elasticsearch's real-time indexing to make data assets searchable immediately after ingestion, with support for complex queries across schemas, lineage, and usage patterns.
+
+* **Custom portals + various engines**: Many organizations build custom data portals using search engines like Elasticsearch, Solr, or even newer solutions like Meilisearch for specific performance requirements.
+
+### How Search Engines Index Metadata
+
+Here's what happens when you add a new dataset to a catalog:
+
+1. **Ingestion**: The catalog system reads both built-in metadata (filename, format, size) and external metadata files (title, description, tags)
+
+2. **Parsing & Validation**: Metadata is parsed according to the catalog's schema and validated for required fields
+
+3. **Transformation**: Data is normalized—dates converted to standard formats, tags split into arrays, categories mapped to controlled vocabularies
+
+4. **Indexing**: The search engine creates searchable indexes from metadata fields, with different indexing strategies for text search vs. faceted filtering
+
+5. **Ranking**: Search algorithms determine relevance based on text matching, metadata completeness, dataset popularity, and recency
+
+## Rich Metadata = Better Matches
+
+### Title & Description: The Foundation of Text Search
+
+Compare these two approaches to naming the same dataset:
+
+**Minimal metadata approach:**
+```text
+filename: NYC-311-2023-Q1.csv
+title: [same as filename]
+description: [empty]
+```
+
+**Rich metadata approach:**
+```text
+filename: NYC-311-2023-Q1.csv
+title: New York City 311 Service Requests - Q1 2023
+description: Comprehensive dataset of citizen complaints, service requests,
+and municipal responses from NYC's 311 system during January-March 2023.
+Includes request types, geographic distribution, response times, and
+resolution status for over 500,000 service requests.
+```
+
+When someone searches for "NYC citizen complaints," the rich metadata provides multiple text matching opportunities:
+- "NYC" matches "New York City"
+- "citizen" matches "citizen complaints"
+- "complaints" matches the description text
+- "service requests" provides additional context
+
+The search engine can confidently rank this dataset highly for the user's query.
+
+### Tags & Keywords: Enabling Faceted Discovery
+
+Tags transform search from simple text matching to structured exploration:
+
+```yaml
+# Example rich tagging for a transportation dataset
+tags:
+  - transportation
+  - public-transit
+  - bus-routes
+  - geographic-data
+  - real-time
+  - gtfs-format
+```
+
+These tags enable users to:
+- **Filter results**: "Show me only transportation datasets"
+- **Discover related data**: "Other datasets tagged 'gtfs-format'"
+- **Refine searches**: "Real-time transportation data"
+
+### Categories & Themes: Structured Browsing Paths
+
+While search handles specific queries, categories provide structure for exploration:
+
+```text
+Government Data Portal Categories:
+├── Transportation
+│   ├── Public Transit
+│   ├── Traffic & Parking
+│   └── Infrastructure
+├── Environment
+│   ├── Air Quality
+│   ├── Water Resources
+│   └── Climate & Weather
+└── Demographics
+    ├── Census Data
+    ├── Housing
+    └── Economic Indicators
+```
+
+Good categorization helps users discover datasets they didn't know existed.
+
+### Temporal & Spatial Metadata: Context That Matters
+
+Time and location metadata enable powerful filtering:
+
+```yaml
+# Temporal metadata
+date_created: "2023-01-15"
+date_modified: "2023-03-20"
+temporal_coverage_start: "2023-01-01"
+temporal_coverage_end: "2023-03-31"
+update_frequency: "daily"
+
+# Spatial metadata
+geographic_coverage: "New York City, NY, USA"
+bounding_box:
+  north: 40.9176
+  south: 40.4774
+  east: -73.7004
+  west: -74.2591
+```
+
+This enables queries like:
+- "Show me datasets updated in the last week"
+- "Find data covering Manhattan from 2020-2023"
+- "Daily updated transportation data"
+
+## Real-World Example: Search in Action
+
+Let's trace how rich metadata helps a user find relevant data:
+
+**User query:** "climate data New York"
+
+**Dataset 1 (Poor metadata):**
+```text
+filename: weather_station_data_2023.csv
+title: weather_station_data_2023
+description: [empty]
+tags: [empty]
+```
+
+**Dataset 2 (Rich metadata):**
+```text
+filename: weather_station_data_2023.csv
+title: New York State Climate Monitoring Network - 2023 Weather Data
+description: Hourly temperature, precipitation, humidity, and wind measurements
+from 45 weather stations across New York State. Data quality controlled and
+validated by NYS Climate Office. Includes extreme weather events and monthly
+climate summaries.
+tags: climate, weather, temperature, precipitation, new-york, monitoring, hourly-data
+geographic_coverage: New York State, USA
+temporal_coverage: 2023-01-01 to 2023-12-31
+```
+
+**Search engine matching process:**
+
+1. **Text relevance**: Dataset 2 matches "climate" (exact match in tags and description) and "New York" (in title and geographic coverage)
+
+2. **Metadata completeness bonus**: Dataset 2 has rich descriptions and complete metadata fields, suggesting higher quality
+
+3. **Geographic precision**: "New York State" closely matches user's "New York" query
+
+4. **Thematic relevance**: Climate-related tags confirm this dataset is specifically about climate data
+
+**Result**: Dataset 2 ranks much higher and provides the user with clear information about whether it meets their needs—all before they even download it.
+
+## Building for Discovery: Metadata Standards
+
+### Popular Metadata Schemas
+
+Successful data catalogs adopt standardized metadata schemas:
+
+**DCAT (Data Catalog Vocabulary)**
+- W3C standard for web-based data catalogs
+- Defines common properties: title, description, keywords, themes, publisher, license
+- Enables cross-catalog data discovery and harvesting
+
+**Schema.org Dataset**
+- Structured data markup for web search engines
+- Helps Google and other search engines understand and index your datasets
+- Includes properties for data downloads, temporal coverage, and spatial coverage
+
+**Frictionless Data Package**
+- Lightweight standard with focus on data usability
+- Emphasizes clear resource descriptions and table schemas
+- Popular in research and scientific data communities
+
+**Custom Organizational Schemas**
+- Extended versions of standards with domain-specific fields
+- Example: Adding "data_sensitivity_level" for enterprise catalogs
+- Balance between standardization and specific organizational needs
+
+### The Consistency Advantage
+
+The most important factor isn't which schema you choose—it's applying it consistently across all datasets. A catalog where every dataset has a clear title, description, tags, and category will outperform one with perfect but inconsistent metadata.
+
+```yaml
+# Minimal but consistent schema across all datasets:
+title: [required - human readable name]
+description: [required - 2-3 sentences explaining the data]
+tags: [required - 3-5 relevant keywords]
+category: [required - from controlled vocabulary]
+license: [required - usage terms]
+last_updated: [required - ISO date format]
+```
+
+This consistency enables:
+- **Reliable search results**: Users can depend on finding complete information
+- **Effective filtering**: Faceted search works when fields are consistently populated
+- **Automated processing**: APIs and integrations can rely on standard fields being present
+
+## Conclusion
+
+Rich metadata is the bridge between data creators and data users at scale. While a single CSV file might need only basic context, data catalogs with hundreds or thousands of datasets require standardized, searchable metadata to remain useful.
+
+The combination of rich metadata and powerful search engines transforms data discovery from a frustrating browsing experience into targeted, relevant search results. Whether you're using CKAN with Solr, OpenMetadata with Elasticsearch, or building a custom solution, the principle remains the same: invest in consistent, descriptive metadata and your users will find exactly what they need.
+
+In our next post, we'll dive into the practical aspects of implementing metadata standards in your data portal—covering schema design, validation workflows, and migration strategies for existing catalogs.]]></description><link>https://portaljs.com/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs</link><guid isPermaLink="false">https://portaljs.com/blog/how-rich-metadata-powers-data-discovery-in-modern-data-catalogs</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 25 Jun 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Basics of Metadata: How It Helps Understand Your Data]]></title><description><![CDATA[
+## Introduction
+
+In the age of big data, raw datasets alone are seldom enough. Without context, understanding a table’s fields, provenance, or usage constraints can be a guessing game. **Metadata**—often described as “data about data”—fills this gap by providing structured, machine-readable descriptions of your datasets. In this article, we’ll explore:
+
+* What metadata is, at a technical level
+* Core metadata concepts including built-in information and external metadata.
+* Basics of further ingestion of metadata in various systems.
+
+Whether you’re building an internal data catalog or a public open-data portal, a robust metadata strategy is the key to making data discoverable, interoperable, and reusable.
+
+## 1. Defining Metadata
+
+Metadata is information that describes the characteristics and context of a data asset. It bridges the gap between raw data and meaningful insight by answering questions such as:
+
+* **What** the data represents (descriptive metadata)
+* **How** it is structured or formatted (structural metadata)
+* **Who**, **when**, and **where** the data was created or modified (administrative metadata)
+
+At the simplest level, metadata can be built into your storage layer (e.g., file name, format, timestamps). For richer context, you can supply external metadata files (JSON, YAML, XML, or simple text) that complement and enhance built-in attributes.
+
+!["An iceberg showing a small tip labeled 'CSV File' above water and a large submerged base labeled with metadata attributes like title, description, license, timestamps, and keywords."](/static/img/blog/basics-of-metadata-how-it-helps-to-understand-your-data/metadata-iceberg-illustration-vector.png)
+
+## 2. From Built-In to External Metadata: A Step-by-Step Example
+
+Let’s say you have a simple CSV file of temperature readings:
+
+```text
+// File on disk:
+temperature-readings-20250528.csv
+
+// Content preview:
+timestamp,value
+2025-05-28T00:00:00Z,15.2
+2025-05-28T01:00:00Z,14.9
+...
+```
+
+### 2.1. Built-In Metadata
+
+Every file system (and HTTP response) carries minimal metadata. For our CSV:
+
+* **File name**: `temperature-readings-20250528.csv`
+* **Media type**: `text/csv`
+
+These two attributes already tell machines:
+
+1. *what* the file is called, and
+2. *how* to parse it (as comma-separated values).
+
+But to your users—or to a search engine—you need richer context.
+
+> [!info] Note about other built-in metadata:
+> Beyond **file name** and **media type**, file systems and delivery protocols expose several other built-in metadata attributes you can leverage before you even add an external metadata file:
+> 1. **File System Attributes**
+>   * **Size** (`Content-Length` in HTTP): the total byte length of the CSV.
+>   * **Timestamps**:
+>     * **Created** (`birthtime` on many Unix-style systems)
+>     * **Last modified** (`mtime`)
+>     * **Last accessed** (`atime`)
+>   * **Permissions & Ownership**: who owns the file and its read/write/execute bits.
+> 2. **HTTP/Transport Metadata** (when serving over HTTP)
+>   * **ETag** or **Last-Modified** header: for cache validation.
+>   * **Content-Encoding**: if you gzip/brotli the CSV in transit.
+>   * **Content-Disposition**: suggests a download filename or whether to display inline.
+> 3. **CSV-Specific “Built-In” Info** (derivable by quickly inspecting the file)
+>   * **Header Row**: column names—essential structural metadata.
+>   * **Row Count**: number of records (you can compute this cheaply on ingest).
+>   * **Character Encoding**: e.g. UTF-8 vs. ISO-8859-1 (often exposed as `charset` in the MIME type).
+
+### 2.2. External Metadata
+
+Often, file names and media types alone are insufficient to convey the context users need. To enrich your CSV with human-readable information, you can provide an external metadata file. For a single attribute—such as a title—you might start with a basic text file named `metadata.txt`:
+
+```text
+Hourly temperature readings for May 28, 2025
+```
+
+While this simple file supplies a clear title, real-world use cases typically require multiple metadata fields (e.g., title, description, type). To represent these as structured data that programs can parse reliably, a key-value format is ideal. Consider the following YAML example:
+
+```yaml
+title: Hourly temperature readings for May 28, 2025
+description: |
+  This CSV contains one-hour-interval temperature measurements
+  recorded in Almaty, Kazakhstan on May 28, 2025. All timestamps
+  are in UTC. Data sourced from XXX weather station.
+```
+
+> [!info] What is YAML?
+> YAML ("YAML Ain't Markup Language") is a human-friendly serialization format. Its indentation-based syntax and key-value structure make it easy to author and parse, making YAML a popular choice for metadata, configuration, and data interchange.
+
+The same information rendered in tabular form:
+
+| Metadata Field | Value                                                     | Purpose                                                                               |
+| -------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `title`        | Hourly temperature readings for May 28, 2025              | Provides a concise, human-readable name—easier for users to scan than a raw filename  |
+| `description`  | This CSV contains one-hour-interval temperature measurements recorded in Almaty, Kazakhstan on May 28, 2025. All timestamps are in UTC. Data sourced from XXX weather station. | Offers detailed context upfront, improving relevance judgment without inspecting data |
+
+> [!info] Why add external metadata?
+> Providing even a simple companion metadata file gives users immediate context—transforming opaque filenames into understandable resource descriptions. It enhances discoverability, improves usability, and lays the groundwork for rich search and filtering features.
+
+### 2.3. Taking It Further: Additional Attributes
+
+Once you’ve mastered `title` and `description`, you can add:
+
+* **keywords**: e.g. `temperature, Almaty, time series`
+* **license**: e.g. `CC-BY-4.0`
+* **provenance**: who collected it and when (e.g. `collectedBy: XXX weather station`).
+
+Each new attribute is just another line in your metadata file:
+
+```text
+keywords: temperature,Almaty,time series
+license: CC-BY-4.0
+collectedBy: XXX weather station
+```
+
+Many systems would automatically pick these up—no custom code required.
+
+### 2.4. How Ingestion Works
+
+1. **Discovery**
+   * An ingestion pipeline identifies data files and their companion metadata files (e.g., `.meta.txt`, `.json`, or `.yaml`).
+2. **Parsing**
+   * Read built-in metadata attributes (filename, media type, file size, timestamps) directly from the file system or HTTP headers.
+   * Parse the external metadata into structured fields (e.g., `title`, `description`, `keywords`).
+3. **Validation**
+   * Validate parsed metadata against a predefined schema or set of rules to ensure completeness and correctness.
+4. **Transformation**
+   * Normalize and transform metadata values (e.g., convert date formats, split comma lists into arrays).
+5. **Indexing**
+   * Store both built-in and external metadata in a search or catalog index, mapping specific fields to facets, full-text search, and structured exports (JSON‑LD, DCAT).
+   * This index powers discovery features like faceted filters, semantic ranking, and metadata exports.
+
+!["Five-step metadata ingestion diagram showing Discovery, Parsing, Validation, Transformation, and Indexing stages with simple icons for each."](/static/img/blog/basics-of-metadata-how-it-helps-to-understand-your-data/metadata-ingestion-pipeline-steps-diagram.png)
+
+### 2.5. Why This Matters
+
+* **Clarity for Users**: A friendly title beats a cryptic filename.
+* **Better Search**: Rich text in `description` fuels full-text relevancy ranking.
+* **Faceted Filters**: Adding `keywords` and `license` turns those into clickable filters.
+* **Automation**: Keep your metadata alongside your data; pipelines stay simple.
+
+By starting with two built-in attributes and a tiny external text file, you can already transform raw CSV dumps into a fully searchable, self-documenting dataset. From here, extending to full JSON-LD or DCAT becomes a natural next step.
+
+## Conclusion
+
+Implementing metadata is not just a best practice—it's essential for unlocking the value of your data. By combining built-in attributes (file name, media type, timestamps) with external metadata files, you provide the context users need to discover, understand, and trust your datasets. A clear metadata strategy powers faceted search, semantic ranking, and linked-data features that scale from a simple CSV repository to enterprise-grade data catalogs. Start small with human-readable titles and descriptions, then grow your metadata alongside your data products to build truly data-driven experiences.]]></description><link>https://portaljs.com/blog/basics-of-metadata-how-it-helps-to-understand-your-data</link><guid isPermaLink="false">https://portaljs.com/blog/basics-of-metadata-how-it-helps-to-understand-your-data</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 02 Jun 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Why We Decoupled CKAN’s Frontend — And What We Gained with PortalJS]]></title><description><![CDATA[
+![CKAN](/static/img/blog/2025-05-28-Why-we-decoupled-CKAN’s-frontend/image1.png)  
+
+> [!info] The short version?
+> [CKAN](https://www.datopian.com/solutions/ckan) is a rock-solid backend for open data portals. 
+But what happens when you want to modernize the user experience?
+For us, the answer was simple: decouple the frontend.
+
+Modern open data portals need more than just a reliable backend. They need speed, customization, and a frontend that’s easy to scale and maintain.
+
+[CKAN](https://www.datopian.com/solutions/ckan) remains one of the most trusted open-source backends for managing datasets. But when it comes to the frontend experience, we chose to decouple — and here’s why.
+
+In this article, we’ll share why we chose to separate the frontend from CKAN’s traditional stack, how we approached it with **PortalJS**, and what we learned about performance, scalability, and developer experience along the way.
+
+## **CKAN: A Powerful Engine for Open Data**
+
+CKAN is widely used by governments, NGOs, and research institutions. Its backend is flexible, reliable, and API-driven — perfect for managing datasets at scale.
+
+But CKAN ships with a built-in frontend based on Flask, a lightweight Python web framework. While this works well for many use cases, we found that as user expectations evolved, so did the need for a more dynamic, scalable, and customizable frontend experience.
+
+That’s when we started asking:
+
+**What if we didn’t replace CKAN, but extended it — with a modern frontend layer built around today’s web standards?**
+
+## **What Is PortalJS and How Does It Work with CKAN?**
+
+**PortalJS** is a decoupled frontend framework built on Next.js. It connects to CKAN via API and replaces the traditional Flask frontend with a faster, more flexible layer.
+
+**Key Features**
+
+- **Static Site Generation (SSG):** Pre-render content that doesn’t change often
+- **Incremental Static Regeneration (ISR):** Update static content in the background
+- **Serverless functions:** Handle dynamic parts on demand
+- **React + TailwindCSS:** Build beautiful, responsive interfaces
+
+This means you can keep CKAN’s backend and get a frontend that:
+- Loads faster
+- Scales easier
+- Is more fun to build on
+
+## **The Case for a Decoupled Frontend**
+
+Our decision wasn’t about what's wrong with CKAN — it was about what's possible with a decoupled architecture.
+
+### **Monolithic Frontends: Solid, But Not Always Flexible**
+
+The traditional CKAN frontend is tightly coupled to the backend:
+
+- Each page is rendered dynamically by the server
+- Customizing the UI often means diving into Python templates
+- Developers need to manage full local stacks (Docker, Solr, PostgreSQL, Redis)
+
+This setup is reliable but comes with friction — especially for frontend teams used to modern JavaScript tooling and performance patterns.
+
+## **Why We Decoupled: The Benefits of Using PortalJS with CKAN**
+
+We built **PortalJS** to bring the best of both worlds together:
+
+- Keep CKAN as the backend
+- Replace the frontend with a modern, decoupled layer powered by **Next.js**
+
+PortalJS communicates with CKAN over its existing API. You still use CKAN to manage datasets, users, organizations, and metadata — but everything the user sees is rendered through a faster, more flexible frontend. 
+
+## **What We Gained by Decoupling**
+
+### **Better Performance**
+
+PortalJS uses Next.js features like:
+
+- **Static Site Generation (SSG)** for pages that rarely change
+- **Incremental Static Regeneration (ISR)** for fresh content, without backend load
+- **Serverless functions** for dynamic rendering only when needed
+
+This reduces API strain, speeds up page loads, and improves SEO dramatically.
+
+### **Happier Developers**
+
+Setting up CKAN’s frontend locally means spinning up Docker containers, databases, and search services.
+
+With PortalJS, the workflow looks like this:
+
+```shell
+npm install
+npm start
+```
+
+That’s it. Developers can focus on building features, not configuring infrastructure.
+
+### **More Customization**
+
+Because PortalJS is built with React and TailwindCSS, it’s easy to:
+
+- Redesign pages and navigation
+- Add filters and search interactions
+- Create responsive, mobile-friendly layouts
+
+You're no longer bound to the default CKAN UI — you can make it your own.
+
+## **Example: How We Handle Dataset Metadata Pages**
+
+In CKAN, every metadata page is rendered dynamically — even though most of that information rarely changes. And every visit hits the backend and database.
+
+With PortalJS, we pre-generate those pages using SSG. That means:
+
+- Instant load times
+- No database hit
+- SEO-friendly static content
+
+For parts that do change (like download counts or updated timestamps), we use client-side rendering or ISR.
+
+It’s the best of both worlds.
+
+## **CKAN + PortalJS: A Collaborative Architecture**
+
+**PortalJS is a frontend layer that works with CKAN — not against it.**
+
+You keep CKAN’s backend, workflows, extensions, and APIs.
+
+But you gain:
+
+- A smoother user experience
+- Easier customization
+- Better performance and scalability
+- Simpler developer onboarding
+
+It’s the same engine — just a better dashboard.
+
+## **Who This Is For**
+
+We’ve seen PortalJS help:
+
+- Governments modernize their public open data portals
+- Nonprofits simplify dataset publishing
+- Enterprises create internal data platforms with custom branding and UX
+
+If you're already using CKAN and want a more modern, maintainable frontend — **this is for you.**
+
+## **Final Thoughts: Let CKAN Do What It Does Best**
+
+CKAN remains one of the best backend systems for open data.
+
+PortalJS doesn’t change that — it simply opens new possibilities.
+
+By decoupling the frontend, we’ve been able to deliver faster, more beautiful, more usable portals — while still relying on the CKAN core that’s trusted worldwide.
+
+[🔗 Explore the full technical breakdown](https://www.portaljs.com/blog/why-portaljs-is-the-future-of-decoupled-frontend-for-data-portals)
+
+## **FAQs**
+
+**What’s the main reason to decouple the CKAN frontend?**
+
+To improve performance, scalability, and developer experience by using a modern, API-first frontend.
+
+**Does PortalJS replace CKAN?**
+
+No. PortalJS replaces only the frontend. CKAN still powers the backend, APIs, and admin functions.
+
+**Can I use existing CKAN extensions?**
+
+Yes. Since the backend remains CKAN, your extensions continue working as expected.
+
+**Where do I deploy PortalJS?**
+
+It runs on any frontend hosting provider. We recommend Vercel, Netlify, or Cloudflare Pages.
+
+**What’s the dev experience like?**
+
+Fast. No Docker required. Just clone, install dependencies, and start building with React.
+
+
+
+
+]]></description><link>https://portaljs.com/blog/why-we-decoupled-CKAN-frontend</link><guid isPermaLink="false">https://portaljs.com/blog/why-we-decoupled-CKAN-frontend</guid><dc:creator><![CDATA[popovayoana]]></dc:creator><pubDate>Wed, 28 May 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Why NASA — and Anyone Using CKAN — Should Consider a Decoupled Front-End with PortalJS]]></title><description><![CDATA[
+## **Imagine a Faster, Smarter NASA Data Portal**
+
+What if a climate scientist visiting [data.nasa.gov](https://data.nasa.gov) could explore global time-series datasets through an interface that loads instantly, adapts to their workflow, and feels intuitive—on any device?
+Today, NASA’s portal runs on CKAN’s built-in frontend, which serves its purpose but limits performance and flexibility. By adopting a **decoupled frontend using PortalJS**, NASA could dramatically improve speed, user experience, and accessibility—without changing the backend.
+**This shift unlocks a more modern open data experience**, tailored for researchers, analysts, and developers working with large, complex datasets.
+
+![CKAN](/static/img/blog/2025-05-19-why-anyone-should-consider-decoupled-frontend/image2.webp)  
+
+## **The Current CKAN-Based Approach**
+
+[NASA’s portal](https://data.nasa.gov) uses CKAN’s built-in frontend — a unified structure where the user interface and backend are tightly connected.
+
+### **Monolithic UI & API**
+
+CKAN’s integrated UI and backend deliver robust search and data-management workflows out of the box. It serves well for dataset CRUD, geospatial previews, and basic theming.
+
+**What Works:**
+
+- Out-of-the-box dataset management
+- Geospatial previews
+- Basic theming and search
+
+**Limitations**
+
+- **Release Cycle Coupling:** UI updates often require CKAN core upgrades or plugin rebuilds.
+
+> [!info] In simple terms
+> If you want to tweak the interface, you have to dig into the backend code. That slows things down and makes small changes more complicated than they should be.
+
+- **Branding Constraints:** Deep theming adjustments can be labor-intensive and risk conflicts with upstream.
+
+> [!info] In simple terms
+> Making your portal look like “NASA” (or any other organization) takes a lot of effort, and those changes may not survive future updates.
+
+- **Performance Overheads:** Server-side rendering for every page load can introduce latency under heavy traffic.
+
+> [!info] In simple terms
+> Every time someone opens a page, the server has to rebuild it. That slows things down when lots of people visit at once.
+
+## **Why a Decoupled PortalJS Front-End?**
+PortalJS is a frontend framework purpose-built for CKAN. PortalJS consumes CKAN’s REST API and renders the frontend independently using Next.js. This architecture gives teams more control over UX, while keeping the backend untouched.
+
+**Key advantages:**
+
+**1. Rapid Iteration**
+
+PortalJS applications consume CKAN’s REST APIs, enabling independent deployment of UI components. New features — like custom data-visualization panels — can ship without touching the CKAN codebase.
+
+
+**2. Enhanced UX & Branding**
+
+- **Component Library:** Reusable “DatasetCard,” “FilterPanel,” and “MapExplorer” snippets conform to NASA’s design system.
+- **Responsive & Accessible:** Built-in patterns for ARIA compliance and mobile-first layouts ensure broad reach.
+
+> [!info] In simple terms
+> You can make the portal look and feel exactly how your users expect, with reusable building blocks. Works well on phones and meets accessibility standards by default.
+
+**3. Scalability & Resilience** Scalability & Resilience By hosting the PortalJS front end on a CDN (e.g., Cloudflare) and separating it from CKAN servers, static assets load faster and UI downtime can be decoupled from backend maintenance windows.
+
+> [!info] In simple terms
+> Pages load almost instantly because they’re already generated and stored near your users — no waiting for the server to respond.
+
+## **A Blueprint for Decoupled Architecture**
+
+A decoupled setup keeps CKAN as the backend and places PortalJS on top as the user-facing layer. The backend stays stable, while the frontend can evolve quickly and scale independently. You serve pages fast, keep your infrastructure lightweight, and give teams more control.
+
+**1. API Gateway:**
+- AWS API Gateway or CloudFront Lambda@Edge enforcing API keys, rate-limits, and caching for CKAN REST endpoints.
+
+
+**2. PortalJS Application:**
+- Deployed to an S3 bucket + CloudFront distribution.
+- Integrations: CKAN’s /api/3/action routes for dataset search, resource download, and user authentication.
+
+
+**3. Extensibility Hooks:**
+- **Widget Registry:** Dynamically load visualization widgets (e.g., D3 timelines, Cesium 3D maps) based on dataset metadata.
+- **Theme Manager:** Allow NASA web teams to tweak color tokens and font scales via a JSON config file.
+
+![PortalJS](/static/img/blog/2025-05-19-why-anyone-should-consider-decoupled-frontend/PortalJS.gif) 
+
+## **Why This Matters**
+
+CKAN’s backend is solid. But a modern frontend makes ALL the difference. 
+
+This isn’t just about NASA. The same constraints exist for many governments, research labs, and institutions using CKAN.
+
+**Decoupling with PortalJS** unlocks:
+- Speed
+- Flexibility
+- Custom and modern UX
+- Resilient architecture
+
+> [!info] Bottom line
+> Your portal can grow, adapt, and look modern — without expensive rebuilds or risky changes to your data backend.
+
+### **See It in Action**
+
+Curious what this would look like for your team? Start a pilot in minutes — no backend changes required. 
+
+If you’d like to explore a PortalJS pilot on your CKAN instance — government, research institution, or enterprise — visit our [site](https://www.portaljs.com) and get started in minutes!
+
+📩 [Talk to us](https://calendar.app.google/sn2PU7ZvzjCPo1ok6) to discuss your use case.
+
+---]]></description><link>https://portaljs.com/blog/why-NASA-and-anyone-using-CKAN-should-consider-a-decoupled-front-end-with-PortalJS</link><guid isPermaLink="false">https://portaljs.com/blog/why-NASA-and-anyone-using-CKAN-should-consider-a-decoupled-front-end-with-PortalJS</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 19 May 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[The New Look of PortalJS Cloud]]></title><description><![CDATA[
+At PortalJS Cloud, we believe that managing and sharing open data should be effortless, beautiful, and accessible. That’s why we’ve launched a complete redesign of the PortalJS Cloud frontend—combining performance upgrades with a sleek, modern interface designed for everyone, from governments and non-profits to academic institutions and private organizations.
+
+The new version offers a cleaner interface, enhanced accessibility, and lightning-fast search—making it the smartest choice for modern open data initiatives.
+
+Let’s explore what’s new and how these improvements help you deliver a better data experience to your users.
+
+## **What’s New?**
+
+### **A Revamped User Interface**
+
+We’ve introduced a fresh, professional design across the entire portal. Pages like the homepage, dataset view, and search experience now feel smoother and more intuitive for all users.
+
+- **Modern, minimalist layout** for a polished first impression:
+
+![Home page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image14.webp)  
+_Home page_
+
+![Search page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image9.webp)  
+_Search page_
+
+![Dataset page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image3.webp)  
+_Dataset page_
+
+![Resource Preview Page](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image7.webp)  
+_Resource Preview Page_
+
+- Optimized for **performance**
+- **Fully responsive** across desktop, tablet, and mobile devices  
+  ![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image2.gif)
+
+- Designed with accessibility in mind, meeting **WCAG 2.1 / 2.2 standards**
+  - All interactive elements (filters, tabs, buttons) are keyboard-friendly
+  - “Skip to content” navigation for screen reader users
+
+_![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image6.webp)_
+
+## **Smarter Search & Filtering 🔍**
+
+We’ve made the search experience much easier and more powerful—especially when it comes to filtering and sharing results.
+
+**Shareable search results**
+
+We’ve rebuilt the search page so that every filter you apply—such as keywords, tags, or formats—is automatically reflected in the page URL. This is known as URL-synced search state.
+
+In other words, the portal keeps track of your search settings directly in the web address.
+
+What this means for the user:
+
+Let’s say a user filters for _“climate data from 2024”_. The page URL will automatically update to reflect those filters. They can now copy that link and send it to a colleague, who will land on the exact same filtered view. No need to repeat the search.  
+Plus, filters are saved in the browser history. So if someone clicks on a dataset, they can use the **Back** button to return to their filtered results—just like browsing a regular website.
+
+- You can copy and share the page link, and others will see the exact same filtered view
+- Saved URLs can act like bookmarks, helping users return to specific filtered searches anytime
+- The portal behaves more like modern apps, where your current view is always reflected in the URL
+
+**Minimal state usage**
+
+In web development, **"state"** is the information a page keeps track of while you’re using it—like which filters you’ve applied or what search terms you’ve entered.
+
+We’ve made sure that the search page in PortalJS Cloud only stores the _essential_ state. This means the system isn’t overloaded with unnecessary data, making everything simpler and faster behind the scenes.
+
+**What this means for the user:**
+
+- Pages load faster
+- Filters respond instantly
+- The portal is more stable—even with large datasets
+- Less chance of bugs or crashes
+
+**Faster and more reliable behind-the-scenes logic with React Context (no more prop-drilling)**
+
+Previously, when different parts of a web page needed to "talk" to each other (for example, when a filter affected the search results), the data had to be passed through multiple layers—like a game of telephone. This process is called **prop-drilling**, and it can get messy and hard to manage.
+
+Now, thanks to improved architecture (using something called [**React Context**](https://react.dev/learn/passing-data-deeply-with-context)), all search filters and components stay in sync automatically—without needing to repeat the same logic in multiple places. Think of it like everyone checking the same live dashboard instead of passing sticky notes around.
+
+**What this means for the user:**
+
+- The search page is easier to maintain, faster to load, and more robust
+- All filters, search bars, and results stay perfectly in sync
+- No lag, no glitches—just smooth, instant updates without reloading the page. The technology behind the scenes is optimized to deliver results quickly, even on slower internet connections.
+- New features and filters can be added quickly without breaking anything
+
+These upgrades make it easier for users to find the data they need—and to share it with others.
+
+![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image8.webp)
+
+### **Better Data Visualizations 📊**
+
+We’ve significantly improved the CSV preview component to make exploring data easier, more accessible, and more interactive.
+
+**Accessibility-First Design**
+
+The preview is now fully compliant with **WCAG 2.1 / 2.2 standards**, meaning it works smoothly with **keyboard navigation** and **screen readers**. Users can tab through rows and columns or use assistive technologies to understand and interact with the data.
+
+**New Interactive Features**
+
+We’ve added powerful new tools to help users make sense of large tables:
+
+- **Search within the table** – Instantly find specific columns or values.  
+   _Example: type “GDP” and jump straight to that column or row._
+- **Column selector** – Choose which columns to show or hide.  
+   _Great for reducing clutter when working with wide datasets._
+- **Pagination control** – Browse large datasets more easily, page by page.
+- **Export to JSON** – Download the data in developer-friendly format for further analysis or integration.
+
+![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image5.gif)
+
+### **Form & Filter Accessibility**
+
+We’ve upgraded all form and filter components to be fully accessible (see Accessibility improvements screenshot above).
+
+- **Accessible labels** – Every input field, dropdown, and button now has a proper label that screen readers can detect and announce.
+- **Live filter updates** – When a user applies a filter, screen readers now receive real-time feedback about the change.  
+   _For example, “3 datasets found for your selection” is announced automatically._
+
+**What this means for the user:**
+
+- People using screen readers or keyboard navigation can interact with forms just as smoothly as others
+- Everyone can confidently use filters and forms, knowing exactly what’s happening on the page
+- Your data portal is more inclusive, user-friendly, and aligned with accessibility best practices
+
+**Visual & Semantic Structure**
+
+Beyond visual design, we’ve made deeper improvements to the way the site is structured under the hood (see Accessibility improvements screenshot above).
+
+- **Verified color contrast** – All UI elements now meet recommended contrast ratios, ensuring readability for users with low vision or color blindness.
+- **Semantic HTML and ARIA roles** – We’ve reorganized the site structure using proper tags (like headers, sections, and landmarks), and added ARIA roles to give screen readers clear context and navigation cues.
+
+**What this means for the user:**
+
+- Text and buttons are easier to read in all lighting conditions
+- Assistive technologies can “understand” the layout and flow of each page
+- The portal feels more predictable and intuitive for everyone, including users with disabilities
+
+### **Easy Customization, Delivered Fast**
+
+Want to match your data portal to your brand’s color and logo? No problem. We’ve made it incredibly simple for our developers to update key visual elements like:
+
+- **Main template color** – Choose a color that fits your brand
+- **Portal logo** – Upload your organization’s logo in seconds
+
+These changes are configured via `.env` variable:
+
+`NEXT_PUBLIC_THEME_COLOR` and `NEXT_PUBLIC_PORTAL_LOGO`
+
+For example:
+
+```shell
+NEXT_PUBLIC_THEME_COLOR=#8847cd
+NEXT_PUBLIC_PORTAL_LOGO=/images/logos/purple.jpg
+```
+
+**What this means for you:**  
+If you need a color or logo update, we can make the change and deploy it almost instantly—no long wait times, no messy custom coding. Because we’ve built it smart from the start.
+
+![](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image1.webp)
+
+### **Why Did We Change It?**
+
+- The old template had some outdated design elements and usability gaps.
+- We wanted to ensure first-time users have a smooth experience setting up their portal.
+- Aligning with modern web standards makes the portal more maintainable and professional.
+- Compliance with accessibility standards was a priority (more on that in our [accessibility article](https://docs.google.com/document/d/1nOBBnGbvPot30MAGonG7dOBxkXWSavVNmEb2o9ZzLBw/edit?tab=t.0#heading=h.1rkstvo96k3f)).
+
+### **Why We Redesigned PortalJS Cloud**
+
+We didn’t just give PortalJS Cloud a facelift—we rebuilt it with purpose.
+
+The previous design, while functional, had limitations. Some visual elements felt outdated, and usability gaps made it harder for new users to get started quickly.
+
+So we took a step back and asked: _What does a modern data portal need in 2025?_
+
+The answer was clear:
+
+- A **clean, intuitive interface** that welcomes first-time users
+- **Streamlined performance** across all devices
+- **Built-in accessibility**, ensuring everyone can navigate and explore data
+- A **future-proof foundation** that aligns with today’s web standards—and tomorrow’s
+
+You can read a bit more about why compliance with accessibility standards were a priority in our [accessibility article.](https://www.portaljs.com/blog/making-portalJS-cloud-admin-panel-accessible)
+
+This redesign is about helping governments, non-profits, researchers, and companies launch professional, user-friendly data portals—faster and more efficiently than ever before.
+
+👉 [**Try the new PortalJS Cloud today with a free 14-day trial**](https://cloud.portaljs.com/dashboard)—no credit card required. Experience the new look, lightning-fast performance, and modern accessibility, all in minutes.
+
+---
+
+### **Before & After Comparison**
+
+![Homepage before](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image10.webp)
+_Homepage before_
+
+![Homepage after](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image11.webp)
+_Homepage after_
+
+![Search page before](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image12.webp)
+_Search page before_
+
+![Search page after](/static/img/blog/2025-04-01-the-new-look-of-portaljs-cloud/image13.webp)
+_Search page after_
+
+---
+]]></description><link>https://portaljs.com/blog/the-new-look-of-portaljs-cloud</link><guid isPermaLink="false">https://portaljs.com/blog/the-new-look-of-portaljs-cloud</guid><dc:creator><![CDATA[williamlima]]></dc:creator><pubDate>Tue, 01 Apr 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to Reduce Data Portal Costs by 90% or More]]></title><description><![CDATA[
+What if the key to smarter, more transparent governance wasn’t spending more—but spending less? Too often, data portals are seen as unavoidable financial burdens, rather than an opportunity. But they don’t have to be. Your data portal can be a cornerstone of transparency, innovation, and better decision-making without draining your budget.
+
+Proprietary solutions, while promising the world, often deliver a painful bill. Hidden fees, rigid systems, and vendor lock-in quietly inflate costs while limiting your ability to adapt. And for what? A tool that’s supposed to serve your organization ends up as a line item that’s tough to justify.
+
+But what if it didn’t have to be this way? What if you could cut your data portal expenses by 90%—or more—every year **without compromising on performance, compliance, or scalability**? It’s not just a possibility; it’s a practical reality. Let’s break down where your money is going, and how a smarter approach can turn your data portal from a financial burden into a strategic asset.
+
+## Where Do the Costs Come From?
+
+If you’ve ever stared at a bloated invoice from a data portal vendor, you’ve probably wondered: Where is all this money going? Here’s what you’re often paying for:
+
+1. **Licensing Fees**: Proprietary solutions can charge six or even seven figures annually. And guess what? Those fees only grow as your data needs increase.
+
+2. **Customization Costs**: Need your portal to match your organization’s branding or workflows? Many platforms charge extra for every tweak.
+
+3. **Maintenance & Hosting**: Whether it’s managing servers, ensuring uptime, or resolving bugs, these costs add up fast.
+
+4. **Training & Support**: Onboarding your team often comes at an additional cost, and premium support packages can be staggeringly expensive.
+
+When you add it all up, it’s no wonder small towns, mid-sized cities, and even large governments struggle to justify the expense. But it doesn’t have to be this way.
+
+## The Open Source Alternative: Why CKAN Is the Gold Standard
+
+CKAN, the open-source data portal solution has become the gold standard for governments, NGOs, and research institutions. Unlike proprietary systems, CKAN is free to use, infinitely customizable, and backed by a global community of developers. But—and this is a big one—while CKAN saves you licensing fees, it doesn’t eliminate all costs. You still need hosting, maintenance, and a user-friendly frontend to make it work for your audience.
+
+That’s where solutions like **PortalJS Cloud** come into play. By combining CKAN’s power with modern, fully managed hosting and customizable frontends, you get the best of both worlds: open-source affordability and enterprise-grade performance.
+
+## How PortalJS Cloud Helps You Save
+
+Let’s break down exactly how PortalJS Cloud can help you trim 90% (or more) from your annual data portal expenses.
+
+1. No Licensing Fees
+Most proprietary platforms lock you into expensive annual contracts. PortalJS Cloud? None of that. Since it’s built on CKAN, you’re free from those hefty licensing costs. You’re essentially only paying for the hosting and support you need—not for the privilege of using the platform.
+
+2. Streamlined Maintenance & Hosting
+Maintaining your own CKAN instance can be time-consuming and expensive, especially if you’re not a tech-heavy organization. PortalJS Cloud offers fully managed hosting, which means we handle the backend, updates, and troubleshooting for you. That’s one less thing for your IT team to worry about (or for you to outsource).
+
+3. Scalable Pricing
+Instead of a one-size-fits-all model, PortalJS Cloud scales to meet your needs. For small towns with limited budgets, plans start at just $99/month. Larger governments can choose plans with advanced features while still saving massively compared to proprietary options.
+
+4. Customizable Frontend Without Extra Fees
+Proprietary platforms often charge an arm and a leg for customization. PortalJS Cloud lets you tailor your data portal’s design and functionality without breaking the bank. Want your portal to reflect your city’s branding? Done. Need specific features for public-facing users? No problem.
+
+5. Faster Deployment, Lower Costs
+Some systems take months to set up, driving up costs with each passing day. PortalJS Cloud offers 5-minute deployment for basic configurations, so you can start sharing data (and seeing value) almost immediately.
+
+## A Quick Comparison: PortalJS Cloud vs. Proprietary Solutions
+
+
+| Feature             | Proprietary Solutions | PortalJS Cloud     |
+|---------------------|-----------------------|--------------------|
+| Annual Cost         | $100,000+             | Starting at $1,188 |
+| Customization Fees  | High                  | Included           |
+| Vendor Lock-In      | Yes                   | No                 |
+| Compliance Standards| Yes                   | Yes                |
+| Deployment Time     | Months                | Minutes            |
+
+## A Closer Look at Value
+
+When you’re not tied to a vendor’s roadmap or locked into their support contracts, you’re free to build the portal your community actually needs. Whether it’s improving data accessibility, expanding transparency efforts, or aligning your data strategy with your long-term goals, the shift to a smarter, more flexible solution creates space for meaningful progress.
+
+## More Than Savings: Future-Proofing Your Data Portal
+
+It’s not just about saving money. It’s about investing in a system that grows with you. PortalJS Cloud combines CKAN’s open-source foundation with modern architecture, ensuring your portal is scalable, adaptable, and built to last. Compliance with standards like WCAG 2.1 AA and DCAT ensures accessibility and interoperability, while features like automated updates and robust APIs simplify your workflow.
+
+Whether you’re managing a small-town transparency initiative or a large-scale federal data program, the combination of CKAN’s open-source foundation and PortalJS’s modern capabilities ensures your portal stays fast, flexible, and future-ready.
+
+By stepping away from rigid, high-cost systems, you regain control over your portal’s direction. This isn’t just a cost decision; it’s a strategic one.
+
+## Get Started Today
+
+Your data portal doesn’t need to be a burden. With PortalJS Cloud, you can achieve a balance between affordability, functionality, and long-term viability.
+
+Ready to cut your data portal costs by 90% (or more)? With PortalJS Cloud, you get the affordability of open source with the reliability of a fully managed platform.
+
+💡 **[Start Your Free Trial](https://portaljs.com/pricing)** today and see how easy and cost-effective your data portal can be. Or, if you’d prefer a closer look, **schedule a demo** with our team. ]]></description><link>https://portaljs.com/blog/how-to-reduce-data-portal-costs-by-90-percent</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-reduce-data-portal-costs-by-90-percent</guid><dc:creator><![CDATA[Yoana Popova]]></dc:creator><pubDate>Fri, 14 Mar 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Enhancing CKAN Resource Uploads via API with Cloudflare R2, Workers, and Queues.]]></title><description><![CDATA[
+### Introduction
+CKAN, a powerful open-source data management system, traditionally stores only metadata about uploaded resources, leaving file storage to external solutions. In our implementation, we used Cloudflare R2 for resource storage, enabling users to upload assets either through a frontend application.
+
+However, we lacked an API-based approach for users to upload files directly. This blog details how we solved this limitation by introducing a new API endpoint for resource uploads and integrating Cloudflare R2 with CKAN using Cloudflare Workers, Queues, and Notifications to automate metadata updates.
+
+### Problem Statement
+By default, CKAN only stores metadata for resources, not the actual files. Users could:
+- Upload files through the frontend, which would generate and store the file URL in CKAN.
+- Provide an external URL directly via the UI or API.
+
+However, there was no provision for users to upload images through the API while ensuring seamless metadata association.
+
+### Solution Approach
+We tackled the issue in two steps:
+1. Enhancing CKAN API to support pre-signed URLs for uploads.
+2. Automating metadata linking after the upload using Cloudflare services.
+
+### Step 1: Modifying and Adding API Endpoints
+We introduced two key API improvements:
+- **`resource_upload` Endpoint**: Returns a pre-signed URL for an existing resource, allowing users to upload assets directly.
+- **Enhanced `resource_create` Endpoint**: Generates a pre-signed URL whenever a new resource is created, enabling direct uploads.
+
+#### Implementation:
+```python
+from ckanext.s3filestore.uploader import BaseS3Uploader
+from ckan.plugins.toolkit import get_action
+import ckan.plugins.toolkit as tk
+import ckan.logic as logic
+import logging
+
+ValidationError = logic.ValidationError
+log = logging.getLogger(__name__)
+
+def _generate_presigned_url(resource_id):
+    try:
+        uploader = BaseS3Uploader()
+        s3_client = uploader.get_s3_client()
+        bucket_name = uploader.bucket_name
+        object_key = f"resources/api_uploads/{resource_id}"
+
+        params = {'Bucket': bucket_name, 'Key': object_key}
+        presigned_url = s3_client.generate_presigned_url(
+            ClientMethod='put_object', Params=params, ExpiresIn=3600)
+
+        return presigned_url
+    except Exception as e:
+        log.error(f"Failed to generate presigned URL: {e}")
+        raise ValidationError({"error": f"Failed to generate presigned URL: {e}"})
+
+def resource_upload(context, data_dict):
+    resource_id = data_dict.get('id')
+    if not resource_id:
+        raise ValidationError({"id": "Resource ID is required to generate upload URL."})
+
+    get_action('resource_show')(context, {'id': resource_id})
+    presigned_url = _generate_presigned_url(resource_id)
+    return {"presigned_url": presigned_url}
+
+@tk.chained_action
+def resource_create(up_func, context, data_dict):
+    result = up_func(context, data_dict)
+    resource_id = result.get("id")
+    presigned_url = _generate_presigned_url(resource_id)
+    result["presigned_url"] = presigned_url
+    return result
+```
+This enhancement enables users to securely upload files via the API without needing to interact with the frontend.
+
+### Step 2: Automating Metadata Linking Using Cloudflare
+Once the file is uploaded, we need to link the uploaded file’s metadata with its CKAN resource entry. While the frontend seamlessly handles this by storing the file URL during resource creation, our API-based approach required an additional step to update metadata post-upload.
+
+To automate this process, we leveraged:
+- **Cloudflare R2 Event Notifications**
+- **Cloudflare Queues**
+- **Cloudflare Workers**
+
+#### Why Use These Cloudflare Features?
+- **Notifications**: Detect file uploads in real-time.
+- **Queues**: Buffer file upload events and handle them asynchronously.
+- **Workers**: Process queued events and update CKAN accordingly.
+
+#### Implementation
+##### Configuring R2 Event Notifications
+- Events triggered for objects in `resources/api_uploads/` on `PutObject`, `CopyObject`, and `CompleteMultipartUpload`.
+- Sends an event to the `r2-file-uploads` queue.
+
+##### Processing Events with Cloudflare Worker
+```javascript
+export default {
+  async queue(batch, env, ctx) {
+    for (const message of batch.messages) {
+      try {
+        let data = typeof message.body === "string" ? JSON.parse(message.body) : message.body;
+        console.log("Received R2 Event:", data);
+
+        const objectKey = data?.object?.key;
+        const resourceId = objectKey.replace("resources/api_uploads/", "");
+        const fileUrl = `https://blob.datopian.com/${objectKey}`;
+
+        console.log("Updating CKAN with URL:", fileUrl);
+
+        // Fetch metadata (Content-Type)
+        const metadataResponse = await fetch(fileUrl, { method: "HEAD" });
+        if (!metadataResponse.ok) continue;
+
+        const fileType = metadataResponse.headers.get("Content-Type") || "application/octet-stream";
+        console.log("Detected MIME Type:", fileType);
+
+        // Update CKAN resource metadata
+        const ckanApiUrl = "https://demo.dev.datopian.com/api/3/action/resource_update";
+        const ckanApiKey = env.CKAN_API_KEY;
+
+        const updatePayload = { id: resourceId, url: fileUrl, format: fileType };
+        const response = await fetch(ckanApiUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "Authorization": ckanApiKey },
+          body: JSON.stringify(updatePayload)
+        });
+
+        if (!response.ok) console.error("CKAN API Error:", await response.text());
+        else console.log("CKAN update successful!");
+      } catch (error) {
+        console.error("Error processing message:", error);
+      }
+    }
+  }
+};
+```
+The provided JavaScript code is a Cloudflare Worker that processes events from a Cloudflare Queue triggered by file uploads to Cloudflare R2 storage. Here's a brief explanation:
+
+1. **Event Processing**: The Worker listens for batch messages from the `r2-file-uploads` queue, which contains details about uploaded files.  
+
+2. **Extracting Metadata**: It extracts the uploaded file's key (path) and derives the `resourceId` from it.  
+
+3. **Fetching File Type**: It makes a `HEAD` request to the file URL to determine the MIME type.  
+
+4. **Updating CKAN**: It sends an API request to CKAN to update the resource metadata (file URL and format).  
+
+5. **Error Handling**: Logs errors if any step fails.  
+
+This automates linking uploaded files to CKAN resources, ensuring seamless metadata updates.
+
+### Future Possibilities
+This automation can be extended to other CKAN functionalities, such as:
+- Uploading organization or group images via API.
+- Supporting other cloud providers (AWS S3, Azure Blob Storage) using their event-driven tools like AWS Lambda and Azure Functions.
+
+### Example Integrations
+**AWS S3 → SNS + SQS + Lambda → CKAN API**
+- A file is uploaded to an S3 bucket.
+- An event notification triggers an SNS topic.
+- The SNS topic sends a message to an SQS queue.
+- A Lambda function reads the SQS message and updates the CKAN API with the file metadata.
+
+**Azure Blob → Event Grid + Functions → CKAN API**
+- A file is uploaded to an Azure Blob Storage container.
+- Event Grid detects the upload and triggers an Azure Function.
+- The Azure Function extracts metadata and updates the CKAN API accordingly.
+
+These platforms offer similar event-driven mechanisms, making it easy to integrate CKAN with different cloud providers.
+
+### Conclusion
+By integrating CKAN APIs with Cloudflare R2, Workers, and Queues, we successfully:
+- Enabled direct file uploads via API.
+- Automated the linking of uploaded files to CKAN resources.
+- Leveraged event-driven processing to ensure seamless user experience.
+
+This approach reduces API complexity for users while maintaining data consistency across systems. With similar integrations, CKAN can be extended to other cloud storage providers, enabling flexible and scalable data management.
+
+]]></description><link>https://portaljs.com/blog/ckan-resource-uploads-via-api</link><guid isPermaLink="false">https://portaljs.com/blog/ckan-resource-uploads-via-api</guid><dc:creator><![CDATA[shreyas]]></dc:creator><pubDate>Wed, 26 Feb 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Effortless User Management in PortalJS]]></title><description><![CDATA[
+
+>[!Key Takeaways]
+> PortalJS has made user management much smoother. Admins can now add existing users to organizations instantly by entering their email—no redundant invites, no errors. If the user isn’t in the system, the invite process works as usual. This update streamlines team management, reduces admin workload, and ensures a better onboarding experience.
+
+
+## PortalJS Now Supports Smoother User Management
+
+Managing users across multiple organizations should be simple, not a tedious task. Yet, until now, adding existing users to a new team in PortalJS required unnecessary steps, redundant invitations, and, at times, frustrating errors.
+ 
+The latest PortalJS user management update makes this process more intuitive. Now, admins can add existing users to an organization by simply entering their registered email in the Members tab. If the user already exists, the system assigns them instantly. No extra steps. No unnecessary complications. If not, the usual invite process applies. This ensures a smooth and efficient team management for data platforms. 
+
+## What’s Improved?
+
+Previously, the system would always attempt to create a new user when sending an invite, causing errors if the user was already registered. The update refines the `user_invite` function by:
+
+- Checking for existing users before sending an invite.
+- Assigning users instantly if they are already in the system.
+- Falling back to the traditional invite process only if necessary.
+- Improving error handling so issues with email invites don’t block the process.
+
+![Add user to organization](/images/blog/add-user.webp)
+
+These refinements remove friction, ensuring admins spend less time on user management and more time on their actual work.
+
+## A More Streamlined Onboarding Experience
+
+For businesses and organizations scaling their data portals with PortalJS, efficient user administration is critical. This update reduces administrative workload for PortalJS admins, allowing them to focus on managing data, not troubleshooting user invites.
+
+With these improved user management features in PortalJS, teams can collaborate more effectively, ensuring smooth workflows for data-driven organizations. 
+
+## Get Started with PortalJS Cloud Today
+
+Launch your Data portal in under 5 minutes with PortalJS Cloud—the fastest and simplest way to share, manage, and collaborate on data. No infrastructure setup, no complex configurations—just a streamlined solution for governments, non-profits, academics, and companies of all sizes.
+
+[Get started now](https://cloud.portaljs.com/) and bring your data to life effortlessly.]]></description><link>https://portaljs.com/blog/effortless-user-management-portaljs</link><guid isPermaLink="false">https://portaljs.com/blog/effortless-user-management-portaljs</guid><dc:creator><![CDATA[popovayoana]]></dc:creator><pubDate>Tue, 28 Jan 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Making PortalJS Cloud Admin Panel Accessible: The Digital Ramp Everyone Deserves]]></title><description><![CDATA[
+## The Need for Accessibility: Building a Digital City for All
+
+Imagine a city where half the streets have potholes so deep that some people can’t pass through. Where doors swing open only for those who fit a certain mold. Where street signs disappear when you look at them from a different angle. Sounds frustrating, right? That’s exactly how the web feels for millions of users when accessibility isn’t a priority.
+
+Accessibility isn’t a nice-to-have—it’s the foundation of a web that welcomes everyone. At PortalJS Cloud, we didn’t just tick compliance checkboxes; we built a digital ramp that ensures everyone gets through the front door.
+
+And we didn’t stop at the admin panel. Every **data portal built with PortalJS Cloud—in just five minutes—is fully WCAG-compliant.** Because accessibility isn’t a checkbox—it’s a mindset woven into everything we build.
+
+## WCAG 2.1 vs. WCAG 2.2: The Blueprint for Digital Inclusion
+
+Think of WCAG (Web Content Accessibility Guidelines) as an evolving map for a fairer internet.
+
+- **WCAG 2.1 (2018)** was like upgrading a city’s infrastructure to accommodate more people—introducing smoother sidewalks, better-lit streets, and accessible public transport for those with diverse needs.
+- **WCAG 2.2 (2023)** took it further by fine-tuning details that improve usability for people with cognitive disabilities and motor impairments. Think of it as adjusting traffic lights, widening sidewalks, and ensuring door handles work for everyone.
+
+## The Journey to an Accessible Admin Panel
+### **1. Auditing and Identifying Issues: Finding the Potholes**
+
+Before fixing anything, we needed to see where the cracks were. Using industry-standard tools like [WAVE](https://wave.webaim.org/), [axe DevTools](https://www.deque.com/axe/), and [Lighthouse](https://developer.chrome.com/docs/lighthouse/accessibility/), we ran a full audit. Every missing label, poor contrast ratio, and keyboard trap was a pothole we needed to fill.
+
+![Lighthouse accessibility check image](/images/blog/lighthouse.png)
+
+### **2. Keyboard Navigation: Every Click Should Have a Clear Path**
+
+For some users, a mouse is as useful as a submarine in a desert. They navigate using keyboards, screen readers, or voice commands. So we made sure that:
+
+- Every button, link, and form could be reached using only a keyboard. 
+![Keyboard navigation image](/images/blog/keyboard-navigation-1.png)
+- A clear visual focus was added to show users where they were on the page.
+- We built skip navigation links, the express lanes of web browsing, allowing users to jump straight to important sections.
+  <img src="/images/blog/keyboard-navigation-2.png" alt="Keyboard navigation image" width="200"/>
+- All interactive elements were designed with a minimum target size of 24x24 pixels, ensuring ease of use for users with motor impairments.
+
+### **3. Fixing Forms: Because Guesswork Shouldn’t Be a Requirement**
+
+Forms are the bureaucratic paperwork of the web. Done wrong, they become a maze. Done right, they feel like a conversation. We ensured that:
+
+- Every form field had clear labels and instructions.
+- Error messages were descriptive and polite, guiding users instead of scolding them.
+- Focus didn’t disappear like a magician’s trick—it stayed predictable and logical.
+- Error prevention mechanisms were implemented for sensitive data entries, giving users confirmation prompts or undo options.
+  ![Error message image](/images/blog/error-message-1.png)
+  <img src="/images/blog/error-message-2.png" alt="Error message image" width="400"/>
+
+### **4. Color Contrast: Making Text Stand Out Like a Lighthouse**
+
+Imagine reading a book where the ink is only a shade darker than the page. That’s what poor color contrast feels like. We ensured that:
+
+- Text and interactive elements had a minimum contrast ratio of 4.5:1, making them readable in all lighting conditions.
+- Alternative visual indicators (icons, underlines, patterns) helped those with color blindness navigate effortlessly.
+  ![Colour contrast image](/images/blog/color-contrast.png)
+
+### **5. Using Semantic HTML and ARIA Roles: Speaking a Universal Language**
+
+Screen readers rely on structure. If a webpage isn’t built with **semantic HTML**, it’s like trying to read a scrambled recipe. We:
+
+- Used semantic HTML to ensure that screen readers understood the page structure.
+- Added ARIA roles and attributes so users with assistive tech could grasp the purpose of each section.
+- Ensured consistent navigation elements throughout the admin panel to maintain familiarity for users.
+  <img src="/images/blog/aria-labels.png" alt="Aria labels image" width="300"/>
+
+### **6. Testing with Real Users: Because Theory is Nothing Without Practice**
+
+Automated audits are useful, but they don’t catch everything. So we tested the admin panel with:
+
+- Screen readers (NVDA, JAWS, VoiceOver) to ensure content made sense.
+- Keyboard-only navigation to confirm smooth interactions.
+- Real users with disabilities, because lived experience trumps theory every time.
+
+## Why Accessibility is a Competitive Advantage
+
+This isn’t just about being compliant—it’s about creating an exceptional product. Here’s why accessibility matters:
+
+- **Inclusivity is Innovation** — The best designs work for everyone. Curb cuts, originally made for wheelchair users, are now a blessing for cyclists and parents with strollers. Digital accessibility follows the same rule.
+- **SEO Rewards Accessibility** — Search engines love structured, accessible content. Fixing accessibility often improves rankings.
+- **Legal Risks are Real** — Many companies have faced lawsuits for failing to meet accessibility standards. Avoiding them is smart business.
+- **Better UX for Everyone** — Accessibility improvements make life easier for **all** users—whether they’re on mobile, in a rush, or in a low-bandwidth area.
+
+## Accessibility Beyond the Admin Panel: A Fully Compliant Data Portal
+
+Accessibility isn’t a feature—it’s the foundation. That’s why **every data portal built with PortalJS Cloud is fully WCAG-compliant right out of the box**. In just five minutes, users can deploy a portal that:
+
+- **Provides seamless screen reader support**, ensuring datasets are easily navigable.
+- **Offers fully accessible data preview tables**, making data exploration effortless for everyone.
+- **Maintains optimized color contrast and keyboard accessibility**, enhancing usability across all devices.
+- **Eliminates mandatory dragging movements**, allowing users to interact without precision-based gestures.
+
+In an upcoming article, we’ll dive deeper into how we designed our out-of-the-box data portal templates to be fully WCAG-compliant, ensuring that accessibility is baked into every dataset preview, every UI element, and every interaction.
+
+## Accessibility is a Journey, Not a Destination
+
+Making the PortalJS Cloud Admin Panel accessible wasn’t a one-and-done project. It’s an ongoing commitment—like maintaining roads, updating maps, and making sure everyone can move freely in our digital city.
+
+The internet is a vast landscape, but we get to decide what kind of world we build. At PortalJS, we’re choosing one where **everyone** has a way in.
+
+Want to make your product accessible? Start with the [official WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) and build a web that works for all.
+]]></description><link>https://portaljs.com/blog/making-portalJS-cloud-admin-panel-accessible</link><guid isPermaLink="false">https://portaljs.com/blog/making-portalJS-cloud-admin-panel-accessible</guid><dc:creator><![CDATA[popovayoana]]></dc:creator><pubDate>Sun, 26 Jan 2025 00:00:00 GMT</pubDate></item><item><title><![CDATA[Why PortalJS is the Future of Decoupled Frontend for Data Portals]]></title><description><![CDATA[
+## Introduction
+
+In the world of (open) data portals, a seamless, fast, and scalable frontend is crucial for delivering a great user experience. As the amount of data grows and user interactions become more complex, traditional monolithic frontends can become bottlenecks. This is especially true for platforms like CKAN, where the default frontend, built with Flask, can struggle to handle the demands of modern data-rich applications.
+
+This is where **PortalJS** comes in—a modern, decoupled frontend framework designed specifically for data portals. Built on top of **NextJS**, it brings the latest in web performance optimization to the world of open data. Unlike CKAN’s built-in frontend, PortalJS enables faster load times, more efficient use of APIs, and a far more flexible development environment.
+
+One of the key features that sets PortalJS apart is its ability to leverage **NextJS’s rendering strategies**, such as **Static Site Generation (SSG)**, **Server-Side Rendering (SSR)**, and **Incremental Static Regeneration (ISR)**. These techniques ensure that your data portal isn’t just faster but also scales more easily, reducing the load on your CKAN APIs and databases.
+
+In this post, we’ll explore how PortalJS transforms the frontend experience for data portals, compare it to CKAN’s traditional frontend, and dive into why features like ISR and SSG make a significant difference in performance and scalability.
+
+## Leveraging NextJS for Better Performance
+
+When it comes to performance, PortalJS, powered by NextJS, has a significant advantage. One of the key features NextJS brings to the table is its Incremental Static Regeneration (ISR) strategy. ISR allows for the generation of static pages on-demand, which means pages are pre-rendered once and then updated in the background, keeping the load on APIs and databases low. 
+
+This is a game-changer for data portals, especially those powered by CKAN, where the Flask-based frontend often regenerates pages dynamically. ISR, in contrast, helps keep pages static until necessary updates are made, making the whole system much more efficient. You get the best of both worlds: the speed of static pages and the freshness of dynamic content.
+
+But NextJS also offers other approaches like Static Site Generation (SSG) and Server-Side Rendering (SSR), which can be applied based on the specific needs of your data portal.
+
+### SSG for Static Content
+
+A perfect example of where **SSG** shines in CKAN is on its homepage. Most of the content on the homepage remains static—the structure, layout, and majority of the information doesn’t change often. While some sections, such as the “latest datasets” or statistics about the number of datasets, organizations, and groups, might be dynamic, these can be handled separately (for example, by re-fetching the dynamic parts on the client side).
+
+By building the CKAN homepage using **SSG**, you can ensure the page loads super fast, since it’s served as pre-generated static HTML, reducing load on the API and databases.
+
+### SSG for Dataset Metadata
+
+Another excellent use case for SSG is dataset metadata pages. In many data portals, dataset metadata—such as the title, description, tags, authors, and sources—are generally created once and remain unchanged. This makes it a great candidate for **SSG**. Pre-building these pages means they’ll load instantly, without the need for the backend to dynamically generate them with each request. This results in faster page loads and an overall smoother user experience.
+
+By using a combination of these strategies, PortalJS can dramatically reduce latency, improve SEO, and ensure that your data portal is scalable without overwhelming CKAN's APIs or databases.
+
+## Improved User Experience
+
+User experience is at the heart of any successful web application, and data portals are no exception. The way users interact with data—whether they’re browsing datasets, filtering through complex metadata, or simply exploring the portal’s interface—directly affects how useful and engaging the platform becomes.
+
+### Faster Page Loads
+
+One of the biggest frustrations users face with data portals is slow loading times, especially when the portal is packed with large datasets. CKAN’s Flask-based frontend typically relies on dynamic page generation, which can slow things down as each request hits the server and database.
+
+PortalJS, by contrast, can take advantage of Static Site Generation (SSG) and Incremental Static Regeneration (ISR) to pre-build pages and serve them instantly. The result? Faster load times, snappier navigation, and a much smoother experience for users.
+
+### Modern UI/UX Design
+
+With PortalJS, the frontend is decoupled from the backend, giving developers the freedom to craft highly customized user interfaces. You’re no longer restricted by the more rigid CKAN frontend, which can sometimes feel difficult to modify without diving into Python application, Docker set up and dealing with Apache Solr, Postgresql etc.
+
+PortalJS allows developers to integrate modern UI libraries, such as React components, Tailwind CSS, or Material UI, providing a much more polished, user-friendly design. This flexibility lets you create intuitive navigation, visually appealing layouts, and even responsive features that make the portal easier to use across devices.
+
+### Seamless Client-Side Interactions
+
+Another major benefit of PortalJS is its ability to handle client-side interactions more effectively. Using dynamic rendering capabilities, features like filtering datasets, sorting results, and searching for content can all be done without constantly reloading the page or hitting the backend server.
+
+This not only improves performance but also creates a more seamless user experience. With CKAN’s built-in frontend, interactions like these often require a round trip to the server, resulting in slower response times and more friction for users.
+
+## Scalability & Modularity
+
+Scalability is a critical factor for data portals, especially when handling large datasets and growing user bases. With **PortalJS**, scaling your application becomes far more straightforward and cost-efficient compared to CKAN’s traditional monolithic frontend, which relies heavily on server-side resources.
+
+### Scaling Without a Server
+
+One of the most significant advantages of PortalJS is its ability to serve most of your pages statically, without requiring a dedicated server. Thanks to **Static Site Generation (SSG)**, many pages can be pre-built and then served from a simple object storage solution, such as **Cloudflare R2** or **AWS S3**. This not only reduces infrastructure costs but also dramatically improves the app’s ability to scale since you’re offloading traffic to globally distributed storage networks (CDNs), which are optimized for delivering static assets.
+
+For dynamic content that still requires server-side logic, **serverless functions** come into play. Pages that need to be generated on the fly can be handled by, for example, **AWS Lambda** functions, eliminating the need for traditional server infrastructure. By leveraging serverless architecture, you only pay for what you use, and scaling becomes seamless since cloud providers automatically manage resource allocation.
+
+### Common Deployment Platforms
+
+PortalJS applications are often deployed using modern hosting platforms like **Vercel** and **Netlify**, which make it incredibly easy to scale without the complexities of managing servers. These platforms are built to handle dynamic content using **Incremental Static Regeneration (ISR)** and support serverless functions to process on-demand requests. Additionally, **Cloudflare** has started supporting **server-side rendering** for PortalJS apps, giving developers even more options to balance static and dynamic content delivery.
+
+### Scaling on Vercel vs Hosting CKAN on AWS/GCP
+
+Now, let’s compare what it means to scale an app on Vercel versus hosting CKAN’s Python-based Flask application on traditional cloud services like **AWS** or **GCP** or **Azure**. When deploying a CKAN instance, you’re dealing with a monolithic application that requires dedicated servers or virtual machines. You must manage uptime, load balancing, and scaling on your own. If traffic spikes, the infrastructure needs to scale vertically or horizontally, often leading to increased complexity and higher costs.
+
+With **Vercel** (or platforms like **Netlify** or **Cloudflare Pages**), PortalJS handles scaling automatically. Static pages can be served globally via CDNs, and serverless functions take care of dynamic requests. You don’t have to worry about managing backend infrastructure—scaling is built into the platform, and your app adapts to changes in traffic without additional manual configuration.
+
+## Developer Experience
+
+A great developer experience (DX) is essential for productivity, especially in fast-paced environments where engineers need to iterate quickly. When it comes to building data portals, **PortalJS** dramatically simplifies the development workflow compared to CKAN’s traditional frontend setup.
+
+### Modern Development Stack
+
+Frontend engineers typically prefer working with a modern JavaScript stack, which includes tools like **React**, **NextJS** and **TailwindCSS** (or other modern CSS frameworks). These technologies are widely adopted, well-documented, and come with robust community support. However, developing with CKAN’s Flask-based frontend can feel much more cumbersome.
+
+To start working on CKAN’s default frontend, developers need to spin up Docker containers with services like **PostgreSQL**, **Apache Solr**, **Redis**, and CKAN (Python app) itself. This setup can take up a lot of storage on the developer's machine, especially when you need multiple CKAN instances for different projects. All these moving parts not only slow down the setup process but also increase the chances of running into configuration issues.
+
+With **PortalJS**, the workflow is refreshingly simple. Frontend engineers can clone a project and start development with just two commands:
+
+* npm install  
+* npm start
+
+That’s it. In a matter of minutes, developers have a fully functional local environment running, without the need to worry about databases, search engines, or caching systems.
+
+### Efficient Development with Hot Reloading
+
+Another significant advantage of PortalJS is its support for **hot reloading**. As soon as you make changes to your code, the browser automatically refreshes to reflect those updates, creating an instant feedback loop. This drastically improves productivity, allowing developers to see their changes in real-time without having to restart services or manually refresh the page.
+
+CKAN does have hot reloading through its Flask development server, which reloads the application when changes are detected. However, the experience may not be as smooth or fast as the hot reloading tools available in modern JavaScript frameworks like NextJS and React. Flask’s hot reloading works well for small changes but might slow down significantly in larger applications, especially if you’re dealing with Docker setups and various integrated services (like PostgreSQL, Solr, and Redis).
+
+### Simplified Multi-Project Development
+
+When handling multiple CKAN projects, spinning up individual instances for each one can be a heavy burden on your machine. Each CKAN instance requires its own PostgreSQL database, Solr service, and sometimes even Redis, making it a storage and resource hog. In contrast, PortalJS decouples the frontend entirely from CKAN’s backend. You can easily create and switch between different projects with minimal overhead, saving both time and disk space.
+
+By offloading backend complexity and streamlining the frontend, PortalJS enables a smoother, faster, and more enjoyable development experience for engineers, helping them focus on building beautiful interfaces instead of wrestling with infrastructure.
+
+## Conclusion
+
+In the evolving landscape of data portals, delivering an exceptional user experience while ensuring scalability and ease of development is crucial. The **PortalJS** framework, built on the powerful **NextJS**, offers a modern solution that addresses the limitations of CKAN's traditional frontend.
+
+Ultimately, choosing PortalJS as a decoupled frontend engine for data portals allows organizations to harness the best of both worlds—robust, high-performing applications that are easy to develop, scale, and maintain. By embracing this innovative approach, data portals can not only meet the demands of today but also adapt to the challenges of tomorrow.
+]]></description><link>https://portaljs.com/blog/why-portaljs-is-the-future-of-decoupled-frontend-for-data-portals</link><guid isPermaLink="false">https://portaljs.com/blog/why-portaljs-is-the-future-of-decoupled-frontend-for-data-portals</guid><dc:creator><![CDATA[Anuar Ustayev]]></dc:creator><pubDate>Fri, 06 Dec 2024 00:00:00 GMT</pubDate></item><item><title><![CDATA[The OpenSpending Revamp: Behind the Scenes]]></title><description><![CDATA[
+_This post was originally published on [the Datopian blog](http://datopian.com/blog/the-open-spending-revamp-behind-the-scenes)._
+
+In our last article, we explored [the Open Spending revamp](https://www.datopian.com/blog/the-open-spending-revamp). Now, let's dive into the tech stack that makes it tick. We'll unpack how PortalJS, Cloudflare R2, Frictionless Data Packages, and Octokit come together to power this next-level data portal. From our Javascript framework PortalJS, that shapes the user experience, to Cloudflare R2, the robust storage solution that secures the data, we'll examine how each piece of technology contributes to the bigger picture. We'll also delve into the roles of Frictionless Data Packages for metadata management and Octokit for automating dataset metadata retrieval. Read on for the inside scoop!
+
+## The Core: PortalJS
+
+At the core of the revamped OpenSpending website is [PortalJS](https://portaljs.org), a JavaScript library that's a game-changer in building powerful data portals with data visualizations. What makes it so special? Well, it's packed with reusable React components that make our lives - and yours - a whole lot easier. Take, for example, our sleek CSV previews; they're brought to life by PortalJS' [FlatUI Component](https://storybook.portaljs.org/?path=/story/components-flatuitable--from-url). It helps transform raw numbers into visuals that you can easily understand and use. Curious to know more? Check out the [official PortalJS website](https://portaljs.org).
+
+![Data visualization](/static/img/blog/2023-10-13-the-open-spending-revamp-behind-the-scenes/data-visualization.png)
+
+## Metadata: Frictionless Data Packages
+
+Storing metadata might seem like a backstage operation, but it is pivotal. We chose Frictionless Data Packages, housed in the `os-data` GitHub organization as repositories, to serve this purpose. Frictionless Data Packages offer a simple but powerful format for cataloging and packaging a collection of data - in our scenario, that's primarily tabular data. These aren't merely storage bins - they align with FAIR principles, ensuring that the data is easily Findable, Accessible, Interoperable, and Reusable. This alignment positions them as an ideal solution for publishing datasets designed to be both openly accessible and highly usable. Learn more from their [official documentation](https://framework.frictionlessdata.io/).
+
+## The Link: Octokit
+
+Can you imagine having to manually gather metadata for each dataset from multiple GitHub repositories? Sounds tedious, right? That’s why we used Octokit, a GitHub API client for Node.js. This tool takes care of the heavy lifting, automating the metadata retrieval process for us. If you're intrigued by Octokit's capabilities, you can discover more in its [GitHub repository](https://github.com/octokit/octokit.js). To explore the datasets we've been working on, take a look at [OpenSpending Datasets](https://github.com/os-data).
+
+## Storage: Cloudflare R2
+
+When it comes to data storage, Cloudflare R2 emerges as our choice, defined by its blend of speed and reliability. This service empowers developers to securely store large amounts of blob data without the costly egress bandwidth fees associated with typical cloud storage services. For a comprehensive understanding of Cloudflare R2, their [blog post](https://cloudflare.net/news/news-details/2021/Cloudflare-Announces-R2-Storage-Rapid-and-Reliable-S3-Compatible-Object-Storage-Designed-for-the-Edge/default.aspx) serves as an excellent resource.
+
+## In Closing
+
+In closing, we invite you to explore the architecture and code that power this project. It's all openly accessible in our [GitHub repository](https://github.com/datopian/portaljs/tree/main/examples/openspending). Should you want to experience the end result firsthand, feel free to visit [openspending.org](https://www.openspending.org/). If you encounter any issues or have suggestions to improve the project, we welcome your contributions via our [GitHub issues page](https://github.com/datopian/portaljs/issues). For real-time assistance and to engage with our community, don't hesitate to join our [Discord Channel](https://discord.com/invite/EeyfGrGu4U). Thank you for taking the time to read about our work! We look forward to fostering a collaborative environment where knowledge is freely shared and continually enriched. ♥️
+
+![FlatUiTable Code Snippet](/static/img/blog/2023-10-13-the-open-spending-revamp-behind-the-scenes/code-example.png)
+]]></description><link>https://portaljs.com/blog/the-open-spending-revamp-behind-the-scenes</link><guid isPermaLink="false">https://portaljs.com/blog/the-open-spending-revamp-behind-the-scenes</guid><dc:creator><![CDATA[Luccas Mateus]]></dc:creator><pubDate>Fri, 13 Oct 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Announcing MarkdownDB: an open source tool to create an SQL API to your markdown files! 🚀]]></title><description><![CDATA[
+Hello, dear readers!
+
+We're excited to announce the official launch of MarkdownDB, an open source library to transform markdown content into sql-queryable data. Get a rich SQL API to your markdown files in seconds and build rich markdown-powered sites easily and reliably.
+
+We've also created a new dedicated website:
+
+https://markdowndb.com/
+
+## 🔍 What is MarkdownDB?
+
+MarkdownDB transforms your Markdown content into a queryable, lightweight SQLite database. Imagine being able to treat your collection of markdown files like entries in a database! Ever thought about fetching documents with specific tags or created in the past week? Or, say, pulling up all tasks across documents marked with the "⏭️" emoji? With MarkdownDB, all of this (and more) is not just possible, but a breeze.
+
+## 🌟 Features
+
+- Rich metadata extracted including frontmatter, links and more.
+- Lightweight and fast indexing 1000s of files in seconds.
+- Open source and extensible via plugin system.
+
+## 🚀 How it works
+
+### You have a folder of markdown content
+
+For example, your blog posts. Each file can have a YAML frontmatter header with metadata like title, date, tags, etc.
+
+```md
+---
+title: My first blog post
+date: 2021-01-01
+tags: [a, b, c]
+author: John Doe
+---
+
+# My first blog post
+
+This is my first blog post.
+I'm using MarkdownDB to manage my blog posts.
+```
+
+### Index the files with MarkdownDB
+
+Use the npm `mddb` package to index Markdown files into an SQLite database. This will create a `markdown.db` file in the current directory.
+
+```bash
+# npx mddb <path-to-folder-with-your-md-files>
+npx mddb ./blog
+```
+
+### Query your files with SQL...
+
+E.g. get all the files with with tag `a`.
+
+```sql
+SELECT files.*
+FROM files
+INNER JOIN file_tags ON files._id = file_tags.file
+WHERE file_tags.tag = 'a'
+```
+
+### ...or using MarkdownDB Node.js API in a framework of your choice!
+
+Use our Node API to query your data for your blog, wiki, docs, digital garden, or anything you want!
+
+E.g. here is an example of a Next.js page:
+
+```js
+// @/pages/blog/index.js
+import React from 'react';
+import clientPromise from '@/lib/mddb.mjs';
+
+export default function Blog({ blogs }) {
+  return (
+    <div>
+      <h1>Blog</h1>
+      <ul>
+        {blogs.map((blog) => (
+          <li key={blog.id}>
+            <a href={blog.url_path}>{blog.title}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getStaticProps = async () => {
+  const mddb = await clientPromise;
+  // get all files that are not marked as draft in the frontmatter
+  const blogFiles = await mddb.getFiles({
+    frontmatter: {
+      draft: false,
+    },
+  });
+
+  const blogsList = blogFiles.map(({ metadata, url_path }) => ({
+    ...metadata,
+    url_path,
+  }));
+
+  return {
+    props: {
+      blogs: blogsList,
+    },
+  };
+};
+```
+
+And the imported library with MarkdownDB database connection:
+
+```js
+// @/lib/mddb.mjs
+import { MarkdownDB } from 'mddb';
+
+const dbPath = 'markdown.db';
+
+const client = new MarkdownDB({
+  client: 'sqlite3',
+  connection: {
+    filename: dbPath,
+  },
+});
+
+const clientPromise = client.init();
+
+export default clientPromise;
+```
+
+### Build your blog, wiki, docs, digital garden, or anything you want
+
+And share it with the world!
+
+![[/static/img/blog/markdowbdb-launch-site-example.png]]
+
+👉 [Read the full tutorial](https://markdowndb.com/blog/basic-tutorial)
+
+---
+
+Find out more on our new official website: https://markdowndb.com/
+
+Check out the source on GitHub: https://github.com/datopian/markdowndb
+
+— Ola Rubaj, Developer at Datopian
+]]></description><link>https://portaljs.com/blog/markdowndb-launch</link><guid isPermaLink="false">https://portaljs.com/blog/markdowndb-launch</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Wed, 11 Oct 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[What We Shipped in Jul-Aug 2023]]></title><description><![CDATA[
+Hey everyone! 👋 Summer has been in full swing, and while I've managed to catch some vacation vibes, I've also been deep into code. I'm super excited to share some of the latest updates and features we've rolled out over the past two months. Let's dive in:
+
+## 🌷 Flowershow
+
+https://flowershow.app/
+
+1. **CLI is old news**: the Flowershow CLI has been deprecated in favor of our new [Flowershow Obsidian plugin](https://github.com/datopian/obsidian-flowershow).
+
+2. **Self-publishing made even easier**: I wrote a [self-publish tutorial](https://flowershow.app/docs/publish-howto) to guide you through using our Obsidian plugin for publishing your digital garden.
+
+3. **Cloud-publishing MVP**: The first version of our Flowershow Cloud which aims to make publishing your digital garden notes a breeze! [Check out the overview](https://flowershow.app#cloud-publish) and stay tuned 📻!
+
+4. **Hydration errors from Obsidian transclusions/note embeddings are fixed**: For now, note transclusions will convert to regular links, but stay tuned — support for note embeds may be on the horizon. [Learn more](https://github.com/datopian/flowershow/issues/545)
+
+5. **New Obsidian tags list format support**: I added support for Obsidian's new tag list format, so now your notes can be even more organized. [Learn more](https://github.com/datopian/flowershow/issues/543)
+
+## 🗂️ MarkdownDB
+
+https://github.com/datopian/markdowndb
+
+1. **Auto-Publishing to npm**: Changesets now trigger auto-publishing, so we're always up to date.
+2. **Obsidian-style wiki links**: Extracting wiki links with Obsidian-style shortest paths is supported now.
+
+## 📚 The Guide
+
+https://portaljs.org/guide
+
+I’ve sketched overviews for two upcoming tutorials:
+
+1. **Collaborating with others on your website**: Learn how to make your website projects a team effort. [See it here](https://portaljs.org/guide#tutorial-3-collaborating-with-others-on-your-website-project)
+2. **Customising your website and previewing your changes locally**: Customize and preview your site changes locally, without headaches. [See it here](https://portaljs.org/guide#tutorial-4-customising-your-website-locally-and-previewing-your-changes-locally)
+
+## 🌐 LifeItself.org
+
+https://lifeitself.org/
+
+LifeItself.org is our website built on the Flowershow template, and it's been getting some extra care too.
+
+1. New blog home page layout with:
+
+- **Team Top Selection**
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-top-picks.png]]
+
+- **Latest Blog Posts**
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-latest-blogs.png]]
+
+- And the long awaited filtering by category 🎉
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-categories.png]]
+
+[👉 Check out the changes!](https://lifeitself.org/blog)
+
+2. **Blog posts layout revamp**: Refreshed design with share options, reading time estimates, and more.
+
+![[/static/img/blog/2023-09-02-what-we-shipped-in-june-aug/life-itself-blog-post.png]]
+
+---
+
+That wraps it up for now! As always, I'm eager to hear your thoughts and feedback. Feel free to report issues or ask for features on our GitHub repositories. Until next time and happy publishing!
+
+— Ola Rubaj, Developer at Datopian
+]]></description><link>https://portaljs.com/blog/summer-updates-2023</link><guid isPermaLink="false">https://portaljs.com/blog/summer-updates-2023</guid><dc:creator><![CDATA[ola-rubaj]]></dc:creator><pubDate>Fri, 01 Sep 2023 18:00:00 GMT</pubDate></item><item><title><![CDATA[Adding Maps to PortalJS: Enhancing Geospatial Data Visualization with PortalJS]]></title><description><![CDATA[
+This post walks you though adding maps and geospatial visualizations to PortalJS.
+
+Are you interested in building rich and interactive data portals? Do you find value in the power and flexibility of JavaScript, Nextjs, and React? If so, [PortalJS](https://portaljs.org/) is for you. It's a state-of-the-art framework leveraging these technologies to help you build rich data portals.
+
+Effective data visualization lies in the use  of various data components. Within [PortalJS](https://portaljs.org/), we take data visualization a step further. It's not just about displaying data - it's about telling a story through combining a variety of data components.
+
+In this post we will share our latest enhancement to PortalJS: maps, a powerful tool for visualizing geospatial data. In this post, we will to take you on a tour of our experiments and progress in enhancing map functionalities on PortalJS. The journey is still in its early stages, with new facets being unveiled and refined as we perfect our API.
+
+## Exploring Map Formats
+
+Maps play a crucial role in geospatial data visualization. Several formats exist for storing and sharing this type of data, with GeoJSON, KML, and shapefiles being among the most popular. As a prominent figure in the field of open-source data portal platforms, [PortalJS](https://portaljs.org/) strives to support as many map formats as possible.
+
+Taking inspiration from the ckanext-geoview extension, we currently support KML and GeoJSON formats in [PortalJS](https://portaljs.org/). This remarkable extension is a plugin for CKAN, the world’s leading open source data management system, that enables users to visualize geospatial data in diverse formats on an interactive map. Apart from KML and GeoJSON formats support, our roadmap entails extending compatibility to encompass all other formats supported by ckanext-geoview. Rest assured, we are committed to empowering users with a wide array of map format options in the future.
+
+So, what makes these formats special?
+
+- **GeoJSON**: This format uses JSON to depict simple geographic features and their associated attributes. It's often hailed as the most popular choice in the field.
+- **KML**: An XML-based format, KML can store details like placemarks, paths, polygons, and styles.
+- **Shapefiles**: These are file collections that store vector data—points, lines, and polygons—and their attributes.
+
+## Unveiling the Power of Leaflet and OpenLayers
+
+To display maps in [PortalJS](https://portaljs.org/), we utilize two powerful JavaScript libraries for creating interactive maps based on different layers: Leaflet and OpenLayers. Each offers distinct advantages (and disadvantages), inspiring us to integrate both and give users the flexibility to choose.
+
+Leaflet is the leading open-source JavaScript library known for its mobile-friendly, interactive maps. With its compact size (just 42 KB of JS), it provides all the map features most developers need. Leaflet is designed with simplicity, performance and usability in mind. It works efficiently across all major desktop and mobile platforms.
+
+OpenLayers is a high-performance library packed with features for creating interactive web maps. OpenLayers can display map tiles, vector data, and markers sourced from anywhere on any webpage. It's an excellent tool for leveraging geographic information of all kinds.
+
+## Introducing Map Feature
+
+Both components have some similar features and props, such as:
+
+### Polygons and points
+
+![Map with polygons and points](/static/img/blog/2023-07-18-Adding-maps-to-portaljs/2023-07-18-map-polygons-and-points.png)
+
+Our initial version enables the use of both vectors and points to display information. Points are simpler and faster to render than vectors, but they have less detail and interactivity. For example, if you have data that is represented by coordinates or addresses, you can use points to show them on the map. This way, you can avoid time-consuming loading and rendering complex vector shapes that may slow down your map.
+
+### Tooltips
+
+![Map with tooltips](/static/img/blog/2023-07-18-Adding-maps-to-portaljs/2023-07-18-map-tooltips.png)
+
+We have implemented an exciting feature that enhances the usability of our map component: tooltips. When you hover over a polygon or point on the map, a small pop-up window, known as a tooltip, appears. This tooltip provides relevant details about the feature under your cursor, according to what features the map creator wants to highlight. For example, when exploring countries, you can effortlessly discover their name, population, and area by hovering over them. Similarly, hovering over cities reveals useful information like their name, temperature, and elevation. To enable this handy tooltip functionality on our map, simply include a tooltip prop when using the map component.
+
+### Focus
+
+![Map with polygons over a region](/static/img/blog/2023-07-18-Adding-maps-to-portaljs/2023-07-18-map-polygons-on-region.png)
+
+Users can also choose a region of focus, which will depend on the data, by setting initial center coordinates and zoom level. This is especially helpful for maps that are not global, such as the ones that use data from a specific country, city or region.
+
+## Mapping the Future with PortalJS
+
+Through our ongoing enhancements to the [PortalJS library](https://storybook.portaljs.org/), we aim to empower users to create engaging and informative data portals featuring diverse map formats and data components.
+
+Why not give [PortalJS](https://portaljs.org/) a try today and discover the possibilities for your own data portals? To get started, check out our comprehensive documentation here: [PortalJS Documentation](https://portaljs.org/docs).
+
+Have questions or comments about using [PortalJS](https://portaljs.org/) for your data portals? Feel free to share your thoughts on our [Discord channel](https://discord.com/invite/EeyfGrGu4U). We're here to help you make the most of your data.
+
+Stay tuned for more exciting developments as we continue to enhance [PortalJS](https://portaljs.org/)!
+]]></description><link>https://portaljs.com/blog/enhancing-geospatial-data-visualization-with-portaljs</link><guid isPermaLink="false">https://portaljs.com/blog/enhancing-geospatial-data-visualization-with-portaljs</guid><dc:creator><![CDATA[João Demenech]]></dc:creator><pubDate>Tue, 18 Jul 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Tutorial 2: Edit your Flowershow website locally on your computer]]></title><description><![CDATA[
+In this tutorial, we will walk you through the process of editing your Flowershow website locally on your computer. 
+
+By the end of this tutorial, you will:
+
+- Understand what is Markdown and why you should use Obsidian to edit content on your Flowershow websites in most cases.
+- Gain a deeper understanding of working with Git and GitHub Desktop.
+- Learn how to clone your website's repository to your computer.
+- Learn how to edit content using Obsidian and what are the benefits of it.
+- Learn how to commit (save) your changes locally and push them back to the GitHub repository.
+
+Below is a screenshot of how the final website will look like:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/tutorial-2-result.png]]
+
+Let's start by understanding why using GitHub UI as we did in tutorial 1 is not always a good choice.
+
+## What is Markdown and why use Obsidian for editing it in Flowershow-based websites
+
+While editing on the GitHub UI is convenient, there are certain limitations and drawbacks to consider. For example, you can't work offline, can't add or edit multiple files simultaneously, and the GitHub UI's preview doesn't render all the Markdown syntax elements that are supported by Flowershow-based websites.
+
+Ok, but, what exactly is Markdown?
+
+[Markdown](https://en.wikipedia.org/wiki/Markdown) is a simple and intuitive syntax, that allows you to structure your text documents. It's widely used for creating content on the web. As Wikipedia puts it:
+
+> *Markdown is a lightweight [**markup language**](https://en.wikipedia.org/wiki/Markup_language) for creating [**formatted text**](https://en.wikipedia.org/wiki/Formatted_text) using a **plain-text editor**.*
+
+The key term here is "markup language". In simple terms, it is a way to annotate or "mark up" a plain text document with symbols that describe how the document is structured and so, how it should be understood, processed, or displayed. These tags can tell a computer program that supports this syntax (e.g. a website) how to format the rendered text, for example: which words should be bold or italic, where to insert images, when to start new paragraphs, how to create tables, and so forth. It's important to note, that even though Markdown symbols change how the text is displayed when it's rendered by a Markdown-compatible viewer, the underlying document in still just a plain text. For instance, if you want to create a heading in Markdown, you use the "#" symbol before your heading text, like this:
+
+```md
+# This is a Heading
+```
+
+BUT, there is no single version of Markdown. It comes in different "flavours", with CommonMark and GitHub Flavoured Markdown (GFM) being the most popular ones. And different tools supporting Markdown may use their own specific versions of Markdown. The two tools relevant in the context of this guide are Obsidian and Flowershow.
+
+Obsidian supports an extended version of Markdown that includes majority of elements from CommonMark and GFM, while also introducing its own unique features, like [wiki-links](https://help.obsidian.md/Linking+notes+and+files/Internal+links) or [callouts](https://help.obsidian.md/Editing+and+formatting/Callouts). And Flowershow template is Obsidian-compatible, meaning it supports (or aims to support) all of the Obsidian Markdown features.
+
+To make things a bit clearer, there are:
+
+- CommonMark
+- GitHub Flavored Markdown (GFM) - superset of CommonMark
+- "Obsidian flavoured Markdown" - majority of the GFM + some extra elements, like wiki-links or callouts
+- "Flowershow flavoured Markdown" - majority of Obsidian-supported syntax
+
+As you might have guessed by now, GitHub UI will only preview GitHub Flavoured Markdown. And while it's a majority of Markdown you would write, it won't be able to render Obsidian-only (or Flowershow-only) syntax elements, like callouts, wiki-links or inline table of contents.
+
+Another drawback of GitHub UI, is that it doesn't allow you to make changes (or to add) multiple files at once. Changes to each file will have to be commited (saved) separately, which can introduce a bit of a mess to your GitHub history, and may be cumbersome (e.g. if you want to update a link to some page on 10 other pages...).
+
+Ok, now we have this sorted, let's dive in and start editing your Flowershow website locally!
+
+## Prerequisites
+
+- A [GitHub](https://github.com/) account.
+- A [Vercel](https://vercel.com/) account. You can set it up using your GitHub account.
+- [Obsidian](https://obsidian.md/) installed
+- [GitHub Desktop](https://desktop.github.com/) installed
+- [[create-a-website-from-scratch|Tutorial 1: Create a website from scratch using Markdown and PortalJS]] completed - this one is recommended so that you have the same sandbox website we're working on in this tutorial.
+
+## Clone the GitHub repository on your computer
+
+### 1. Open GitHub Desktop app
+
+### 2.  Click on "Clone a Repository from the Internet..."
+
+Or click on "File" -> "Clone repository".
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-starting-screen.png]]
+
+If this is the first time you're using GitHub Desktop, it will prompt you to log in to your GitHub account. Click "Sign In" and follow the prompts.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-clone-signin.png]]
+
+Once you're done and you've authorised GitHub Desktop to access your repositories, go back to GitHub Desktop. You should now see a list of all your GitHub repositories. 
+
+### 3. Select the repository you want to clone
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-clone.png]]
+
+### 4. Choose where your repository should be saved
+
+Type the path manually or click "Choose..." to find it using file explorer.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-clone-path-select.png]]
+
+### 5. Click "Clone" and wait for the process to complete
+
+You should now see the following screen:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/gh-desktop-no-local-changes.png]]
+
+Done! You've successfully cloned your website's repository on your computer! 🎉
+
+## Edit your site in Obsidian
+
+### 1. Open Obsidian
+
+### 2. Open your repository's `/content` folder as vault
+
+Click on "Open" in "Open folder as vault" section and select the path to the `/content` of the cloned repository.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-starting.png]]
+Now you're ready to edit your site! In the left-hand side panel you should see the two files we created in [[create-a-website-from-scratch|tutorial 1]]: `index.md` and `about.md`.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-start.png]]
+
+### 3. Edit your site's content
+
+Now, let's add some more stuff to the home page.
+
+Click on `index.md` to open it and replace the dummy text with "About Me" section, .e.g.:
+
+```md
+## About Me
+
+Hey there! I'm Your Name, a passionate learner and explorer of ideas.
+```
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-edit.png]]
+
+Now, let's say for more information about you and your site, you want to add link to the about page. You can do so, by creating a wiki-link to that page, like so:
+
+```md
+[[about]]
+```
+
+When you start typing, after writing empty double brackets `[[]]`, Obsidian will suggest all the available pages you can link to, and after you select one it will create the link automatically for you.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-add-link.png]]
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-add-link-2.png]]
+
+Now, let's say you want to show people what books you've read and share your reviews and other information on each one. And let's say information on each book should be available at `/books/abc` path on our website. To achieve this, you need to create a folder called `books` in your vault and add all the project-related files in there.
+
+To create a new folder in Obsidian, click on the "New folder" icon, and give your folder a name:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-add-folder.png]]
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-add-folder-2.png]]
+
+Now, let's write some book reviews. You can do this by right-clicking on the `/books` folder, and selecting "New note" option. Rename the newly created `Untitled.md` file and add some review in it. Then add some other reviews.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book.png]]
+
+Ok, now let's make a page that will list all your books reviews - our Bookshelf! It would be nice to have it available under `/books` path on the website, since each of our books will be available under `/books/abc`. To achieve this, we have to create an index page **inside** our `/books` folder, like so:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book-index.png]]
+
+Then, let's list our book reviews with wiki-links to their pages:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book-index-2.png]]
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-book-index-3.png]]
+
+Now, let's add a link to our Bookshelf page on our home page, so that it's easy to find.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-bookshelf-link.png]]
+
+Now, if you want to have your link say something different than the raw `books/index`, you can do this by typing `|` after the path and specifying an alternative name, .e.g:
+
+```md
+[[books/index|Bookshelf]]
+```
+
+Let's also do this for the about page:
+
+```md
+[[about|About me]]
+```
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-link-aliases.png]]
+
+That's better!
+
+Now, let's maybe add a short info at the bottom, that this site is new and is currently being worked on, in form of an Obsidian callout:
+
+```md
+> [!info]
+> 🚧 This site it pretty new and I'm enhancing it every day. Stay tuned!
+```
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/obsidian-content-index-callout.png]]
+
+Great, our updated site is ready to be published! 🔥
+
+## Save and publish your changes
+
+### 1. Navigate to GitHub Desktop app
+
+In the "Changes" tab, you'll see all the changes that have been made to the repository.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-all-changed-files.png]]
+
+All the new files will have `[+]` sign next to them, and all the edited files will have `[•]`.
+
+### 2. Commit your changes
+
+Now, to save these changes we need to "commit" them, which is a fancy term for making a checkpoint of the state at which your repository is currently in.
+
+Let's make this checkpoint! In the bottom left corner there is a "Summary (required)" field, which is the place for a commit message - a concise description of the changes you made. The "Description" field is optional, and it's only needed if you need to add some more information about your changes that doesn't fit in the commit message.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-add-commit-message.png]]
+
+Now, hit the "Commit to main" button, and done! Now GitHub Desktop should say there are no local changes again. And that's correct, as all the changes we made have successfully been saved, and no other changes have been made since then.
+
+You should see the last commit message under the button:
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-commit-message.png]]
+
+You can also inspect the whole history of past commits in the "History tab".
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-history.png]]
+
+The very fist commit on top is the commit we've just made, but you can also see all the commits to the repository we made in [[create-a-website-from-scratch|tutorial 1]], via GitHub UI.
+
+### 3. Push your changes to the remote repository
+
+The commit we've just crated has ↑ sign next to it. It means it hasn't yet been pushed to our remote version of the repository - the changes you made has been saved, but only locally on your computer. In order to push them to the cloud copy of the repository (aka "remote"), click "↑ Push origin (1 ↑)" tab.
+
+When the "push" is complete, the arrow next to the last commit message should disappear, and there should be no `(1 )` indicator next to "Push origin" button.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/github-desktop-history-after-push.png]]
+
+### 4. See updated site live!
+
+Navigate to your [vercel dashboard](https://vercel.com/dashboard).
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/vercel-dashboard.png]]
+
+Click on the project repository to go to its dashboard.
+
+You may have to wait a bit until the site builds, but once it's ready, you should see the preview with our latest changes.
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/vercel-project-dashboard.png]]
+
+Note, that under "SOURCE" section (next to the preview) there is also our last commit message, indicating that the latest deployment has been triggered by this commit.
+
+Click on the preview to see the updated site live!
+
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/tutorial-2-result.png]]
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/live-book-home-page.png]]
+![[/static/img/blog/2023-06-22-Edit-your-flowershow-website/live-book.png]]
+
+Congratulations!
+
+You have successfully completed the tutorial on editing your Flowershow website locally on your computer. By utilising Obsidian and GitHub Desktop, you have unlocked powerful editing capabilities and improved the overall publishing process. Now, you can enjoy the benefits of offline editing, simultaneous file editing, and previewing the extended Markdown syntax provided by Obsidian.
+]]></description><link>https://portaljs.com/blog/edit-a-website-locally</link><guid isPermaLink="false">https://portaljs.com/blog/edit-a-website-locally</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Thu, 22 Jun 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Tutorial 1: Create a website from scratch using Markdown and Flowershow]]></title><description><![CDATA[
+In this tutorial we will walk you through creating an elegant, fully functional website written in simple markdown and published with Flowershow.
+
+By the end of this tutorial you will:
+
+- have a working markdown-based website powered by Flowershow.
+- be able to edit the text and add pages, all from an online interface without installing anything.
+
+Below is a screenshot of how the final website will look like:
+![[/static/img/blog/tutorial-1-result.png]]
+
+## Prerequisites
+
+- A [GitHub](https://github.com/) account.
+- A [Vercel](https://vercel.com/) account. You can set it up using your GitHub account.
+
+## Setting up a sandbox website
+
+### 1. Navigate to the [datopian/flowershow repository](https://github.com/datopian/flowershow).
+
+### 2. Scroll down and click on the "Deploy" button
+
+After clicking on it, you'll be redirected to Vercel's "Create Git Repository" page.
+
+![Step 2 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/35cb9df6-d93e-4ce6-9741-54be744cf9e7/55ca0e14-6780-40e3-9ecc-148a7fa7c08e.png?crop=focalpoint&fit=crop&fp-x=0.0945&fp-y=0.4783&fp-z=2.5970&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=162&mark-y=440&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yNjUmaD03MiZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 3. Select your GitHub account in "Git Scope"
+
+Click on "Select Git Scope" dropdown and select your GitHub account name from the list if it's there.
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/bdd61961-e1fe-4282-abec-75ae66bfeaa5/85df39b9-51a8-410a-a83b-93f2d2d6256c.png?crop=focalpoint&fit=crop&fp-x=0.2455&fp-y=0.4226&fp-z=1.4615&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=94&mark-y=427&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzQmaD05OSZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+If your GitHub account is not available in the dropdown list, click on "Add GitHub Account"...
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/879ebed5-fec7-443e-8be9-66b73a4ec044/583f8a42-fc35-43d8-b791-70e22976ed46.png?crop=focalpoint&fit=crop&fp-x=0.2455&fp-y=0.5030&fp-z=1.5031&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=113&mark-y=429&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NTkmaD05NCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+...and authorize Vercel to access your GitHub repositories by clicking "Install".
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/61441f7d-ccc4-45ca-b52d-4ccc0573d787/ff97c393-2fff-407e-abe2-bc96c18562cc.png?crop=focalpoint&fit=crop&fp-x=0.2922&fp-y=0.7621&fp-z=2.4427&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=440&mark-y=385&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0zMjEmaD0xMjgmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+Now you can select your GitHub account.
+
+![Step 3 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/d2382391-f4bc-4ffe-b8e8-e22b9f6550ad/f4817109-ae2e-49f9-98ad-2f8dfe9a5b3b.png?crop=focalpoint&fit=crop&fp-x=0.2455&fp-y=0.5833&fp-z=1.5031&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=113&mark-y=429&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NTkmaD05NCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 4. Give your repository a name
+
+A good practice is to use lowercase and dashes.
+
+![Step 4 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/a9b6af4c-4645-4b93-9c28-75d23e7f48a3/55dcaf47-8851-4808-ab9e-6fe6c4d552aa.png?crop=focalpoint&fit=crop&fp-x=0.6919&fp-y=0.4929&fp-z=1.7767&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=57&mark-y=416&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMDg2Jmg9MTIxJmZpdD1jcm9wJmNvcm5lci1yYWRpdXM9MTA%3D)
+
+### 5. Click on "Create" and wait until the site deploys
+
+After you click "Create", Vercel will create a new repository on your GitHub account, using the `datopian/flowershow` repository as a template. Then, it will immediately start buidling the initial version of your website. This may take about 1-2 minutes.
+
+![Step 5 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/ae740310-736d-48e5-9fbf-cf567a2ff966/2bc653a7-0e6c-4eaa-a11b-85a2a4d4c1d3.png?crop=focalpoint&fit=crop&fp-x=0.5007&fp-y=0.5152&fp-z=1.0564&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=33&mark-y=379&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMTM0Jmg9MTk1JmZpdD1jcm9wJmNvcm5lci1yYWRpdXM9MTA%3D)
+
+### 6. See your published website!
+
+And voila! Your site is up and running. Once on the "Congratulations" screen, navigate to the project dashboard...
+
+![Step 6 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/1df8967e-2bcf-43ec-b3d0-a9d638d21ff7/af6d363d-2872-4a45-b5e5-16ca754e4702.png?crop=focalpoint&fit=crop&fp-x=0.5005&fp-y=0.3351&fp-z=1.8197&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=328&mark-y=414&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz01NDUmaD0xMjQmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+... and click on "Visit" to see your published website!
+
+![Step 6 screenshot](https://images.tango.us/workflows/9bef984b-9dd1-4c07-ae32-88bb426c306e/steps/319f8eef-5007-4885-a3d6-6dc7fd7472ea/80b34413-f7da-4765-90d6-89a93fb4eab5.png?crop=focalpoint&fit=crop&fp-x=0.0697&fp-y=0.3482&fp-z=2.5500&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=72&mark-y=390&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yODImaD0xNzQmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+## Editing a page on your website
+
+Once your site is up and running, the next step is to customize it to your liking. Let's start by editing our home page.
+
+### 1. Navigate to the repository of your website on GitHub
+
+You can get there by going to GitHub, clicking on your profile icon, and going to "Your repositories".
+
+![Step 1 screenshot](https://images.tango.us/workflows/5b5166f4-2965-4a91-9bec-47108fe34234/steps/adecdf18-e46a-4003-984e-1dc1945963df/6792cf00-20fc-4e24-88ca-8d35a41aadab.png?crop=focalpoint&fit=crop&fp-x=0.9589&fp-y=0.0345&fp-z=3.0108&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=992&mark-y=53&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMjAmaD05MiZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+![Step 1 screenshot](https://images.tango.us/workflows/5b5166f4-2965-4a91-9bec-47108fe34234/steps/8578ff07-5dc9-4908-bc81-197293970344/9b01a3fb-47fe-48ed-a7bc-c9910e9e42ef.png?crop=focalpoint&fit=crop&fp-x=0.8963&fp-y=0.1997&fp-z=2.9422&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=553&mark-y=420&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz01NjImaD0xMTImZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+Or, you can navigate to [your Vercel dashboard](https://vercel.com/dashboard), select your project in the "Overview" tab...
+
+![Step 1 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/b7f96b7d-28b1-4366-b889-681b327b5f40/a0d2bffd-2e81-4878-854b-0766cf710339.png?crop=focalpoint&fit=crop&fp-x=0.2578&fp-y=0.4408&fp-z=1.3063&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=39&mark-y=274&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz03MzAmaD00MDQmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+...and click on "Git Repository". You'll be redirected to the repository of your website on GitHub.
+
+![Step 1 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/2cfbda16-23dc-45b2-9be9-a4b5b3a255d1/da2be1ca-da13-4257-a830-3ece2b89ff51.png?crop=focalpoint&fit=crop&fp-x=0.4560&fp-y=0.4590&fp-z=1.1707&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=321&mark-y=313&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yMjYmaD04MCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 2. Navigate to the "content" folder
+
+This is where all the Markdown-based pages live in a Flowershow-based project.
+
+![Step 2 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/4ce5b74e-40e5-4c3f-a3ce-be7fa8959489/25b9ddc8-c1df-44f8-bf3e-7d08960f0592.png?crop=focalpoint&fit=crop&fp-x=0.0900&fp-y=0.4574&fp-z=2.8680&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=226&mark-y=441&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xNjgmaD03MCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 3. Edit the "index.md" file
+
+The homepage on your website is built with the "index.md" file in the root of the "content" folder. Click on it to open.
+
+![Step 3 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/b14c059d-89e4-419b-8ac4-0e219ed195af/4d86a32a-b5f8-48d1-bccd-ddbfd140fe5a.png?crop=focalpoint&fit=crop&fp-x=0.0754&fp-y=0.4711&fp-z=2.7997&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=157&mark-y=442&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xOTImaD02OCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+Then, click on the "Edit this file" icon...
+
+![Step 3 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/e4d28cd5-3863-46e3-813d-5304ec0d769f/ce2bf765-9bef-4d96-8354-0eed3aa88c03.png?crop=focalpoint&fit=crop&fp-x=0.9435&fp-y=0.3449&fp-z=2.9525&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=945&mark-y=422&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMDkmaD0xMDkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+... and add some content.
+
+![Step 3 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/daad6528-db93-426c-8b8b-ae67d0a28189/a5767c01-a16e-4c4b-b4a0-5595663b175d.png?crop=focalpoint&fit=crop&fp-x=0.5170&fp-y=0.3762&fp-z=1.0470&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=7&mark-y=300&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMTg2Jmg9MTUwJmZpdD1jcm9wJmNvcm5lci1yYWRpdXM9MTA%3D)
+
+### 4. Save your changes
+
+To see your changes live, you need to "commit" them. Click on "Commit changes..." buttom in the top-tight corner.
+
+![Step 4 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/74159a33-2897-4ffb-af3d-ce2fa109e570/0e96f7a4-b4ff-418e-9b44-73573a4354d1.png?crop=focalpoint&fit=crop&fp-x=0.9227&fp-y=0.2208&fp-z=2.9167&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=696&mark-y=417&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz00NjgmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+In the "Commit message" field add a concise description of your changes. Optionally, if the commit message is not enough, you can add more info in the "Extended description" field.
+
+![Step 4 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/09130863-221f-436e-bab0-a46bea2fd5c4/bdbd1458-3b5c-4352-a8fb-5921132ee3e4.png?crop=focalpoint&fit=crop&fp-x=0.4998&fp-y=0.3476&fp-z=1.4555&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=262&mark-y=447&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzYmaD01OCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+Leave "Commit directly to `main` branch" selected and click on "Commit changes". Doing that will trigger rebuilding of your site on Vercel.
+
+![Step 4 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/40bf87e4-a2b1-4a99-97da-5e87530d0622/88a19d05-ce63-4da0-9e85-e427b063245e.png?crop=focalpoint&fit=crop&fp-x=0.5545&fp-y=0.5989&fp-z=1.3207&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=612&mark-y=616&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0yMDcmaD01NSZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 5. See your site getting rebuild
+
+If you want to see the current progress of rebuilding your website after you've commited the changes, click on the dot next to your commit message.
+
+> [!note]
+> It will be either a dot (if the site is currently being rebuilt after your changes), a check mark (if the site has finished building) or a cross (if something went wrong when rebuilding it).
+
+![Step 5 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/0d273173-d852-47e4-b41e-418b9196e0fd/fbf1afe6-7af3-4b06-8ab0-d3c41d2923ce.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.5000&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n)
+
+Click on "Details" to see your project's deployment status on Vercel.
+
+![Step 5 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/94b4e4ab-458c-4be9-b7a9-e34c7b4185b9/645687a4-b91d-4870-a935-48403b8ce33c.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.5000&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n)
+
+### 6. Preview your site after changes
+
+Once the site has been rebuilt, click the preview to see your changes live.
+
+![Step 6 screenshot](https://images.tango.us/workflows/4aa9bd80-6829-415e-b3a8-6136bfb176eb/steps/a1294580-7d0d-492c-a880-32040b4bee48/5e7ddd43-03e3-4545-b1b3-cd631da401d8.png?crop=focalpoint&fit=crop&fp-x=0.2207&fp-y=0.3824&fp-z=1.4465&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=43&mark-y=261&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzkmaD00MzEmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+## Add a single Markdown-based page
+
+### 1. Navigate to the "content" folder in your website's repository
+
+See how to find it in the previous section.
+
+### 2. Create new file
+
+Click on "Add file"...
+
+![Step 2 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/1708e4fa-8234-4393-a8e9-cd972afce770/b986ab26-d53f-4b57-8520-fb87782dfb22.png?crop=focalpoint&fit=crop&fp-x=0.9119&fp-y=0.2208&fp-z=2.9167&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=737&mark-y=417&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0zMDkmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+...and "Create new file".
+
+![Step 2 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/e79d32ef-9385-4903-8ca1-408f78752633/7006ac1c-796c-4bb6-95ef-dd4d9969c9b6.png?crop=focalpoint&fit=crop&fp-x=0.8712&fp-y=0.2679&fp-z=2.9167&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=476&mark-y=417&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz01NDcmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+### 3. Type the name of the new file you want to create
+
+![Step 3 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/54c786cb-15d6-4abe-8893-fa95dff3ed0a/c39152b2-f446-4e39-a2f3-9b3cf0e7c193.png?crop=focalpoint&fit=crop&fp-x=0.3476&fp-y=0.2214&fp-z=2.1864&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=394&mark-y=418&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz00MTMmaD04NyZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 4. Write the content of the file
+
+![Step 4 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/8ffe1e8c-45f9-42b7-8053-bc8bc61b098c/56489034-d5a9-495e-8fb7-1fbfff62d7f3.png?crop=focalpoint&fit=crop&fp-x=0.5170&fp-y=0.3440&fp-z=1.0470&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=7&mark-y=300&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0xMTg2Jmg9ODYmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+### 5. Save your changes
+
+To see your changes live, you need to "commit" them. Click on "Commit changes..." buttom in the top-tight corner.
+
+![Step 5 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/382d133d-19f3-4aee-a0fa-535fcb361090/fe7b1fc6-c8f0-4f3f-958a-204c4fc65cf8.png?crop=focalpoint&fit=crop&fp-x=0.9227&fp-y=0.2208&fp-z=2.9167&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=696&mark-y=417&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz00NjgmaD0xMTkmZml0PWNyb3AmY29ybmVyLXJhZGl1cz0xMA%3D%3D)
+
+In the "Commit message" field add a concise description of your changes. Optionally, if the commit message is not enough, you can add more info in the "Extended description" field.
+
+![Step 5 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/13c5873d-4071-4ae2-b641-d6202631076c/53029856-5543-4681-919a-092ed2dacb02.png?crop=focalpoint&fit=crop&fp-x=0.4998&fp-y=0.3476&fp-z=1.4555&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=262&mark-y=447&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz02NzYmaD01OCZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+Leave "Commit directly to `main` branch" selected and click on "Commit changes". Doing that will trigger rebuilding of your site on Vercel.
+
+![Step 5 screenshot](https://images.tango.us/workflows/c14ae6dc-9e15-49f5-af87-b513daa701ba/steps/68002c21-451a-4536-89b6-8a0d01d327eb/bb71cbb3-7a79-45f3-a71e-2500a380556c.png?crop=focalpoint&fit=crop&fp-x=0.6278&fp-y=0.7315&fp-z=2.3207&w=1200&border=2%2CF4F2F7&border-radius=8%2C8%2C8%2C8&border-radius-inner=8%2C8%2C8%2C8&blend-align=bottom&blend-mode=normal&blend-x=0&blend-w=1200&blend64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL21hZGUtd2l0aC10YW5nby13YXRlcm1hcmstdjIucG5n&mark-x=418&mark-y=428&m64=aHR0cHM6Ly9pbWFnZXMudGFuZ28udXMvc3RhdGljL2JsYW5rLnBuZz9tYXNrPWNvcm5lcnMmYm9yZGVyPTYlMkNGRjc0NDImdz0zNjUmaD05NyZmaXQ9Y3JvcCZjb3JuZXItcmFkaXVzPTEw)
+
+### 6. Preview your site after changes
+
+As you already know, Vercel will now start rebuilding your website. When it's done, you can navigate to `/about` url on your website to see the new file we've just added.
+
+## What's next?
+
+While editing on GitHub UI is acceptable, it has its limitations – it doesn't support working offline, adding multiple files simultaneously, or previewing many markdown syntax elements supported by Flowershow-based websites. We'll delve into these issues and solutions to overcome them in our next tutorial. Stay tuned!
+]]></description><link>https://portaljs.com/blog/create-a-website-from-scratch</link><guid isPermaLink="false">https://portaljs.com/blog/create-a-website-from-scratch</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Tue, 20 Jun 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Create a catalog of anything using Markdown files in Obsidian]]></title><description><![CDATA[
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/dataview.gif]]
+
+Have you ever wanted to create a catalog of stuff? Maybe it's a list of personal projects, maybe favourite books or movies, or perhaps the options for the next smartphone you'll buy. But you've found yourself deterred by expensive software, lack of flexibility in capturing and modifying the structure of the data, or lack of control over it?
+
+Markdown files, with their unique combination of 1) rich content, including text, images, links, and more, with 2) structured metadata allowing for data retrieval, are an excellent tool for this task. These features, coupled with the user-friendly interface of Obsidian and the analytical power of the Dataview plugin, make creating a data catalog an easy task. And it's free!
+
+This tutorial will provide you with an easy yet extendable approach to creating your personal data catalogs using Markdown, in Obsidian.
+
+## What are we going to build?
+
+In this tutorial, we're going to create a catalog of characters from the Harry Potter series. Each character will have their own markdown file containing some unstructured data like character's quotes, as well as structured metadata, such as the character's name, house, creature they own, and status (alive or dead).
+
+## Step 1: Setup
+
+Here are the steps to get you started:
+
+1. Download and install Obsidian from their [official website](https://obsidian.md/).
+2. Create a new Obsidian vault.
+   1. Open the app.
+   2. Click the "New" button to create a new vault.
+   3. Choose a name and a location for your vault. For this tutorial, you might name it "Harry Potter Characters".
+   4. Click "Create" to create the vault.
+3. Install the ["Dataview" plugin](https://github.com/blacksmithgu/obsidian-dataview) from Obsidian's community plugins.
+   1. Open the newly created vault in Obsidian.
+   2. Click on the settings icon ⚙️ in the left-hand pane to open the Settings view.
+   3. In the Settings view, find the "Community plugins" section and click on it.
+   4. Click on the button "Turn on community plugins".
+   5. Click on "Browse" and search for "Dataview" in the plugin browser.
+   6. Click on "Install" to install the Dataview plugin.
+   7. After the plugin is installed, click on "Enable" to enable the plugin in your vault.
+
+## Step 2: Add some data about the characters
+
+Let's start by creating a subfolder in our Obsidian vault, that will store all the markdown files with our characters data. Let's name it e.g. `/characters`. Then, we're going to create three markdown files in it for data about Harry Potter, Hermione, and Malfoy.
+
+Here's an example file for Harry Potter:
+
+```md
+---
+name: Harry Potter
+house: Gryffindor
+status: Alive
+---
+
+## Quotes
+
+"I solemnly swear I am up to no good."
+```
+
+Here's an example file for Hermione:
+
+```md
+---
+name: Hermione Granger
+house: Gryffindor
+status: Alive
+---
+
+## Quotes
+
+"Books! And cleverness! There are more important things - friendship and bravery."
+```
+
+Here's an example file for Malfoy:
+
+```md
+---
+name: Draco Malfoy
+house: Slytherin
+status: Alive
+---
+
+Draco Malfoy is Harry's rival and a member of Slytherin House.
+
+## Quotes
+
+"My father will hear about this!"
+```
+
+By the end of this step you should end up with the following folder structure:
+
+```
+Harry Potter Characters
+└── characters
+    ├── Harry Potter.md
+    ├── Hermione.md
+    └── Malfoy.md
+```
+
+## Step 3: Create a data catalog
+
+Now let's create a data catalog of our Harry Potter characters!
+
+In the root of our vault, let's create a file called `Catalog` (but you can name it whatever you want) that's going to display a table with all our characters and their metadata. Inside it, we're going to write the following code block with a simple Dataview query:
+
+````md
+```dataview
+table name, house, status
+from "characters"
+sort name asc
+```
+````
+
+Let's break it down:
+
+- `table name, house, status`: This line instructs Dataview to create a table that includes columns for "name", "house", and "status". These are fields that you should have defined in your markdown files' frontmatter, but you don't have to. For any missing field Dataview will just display `-`.
+- `from "characters"`: This tells Dataview to pull the data from all markdown files located in the `/characters` folder in your Obsidian vault.
+- `sort name asc`: This command sorts the data based on the "name" field, in ascending order.
+
+After you click somewhere outside of this code block, you should see the following table:
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/table1.png]]
+
+## Step 4: Add more metadata about characters
+
+We can continue to add more information about our characters. For example, let's add creatures each character owns:
+
+```md=
+---
+name: Harry Potter
+...
+creature: Hedwig (Owl)
+---
+
+...
+
+---
+
+name: Hermione Granger
+...
+creature: Crookshanks (Cat)
+---
+
+...
+
+```
+
+Now, if we want to show this field in our Dataview table, we need to add it to the first line of our dataview code block:
+
+````md
+```dataview
+table name, house, status, creature
+from "characters"
+sort name asc
+```
+````
+
+After clicking somewhere outside the code block, you should see an updated table that includes the column `creature`.
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/table2.png]]
+
+## Step 5: Enrich content with images and links
+
+To enhance your catalog, you can add images of characters, and links to other characters in your markdown content.
+
+#### Add images
+
+To add an image of a character, right-click on the image you want to embed and copy it to clipboard - you can use the image below - and paste it directly in your markdown file.
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/harry_original.png]]
+
+Obsidian will automatically save the file to the root of your vault and create a link to it in your content, so you'll end up with a link similar to this one:
+
+```md
+![[Pasted image 20230525212302.png]]
+```
+
+Which will render as:
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/harry.png]]
+
+#### Add links to other pages
+
+Obsidian allows you to create links between different notes (or in this case, characters). To add a link to another character, use the double bracket `[[]]` syntax.
+
+For example, if you're writing about Harry Potter and want to mention that he is friends with Hermione, you can link to Hermione's markdown file like this:
+
+```md
+He is a friend of [[Hermione]].
+```
+
+When you click on Hermione's name in the rendered link, Obsidian will take you to Hermione's file in your vault. If you hover over it, you'll see a preview of Hermione's file:
+
+![[/static/img/blog/2023-05-30-Create-a-catalog-of-anything-using-markdown-files/link-preview.png]]
+
+## Summary
+
+And there you have it! We've walked through the process of creating a personal data catalog using markdown files, the Obsidian application, and its Dataview plugin. We've transformed scattered data into a well-organized, easy-to-navigate, and visually pleasing catalog. Whether you've used our example of a Harry Potter character catalog or applied these steps to a different topic of your choosing, we hope you've found this tutorial helpful and empowering.
+
+Happy data cataloging!
+
+---
+
+You can find the [vault created in this tutorial here](https://github.com/datopian/markdowndb/tree/main/examples/obsidian-dataview).
+]]></description><link>https://portaljs.com/blog/create-a-simple-catalog-of-anything-using-markdown</link><guid isPermaLink="false">https://portaljs.com/blog/create-a-simple-catalog-of-anything-using-markdown</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Tue, 30 May 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Learn how to use MarkdownDB with our First Tutorial!]]></title><description><![CDATA[
+We've just released our first tutorial that covers the fundamentals of [MarkdownDB](https://github.com/datopian/markdowndb) - our new package for treating markdown files as a database. If you've been curious about how to manage your markdown files more effectively, this tutorial is an excellent starting point!
+
+![Gif](/static/img/blog/2023-05-26-lean-how-to-use-markdown/markdowndb.gif)
+
+## What is MarkdownDB?
+
+MarkdownDB can parse your markdown files, extract structured data (such as frontmatter, tags, back- and forward links and more), and create an index in a local SQLite database. It also provides a lightweight JavaScript API for querying the database and importing files into your application. With MarkdownDB, you have a powerful tool that allows you to efficiently query your markdown data.
+
+[🔍 Click here to learn more!](https://github.com/datopian/markdowndb)
+
+## What you're going to learn
+
+This tutorial guides you through the steps of creating a small project catalog. In our case, we used our open-source projects on GitHub - but you could use anything! We use simple markdown files to describe each project and then display them with the MarkdownDB package.
+
+## Step 1: Create a markdown file for each project
+
+First, let's create a markdown file for each project. You can use real project details or make up some examples. For the sake of this tutorial, we'll create files for some of the projects we've built at Datopian.
+
+```bash
+mkdir projects
+cd projects
+touch markdowndb.md portaljs.md flowershow.md datapipes.md giftless.md data-cli.md
+```
+
+In each file we'll write some short info about a given project, like so:
+
+```md
+# What is MarkdownDB
+
+MarkdownDB is a javascript library for treating markdown files as a database -- as a "MarkdownDB". Specifically, it:
+
+- Parses your markdown files to extract structured data (frontmatter, tags, etc) and creates an index in a local SQLite database
+- Provides a lightweight javascript API for querying the database and importing files into your application
+```
+
+## Step 2: Index markdown files into SQLite database
+
+Once we have prepared our markdown files, we can store them (or more precisely - their metadata) in a database, so that we can then query it later for specific project files.
+
+```bash
+# npx mddb <path-to-folder-with-md-files>
+npx mddb ./projects
+```
+
+The above command will output a `markdown.db` file in the directory where it was executed. So, in our case, the folder structure will look like this:
+
+```
+.
+├── markdown.db
+└── projects
+    ├── data-cli.md
+    ├── ...
+    └── portaljs.md
+```
+
+## Step 3: Explore the SQLite database
+
+Now, let's explore the database. We can do it with any SQLite viewer, e.g. https://sqlitebrowser.org/. When we open the `markdown.db` file in the viewer, we'll see a list of tables:
+
+- `files`: containing metadata of our markdown,
+- `file_tags`: containing tags set in the frontmatter of our markdown files,
+- `links`: containing wiki links, i.e. links between our markdown files,
+- `tags`: containing all tags used in our markdown files.
+
+In our case, the `files` table will look like this:
+
+![[/static/img/blog/2023-05-26-lean-how-to-use-markdown/sqlite-viewer.png]]
+
+You can also explore the database from the command line, e.g.:
+
+```bash
+sqlite3 markdown.db
+```
+
+And then run SQL queries, e.g.:
+
+```sql
+SELECT * FROM files;
+```
+
+Which will output:
+
+```bash
+27ce406aac24e59af7a9f3c0c0a437c1d024152b|projects/data-cli.md|md|data-cli||{}
+26b1b0b06a4f450646f9e22fc18ec069bf577d8c|projects/datapipes.md|md|datapipes||{}
+dafdd0daf71a1b06db1988c57848dc36947375f4|projects/flowershow.md|md|flowershow||{}
+32c8db33fb8758516bfefb6ab1f22d03b1e53a08|projects/giftless.md|md|giftless||{}
+7e01cae193f12f5a4a9be2b89f22b429761bd313|projects/markdowndb.md|md|markdowndb||{}
+5445349c6822704d6f531a83c2aca2e4f90de864|projects/portaljs.md|md|portaljs||{}
+```
+
+## Step 4: Query the database in the Node.js app
+
+Now, let's write a simple script that will query the database for our projects and display them on the terminal.
+
+First, let's create a new Node.js project:
+
+```bash
+mkdir projects-list
+cd projects-list
+npm init -y
+```
+
+Then, let's install the `mddb` package:
+
+```bash
+npm install mddb
+```
+
+Now, let's create a new file `index.js` and add the following code:
+
+```js
+import { MarkdownDB } from 'mddb';
+
+// change this to the path to your markdown.db file
+const dbPath = 'markdown.db';
+
+const client = new MarkdownDB({
+  client: 'sqlite3',
+  connection: {
+    filename: dbPath,
+  },
+});
+
+const mddb = await client.init();
+
+// get all projects
+const projects = await mddb.getFiles();
+
+console.log(JSON.stringify(projects, null, 2));
+
+process.exit(0);
+```
+
+Since we're using ES6 modules, we also need to add `"type": "module"` to our `package.json` file.
+
+Before we run the above script, we need to make sure that the `dbPath` variable is pointing to our `markdown.db` file. If you want to store the database outside of your project folder, you can update the `dbPath` variable to point to the correct location. If you want to have it inside your project folder, you can copy it there, or simply re-run the `npx mddb <path-to-markdown-folder>` command from within your project folder.
+
+Now, let's run the script:
+
+```bash
+node index.js
+```
+
+It should output the JSON with all our projects.
+
+```json
+[
+  {
+    "_id": "7e01cae193f12f5a4a9be2b89f22b429761bd313",
+    "file_path": "projects/markdowndb.md",
+    "extension": "md",
+    "url_path": "markdowndb",
+    "filetype": null,
+    "metadata": {}
+  },
+  ...
+]
+```
+
+## Step 5: Add metadata to project files
+
+Now, let's add some metadata to our project files. We'll use frontmatter for that. Since we're creating a catalog of our GitHub projects, we'll add the following frontmatter fields to each file:
+
+```md
+---
+name: markdowndb
+description: Javascript library for treating markdown files as a database.
+stars: 6
+forks: 0
+---
+```
+
+After adding the metadata, we need to re-index our markdown files into the database:
+
+```bash
+npx mddb ../projects
+```
+
+Now, if we run our script again, we'll see that the `metadata` field in the output contains the metadata we've added to our project files:
+
+```json
+[
+  {
+    "_id": "7e01cae193f12f5a4a9be2b89f22b429761bd313",
+    "file_path": "projects/markdowndb.md",
+    "extension": "md",
+    "url_path": "markdowndb",
+    "metadata": {
+      "name": "markdowndb",
+      "description": "Javascript library for treating markdown files as a database",
+      "stars": 6,
+      "forks": 0
+    }
+  },
+  ...
+]
+```
+
+## Step 6: Pretty print the output
+
+Now, let's make the output a bit more readable. We'll use the `columnify` package for that:
+
+```bash
+npm install columnify
+```
+
+And then we'll update our `index.js` file:
+
+```js {2,16-38}
+import { MarkdownDB } from 'mddb';
+import columnify from 'columnify';
+
+const dbPath = 'markdown.db';
+
+const client = new MarkdownDB({
+  client: 'sqlite3',
+  connection: {
+    filename: dbPath,
+  },
+});
+
+const mddb = await client.init();
+const projects = await mddb.getFiles();
+
+// console.log(JSON.stringify(projects, null, 2));
+
+const projects2 = projects.map((project) => {
+  const { file_path, metadata } = project;
+  return {
+    file_path,
+    ...metadata,
+  };
+});
+
+const columns = columnify(projects2, {
+  truncate: true,
+  columnSplitter: ' | ',
+  config: {
+    description: {
+      maxWidth: 80,
+    },
+  },
+});
+
+console.log('\n');
+console.log(columns);
+console.log('\n');
+
+process.exit(0);
+```
+
+The above script will output the following to the terminal:
+
+![[/static/img/blog/2023-05-26-lean-how-to-use-markdown/output.png]]
+
+## Done!
+
+That's it! We've just created a simple catalog of our GitHub projects using markdown files and the MarkdownDB package. You can find the [full code for this tutorial here](https://github.com/datopian/markdowndb/tree/main/examples/basic-example).
+
+We look forward to seeing the amazing applications you'll build with this tool!
+
+Happy coding!
+]]></description><link>https://portaljs.com/blog/markdowndb-basics-tutorial-2023</link><guid isPermaLink="false">https://portaljs.com/blog/markdowndb-basics-tutorial-2023</guid><dc:creator><![CDATA[Ola Rubaj]]></dc:creator><pubDate>Fri, 26 May 2023 00:00:00 GMT</pubDate></item><item><title><![CDATA[Generate an interactive webpage from CSV data and markdown]]></title><description><![CDATA[
+## Getting Started
+
+This tutorial will help you get started with the Datahub pages, and how you can use it to create data driven webpages from static data. 
+
+Data pages you will create can be deployed with static site hosting providers like Github pages. Cloudfare pages, Netlify, or Vercel. 
+
+Here's an [example of a hosted Datahub page](https://datahub.io/collections/demographics) showing how data, text and simple charts can be displayed. 
+
+In this tutorial, we aim to keep things simple, so we'll show you how you can turn a CSV and a ReadMe into a Datahub page. 
+
+## Set up
+
+### Prepare your data folder
+
+* Create new data folder and add your CSV data. We'll be using a folder called `my-data` and a CSV data called `data.csv`
+* Add a `README.md` file with some markdown content. You can also add and use custom Datahub components like TableGrid, and LineCharts. See [this example](https://github.com/datopian/portal.js/blob/main/examples/data-literate/pages/demo.mdx)
+* For example to display your data as a Table in the page, you can add the following to your `README.md` file:
+
+```markdown
+<TableGrid url='data.csv' /> 
+```
+
+* At the end you should have a data folder with the following structure:
+
+```bash
+
+├── my-data
+
+     └── data.csv
+
+     └── README.md
+```
+### Initialize Datahub page from template
+
+Now that you have your data folder created and saved. In a new folder, you're going to initialize your datahub page, using a template we have provided. Follow the steps below to achieve this:
+
+* Run the following command in your terminal to install and create your datahub page from our template. You can always change the name of the folder from `datahub-pages-example`  to anything you like:
+
+```bash
+npx create-next-app@latest --example https://github.com/datopian/portal.js/tree/main/examples/data-literate-template datahub-pages-example
+```
+
+* Navigate into the folder:
+
+```bash
+cd datahub-pages-example
+```
+
+* Next you'll copy data files from your data folder into Datahub page. We have provided a handy script to automatically do this for you. All you need to do is pass the full/relative path to your data folder
+
+```bash
+node datahub-portal-local-cli.js ./my-data
+```
+## Test Locally
+
+After copying the files with the `datahub-portal-local-cli.js`, you should have the data.csv file in the `public` folder, and the README.md file in the pages folder under the name `index.mdx`. 
+Now we can view the generated page locally by running:
+
+```
+npm run dev  
+```
+
+This will start the development server, and you can view the page by navigating to http://localhost:3000
+
+## Deployment
+
+The generated page from above is a static Next.js webpage. As such you can deploy it anywhere Next.Js sites can be deployed. The following platforms support deployment of Next.js sites, and you can yse anyone of your choice:
+
+* [Vercel](https://nextjs.org/docs/deployment#managed-nextjs-with-vercel)
+* [Cloudfare pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
+* [Netlify](https://www.netlify.com/blog/2021/03/16/try-the-new-essential-next.js-plugin-now-with-auto-install/)
+* [Github pages](https://gregrickaby.blog/article/nextjs-github-pages)
+
+## Conclusion
+
+We are working towards adding new and better features to Datahub pages. You can request or suggest features in your issue tracker on Github [here](https://github.com/datopian/next.datahub.io/issues).
+
+## Resources
+
+* [Portal.js](https://github.com/datopian/portal.js#component-list) provides custom components you can use in your data pages
+* [Demo page](https://datahub.io/collections/air-pollution) a live Datahub page deployed on Cloudfare
+]]></description><link>https://portaljs.com/blog/generate-an-interactive-webpage-from-csv-data-and-markdown</link><guid isPermaLink="false">https://portaljs.com/blog/generate-an-interactive-webpage-from-csv-data-and-markdown</guid><dc:creator><![CDATA[Rising Odegua]]></dc:creator><pubDate>Mon, 14 Mar 2022 00:00:00 GMT</pubDate></item><item><title><![CDATA[A Short Case Study Involving Table Schema Frictionless Specs at the European Union]]></title><description><![CDATA[
+The Frictionless specifications are helping with simplifying data validation for applications in production at the European Union. More specifically, [Costas Simatos](https://joinup.ec.europa.eu/user/73932) introduced the Frictionless Data community to the [Interoperability Test Bed](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository) (ITB), an online platform that can be used to test systems against technical specifications --- curious minds will find a recording of his presentation on the subject [available on YouTube](https://www.youtube.com/watch?v=pJFsJW96fuA). Amongst the tools it offers, there is a [CSV validator](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository/solution/csvvalidator) which relies on the [Table Schema specifications](https://specs.frictionlessdata.io/table-schema/). Those specifications filled a gap that the [RFC 4180](https://datatracker.ietf.org/doc/html/rfc4180) didn't address by having a structured way of defining the content of individual fields in terms of data types, formats and constraints, which is a clear benefit of the Frictionless specifications as reported back in 2020 [when a beta version of the CSV validator was launched](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository/solution/interoperability-test-bed/news/table-schema-validator).
+
+![Puzzle texture with negative space](/static/img/blog/2021-06-21-frictionless-specs/clark-van-der-beken-596baa0MpyM-unsplash.jpg)
+_Photo by Clark Van Der Beken on Unsplash_
+
+---
+
+Frictionless specifications are flexible while allowing users to define unambiguously the expected content of a given field, therefore they were officially adopted to [realise the validator for the Kohesio pilot phase of 2014-2020](https://joinup.ec.europa.eu/collection/interoperability-test-bed-repository/solution/interoperability-test-bed/news/test-bed-support-kohesio-pilot), [Kohesio](https://kohesio.eu/) being the _"Project Information Portal for Cohesion Policy"_. The Table Schema specifications made it easy and convenient for the Interoperability Test Bed to establish constraints and describe the data to be validated in a concise way based on an initial set of [CSV syntax rules](https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/kohesio-validator/specification), converting written and mostly non-technical definitions to their Frictionless equivalent. Using simple JSON objects, Frictionless specifications allowed the ITB to enforce data validation in multiple ways as can be observed from the [schema used for the CSV validator](https://github.com/ISAITB/validator-resources-kohesio/blob/master/resources/schemas/schema.json). The following list of items calls attention to the core aspects of the Table Schema standard that were taken advantage of:
+
+* Dates can be defined with string formatting (e.g. `%d/%m/%Y` stands for `day/month/year`);
+* Constraints can indicate whether a column can contain empty values or not;
+* Constraints can also specify a valid range of values (e.g. `"minimum": 0.0` and `"maximum": 100.0`);
+* Constraints can specify an enumeration of valid values to choose from (e.g. `"enum" : ["2014-2020", "2021-2027"]`).
+* Constraints can be specified in custom ways, such as with [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) for powerful string matching capabilities;
+* Data types can be enforced for any column;
+* Columns can be forced to adapt a specific name and a description can be provided for each one of them.
+
+Because these specifications can be expressed as portable text files, they became part of a multitude of tools to provide greater convenience to users and the validation process has been [documented extensively](https://www.itb.ec.europa.eu/docs/guides/latest/validatingCSV/index.html). JSON code snippets from the documentation highlight the fact that this format conveys all the necessary information in a readable manner and lets users extend the original specifications as needed. In this particular instance, the CSV validator can be used as a [Docker image](https://hub.docker.com/repository/docker/isaitb/validator-kohesio), as part of a [command-line application](https://www.itb.ec.europa.eu/csv-offline/kohesio/validator.zip), inside a [web application](https://www.itb.ec.europa.eu/csv/kohesio/upload) and even as a [SOAP API](https://www.itb.ec.europa.eu/csv/soap/kohesio/validation?wsdl).
+
+In a way, the Frictionless specifications were the missing piece of the puzzle that enabled the ITB to rely on a well-documented set of standards for their data validation needs.
+]]></description><link>https://portaljs.com/blog/frictionless-specs-european-commission</link><guid isPermaLink="false">https://portaljs.com/blog/frictionless-specs-european-commission</guid><dc:creator><![CDATA[sebastien.lavoie]]></dc:creator><pubDate>Tue, 22 Jun 2021 00:00:00 GMT</pubDate></item><item><title><![CDATA[Setup Guide: How to create a full-featured custom data portal frontend for CKAN with PortalJS]]></title><description><![CDATA[
+We have created a full data portal demo using DataHub PortalJS all backed by a CKAN instance storing data and metadata, you can see below a screenshot of the homepage and of an individual dataset page.
+
+![Datahub Home page](https://i.imgur.com/ai0VLS4.png)
+![individual dataset page](https://i.imgur.com/3RhXOW4.png)
+
+## Create a Portal app for CKAN
+
+To create a Portal app, run the following command in your terminal:
+
+```console
+npx create-next-app -e https://github.com/datopian/datahub/tree/main/examples/ckan
+```
+
+> NB: Under the hood, this uses the tool called create-next-app, which bootstraps an app for you based on our CKAN example.
+
+## Guide
+
+### Styling 🎨
+
+We use Tailwind as a CSS framework. Take a look at `/styles/globals.css` to see what we're importing from Tailwind bundle. You can also configure Tailwind using `tailwind.config.js` file.
+
+Have a look at Next.js support of CSS and ways of writing CSS:
+
+https://nextjs.org/docs/basic-features/built-in-css-support
+
+### Backend
+
+So far the app is running with mocked data behind. You can connect CMS and DMS backends easily via environment variables:
+
+```console
+$ export DMS=http://ckan:5000
+$ export CMS=http://myblog.wordpress.com
+```
+
+> Note that we don't yet have implementations for the following CKAN features:
+>
+> - Activities
+> - Auth
+> - Groups
+> - Facets
+
+### Routes
+
+These are the default routes set up in the "starter" app.
+
+- Home `/`
+- Search `/search`
+- Dataset `/@org/dataset`
+- Resource `/@org/dataset/r/resource`
+- Organization `/@org`
+- Collection (aka group in CKAN) (?) - suggest to merge into org
+- Static pages, eg, `/about` etc. from CMS or can do it without external CMS, e.g., in Next.js.
+
+### New Routes
+
+You can create new routes in `/pages` directory where each file is associated with a route based on its name. We suggest using [Next.JS docs][] for more detailed information.
+
+[next.js docs]: https://nextjs.org/docs/basic-features/pages
+
+### Data fetching
+
+We use Apollo client which allows us to query data with GraphQL. We have setup CKAN API for the demo (it uses demo.ckan.org as DMS):
+
+http://portal.datopian1.now.sh/
+
+Note that we don't have Apollo Server but we connect CKAN API using [`apollo-link-rest`](https://www.apollographql.com/docs/link/links/rest/) module. You can see how it works in [lib/apolloClient.ts](https://github.com/datopian/portal/blob/master/lib/apolloClient.ts) and then have a look at [pages/\_app.tsx](https://github.com/datopian/portal/blob/master/pages/_app.tsx).
+
+For development/debugging purposes, we suggest installing the Chrome extension - https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm.
+
+### I18n configuration
+
+PortalJS is configured by default to support both `English` and `French` subpath for language translation. But for subsequent users, this following steps can be used to configure i18n for other languages;
+
+1.  Update `next.config.js`, to add more languages to the i18n locales
+
+```js
+i18n: {
+  locales: ['en', 'fr', 'nl-NL'], // add more language to the list
+  defaultLocale: 'en',  // set the default language to use
+},
+```
+
+2. Create a folder for the language in `locales` --> `locales/en-Us`
+
+3. In the language folder, different namespace files (json) can be created for each translation. For the `index.js` use-case, I named it `common.json`
+
+```json
+// locales/en/common.json
+{
+   "title" : "Portal js in English",
+}
+
+// locales/fr/common.json
+{
+   "title" : "Portal js in French",
+}
+```
+
+4. To use on pages using Server-side Props.
+
+```js
+import { loadNamespaces } from './_app';
+import useTranslation from 'next-translate/useTranslation';
+
+const Home: React.FC = ()=> {
+  const { t } = useTranslation();
+  return (
+    <div>{t(`common:title`)}</div> // we use common and title base on the common.json data
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+      ........  ........
+  return {
+    props : {
+      _ns:  await loadNamespaces(['common'], locale),
+    }
+  };
+};
+
+```
+
+5. Go to the browser and view the changes using language subpath like this `http://localhost:3000` and `http://localhost:3000/fr`. **Note** The subpath also activate chrome language Translator
+
+### Pre-fetch data in the server-side
+
+When visiting a dataset page, you may want to fetch the dataset metadata in the server-side. To do so, you can use `getServerSideProps` function from NextJS:
+
+```javascript
+import { GetServerSideProps } from 'next';
+import { initializeApollo } from '../lib/apolloClient';
+import gql from 'graphql-tag';
+
+const QUERY = gql`
+  query dataset($id: String) {
+    dataset(id: $id) @rest(type: "Response", path: "package_show?{args}") {
+      result
+    }
+  }
+`;
+
+...
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: QUERY,
+    variables: {
+      id: 'my-dataset'
+    },
+  });
+
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+  };
+};
+```
+
+This would fetch the data from DMS and save it in the Apollo cache so that we can query it again from the components.
+
+### Access data from a component
+
+Consider situation when rendering a component for org info on the dataset page. We already have pre-fetched dataset metadata that includes `organization` property with attributes such as `name`, `title` etc. We can now query only organization part for our `Org` component:
+
+```javascript
+import { useQuery } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
+
+export const GET_ORG_QUERY = gql`
+  query dataset($id: String) {
+    dataset(id: $id) @rest(type: "Response", path: "package_show?{args}") {
+      result {
+        organization {
+          name
+          title
+          image_url
+        }
+      }
+    }
+  }
+`;
+
+export default function Org({ variables }) {
+  const { loading, error, data } = useQuery(
+    GET_ORG_QUERY,
+    {
+      variables: { id: 'my-dataset' }
+    }
+  );
+
+  ...
+
+  const { organization } = data.dataset.result;
+
+  return (
+    <>
+      {organization ? (
+        <>
+        {}
+          <img
+            src={
+              organization.image_url
+            }
+            className="h-5 w-5 mr-2 inline-block"
+            alt={`${oragnization.name} logo`}
+          />
+          <Link href={`/@${organization.name}`} className="font-semibold text-primary underline">
+              {organization.title || organization.name}
+          </Link>
+        </>
+      ) : (
+        ''
+      )}
+    </>
+  );
+}
+```
+]]></description><link>https://portaljs.com/blog/example-ckan-2021</link><guid isPermaLink="false">https://portaljs.com/blog/example-ckan-2021</guid><dc:creator><![CDATA[Luccas Mateus]]></dc:creator><pubDate>Tue, 20 Apr 2021 00:00:00 GMT</pubDate></item><item><title><![CDATA[COVID-19 and Compartmental Models in Epidemiology]]></title><description><![CDATA[
+The severity of the current SARS-CoV-2 epidemic is undeniable: since the latest months of 2019, the COVID-19 outbreak is having a significant impact in the world at the macro level, starting its spread from China, then to the Asia-Pacific and then around the rest of the globe.
+
+![Man sleeping on a bus during the COVID-19 outbreak in London](/static/img/blog/2020-05-05-covid19-models/edward-howell-IDhks1n8GYM-unsplash.jpg)
+
+_Photo by Edward Howell on Unsplash_
+
+---
+
+## Models
+
+### Introduction
+
+More than 41 articles were published about COVID-19 just from the beginning of 2020, more than 10,000 GitHub forks of [CSSEGISandData](https://github.com/CSSEGISandData) were made, various open data sets (including [on GitHub](https://github.com/nties/COVID19-open-research-dataset) and [on Kaggle](https://www.kaggle.com/sudalairajkumar/novel-corona-virus-2019-dataset)) shared the number of cases and the number of people affected as well as other metrics.
+
+Many scientists around the globe participated in a global hackathon, trying to address current issues (lockdowns, lack of resources, etc.), trying to fit, predict and estimate the impact. Which models from these ones are close to the reality and which ones have a chance to be implemented as solutions for humanitarian response?
+
+### Basic Mathematical Models
+
+There are various types of models in epidemiology, which are used for prediction of prevalence (total number of people infected), the duration of an epidemic spreading processes and other variables.
+
+One of the most commonly used types are compartmental models, developed in the 1920s from the Kermack–McKendrick theory. In compartmental models, the population is divided into compartments of people with the same properties: people who are susceptible to the virus; those who have recovered; etc. There are three main types of compartmental models in epidemiology based on which many other models can be built upon:
+
+- Susceptible-Infectious (SI), where each person can be in one of two states, either susceptible (S) or infectious (I);
+- Susceptible-Infectious-Susceptible (SIS), where a person can be in one of two states, susceptible (S) or infectious (I), but can then become susceptible again;
+- Susceptible-Infectious-Recovered (SIR), where a person can be in one of three states: susceptible (S), infectious (I) or recovered \(R\).
+
+In the SIR model, one can study the number of people in each of three compartments: susceptible, infectious and recovered, denoted by the variables S, I and R correspondingly. The SIR system can be expressed by the set of ordinary differential equations proposed by O. Kermack and Anderson Gray McKendrick.
+
+Another model, which has been proven to be much more realistic for some epidemics spreading models is the [SEIR model](https://www.medrxiv.org/content/10.1101/2020.03.20.20040048v1). The main idea of this model is that for many important infections, there is a significant incubation period during which individuals have been infected but are not yet infectious themselves. During this period, the individual is in a special state E (exposed), an additional state to three states in the SIR model.
+
+![sirmodel-beta-mu-parameters](/static/img/blog/2020-05-05-covid19-models/sirmodel_beta_mu_parameters.png)
+
+Some models described here are also explained [on this page](https://github.com/datasets/awesome-data/blob/master/coronavirus.md).
+
+### "Fitting the Curve" - Issues to Consider
+
+During COVID-19 many open data sources were gathered, which explains the temptation of fitting the curve to empirical data or inferring parameters of spreading models. Here, we list some of the main issues with simply trying to do "curve fitting" approach:
+
+1. One of the first and simplest epidemiological model is the SI model. If you are in an infected state within this model, you stay infected forever. This one-way transition S → I is already not so realistic, at the same time the increasing number of infected cases can be obviously fit to the curves with the increasing number of cases, for example from this [time series](https://datahub.io/core/covid-19).
+2. Issues with more complex models, such as SIR or SEIR are more delicate. If we assume that in the beginning of an epidemic the fraction of susceptible individuals is still around 1 and that the number of infected people is exponentially growing as <img src="/static/img/blog/2020-05-05-covid19-models/math_expr1.png" alt="math-expr-1"/>, we need to estimate the [basic reproduction number](https://en.wikipedia.org/wiki/Basic_reproduction_number) of the virus as <img src="/static/img/blog/2020-05-05-covid19-models/math_expr2.png" alt="math-expr-2"/>. The intuitive explanation of the basic reproduction number is the following: if each person is able to spread the disease to at least one other person before recovering, then the epidemic can continue, otherwise, if <img src="/static/img/blog/2020-05-05-covid19-models/math_expr3.png" alt="math-expr-3"/>, the epidemic dies off. The problem here is that in reality, the population is very heterogeneous: there is no such thing as a single type of infectious individual since immune systems are varying from one person to another. Hence even if estimated from the empirical data, the true value <img src="/static/img/blog/2020-05-05-covid19-models/math_expr4.png" alt="math-expr-4"/> will still need to be estimated with the confidence interval. For COVID-19 the estimates show that <img src="/static/img/blog/2020-05-05-covid19-models/math_expr5.png" alt="math-expr-5"/>.
+3. In reality, one needs to take into account the information about so-called *incubation period*, the time elapsed between exposure to a pathogen, and when symptoms and signs start to appear. At the same time the effects from the mitigation policies, such as lockdown procedures, can be miscalculated using the simplest SIR models, since there total lockdown would correspond to <img src="/static/img/blog/2020-05-05-covid19-models/math_expr6.png" alt="math-expr-6"/>, which gives unrealistic results.
+
+For more publications on COVID-19 please see recent peer-reviewed articles, such as [Fergusson et al.](https://www.medrxiv.org/content/10.1101/2020.03.09.20033357v1)
+
+Find more illustrations and code by B.Goncalves at [Epidemiology101](https://github.com/DataForScience/Epidemiology101).
+
+## Predictions of next waves and role of mobility data
+
+Prediction of next waves of COVID19 can be made using various models, 
+including classical simple SIR model or its variations. One can already see the effect of curve flattening by changing the parameters, such as mobility index or average number of interactions between people. For spatial statistics one may need to use spatially embedded models, such as more generic and complex models [Gleamviz model](http://www.gleamviz.org/).
+For calibrating these models, 
+one need to use expert-curated healthcare datasets available to COVID-19 researchers and data scientists.  Mobility trends are important components for prediction of epidemics spreading, therefore we are working on making finding open mobility datasets.
+Below we collected some references of datasets and peer-reviewed publications:
+
+1. Mobility data on the effect of confinement on mobility: [mobility data](https://github.com/datasciencecampus/google-mobility-reports-data/) on
+mobility of people in residential, non-residential areas;
+2. Mobility data and predictions from the perspective of so-called "mobility index" can be found on the website of Cuebiq and illustrated in [Gleamproject](https://covid19.gleamproject.org/mobility);
+3. Recent work and overview of predictive modeling of spreading COVID19 made and explained simply by B.Gonsalves, network scientist and physicist [here](https://medium.com/data-for-science/visualizing-the-spread-of-covid-19-a4ea21ee8e46);
+4. References resource of more than 128,000 scholarly articles about the novel coronavirus for use by the global research community: [coronawhy](https://www.coronawhy.org/cord19).
+
+
+]]></description><link>https://portaljs.com/blog/covid19-and-compartmental-models-in-epidemiology</link><guid isPermaLink="false">https://portaljs.com/blog/covid19-and-compartmental-models-in-epidemiology</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Fri, 08 May 2020 00:00:00 GMT</pubDate></item><item><title><![CDATA[Open Data Day 2020 and COVID-19 data]]></title><description><![CDATA[
+Here at DataHub and [Datopian](https://www.datopian.com/), we recently celebrated [Open Data Day 2020](https://opendataday.org/). If you're not familiar with Open Data Day, it's an annual worldwide celebration of open data.
+
+For part of our day, we decided to clean up and package some data on COVID-19 (coronavirus). The data includes **province/state**, **country/region**, **latitude**, **longitude**, **date**, **confirmed**, **recovered**, and **deaths**. Our source was from the [Data Repository by Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19), which is updated daily by [Johns Hopkins Whiting School of Engineering](https://systems.jhu.edu/).
+
+To clean up the data, we used a Python library called dataflows, which is available in the [PyPI](https://pypi.org/project/dataflows/), and on [GitHub](https://github.com/datahq/dataflows). We used this library to unpivot the data, accumulate the daily cases, and consolidate our 3 sources (Johns Hopkins has separate CSV files for cases: [confirmed](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Confirmed.csv), [recovered](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Recovered.csv), and [deaths](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Deaths.csv)).
+
+The source code and results can be found on [GitHub](https://github.com/datasets/covid-19), and a published dataset can be found here on [DataHub](https://datahub.io/core/covid-19). Our next step is to release a visualization.
+
+Whether or not you've participated in Open Data Day before, we hope to see you participate next year!
+]]></description><link>https://portaljs.com/blog/open-data-day-covid-19</link><guid isPermaLink="false">https://portaljs.com/blog/open-data-day-covid-19</guid><dc:creator><![CDATA[michael.polidori]]></dc:creator><pubDate>Tue, 17 Mar 2020 00:00:00 GMT</pubDate></item><item><title><![CDATA[Comparotron: A simple way to visualize and share comparisons]]></title><description><![CDATA[
+Comparotron allows users to quickly create simple comparative visualizations.
+
+There are already many graphing and apps out there so what's different about comparotron? 
+
+The essence of the idea is simplicity and the power (and freedom) of constraints: comparotron is *only* about comparisons and limits you to just one or two numbers. That's it. No more, no less. We think that this constraint is powerful -- and fun! And lends itself to quick, creative story-telling.
+
+As pictures 📷 are worth a thousand words let's dive in with some mockups that give a sense of the idea.
+
+[[toc]]
+
+## Comparotron Illustrated
+
+### The first mockup of the idea (by David McCandless) in 2010
+
+The first mockup of the idea (by David McCandless) done for the [Where Does My Money Go][wdmmg] project (2010)
+
+![The first mockup of the idea (by David McCandless) done for the Where Does My Money Go](https://f.cloud.github.com/assets/180658/750549/198722d0-e4d0-11e2-8a57-998f68acfeaf.png)
+
+### New mockups created as part of Open Data Day 2020
+
+This is all real data by the way!
+
+![Coronavirus (COVID-19) vs Flu Mortality Rates](/static/img/blog/comparotron-v0.2-march-2020-coronavirus-vs-flu.svg)
+
+![US Spending on Military vs Aid](/static/img/blog/comparotron-v0.2-march-2020-military-vs-aid.svg)
+
+ ## History
+
+The concept originated in 2010 as part of [Where Does My Money Go][wdmmg] when looking for ways to present government spending effectively. Giving a real sense of this kind of data can be hard because of the size, variety and abstractness of the figures -- what does $3bn of aid spending really *mean*?
+
+Introducing comparison can help provide context, tangibility and "meaning". For example, we can compare aid spending to other spending items  such as spending on the military which will given a relative sense to the aid number.
+
+Or, alternatively, we could compare aid expenditure to some external more "every-day" figure; for example, the cost of a loaf of bread of a teacher's salary yielding a comparison like "aid spending is equivalent to employing 10,000 teachers for a year".
+
+[wdmmg]: https://app.wheredoesmymoneygo.org/
+
+## Work on Open Data Day 2020
+
+Here at [DataHub][] and [Datopian][] we were delighted to take part of [Open Data Day][] -- and [to help sponsor it][sponsor]. We've been part of [open data][] from the beginning -- our President started [Open Knowledge Foundation][okf] and helped kick-off Open Data Day as an event!
+
+[Comparotron][] is one of the projects we worked on this [Open Data Day][]. Along with getting on top of the [initial effort][] from nearly eight years ago (how time flies!) we:
+
+* Created example comparisons by hand -- see above
+* Outlined the MVP -- see below
+* And ... created a plan of work for it
+
+Phew, that's quite a bit! 🚀
+
+[DataHub]: https://datahub.io/
+[Datopian]: https://datopian.com/
+[sponsor]: https://www.datopian.com/2020/01/15/a-data-platform-for-open-data-day-2020/
+[open data]: https://okfn.org/opendata/
+[Open Data Day]: https://opendataday.org/
+[okf]: https://okfn.org/
+[Comparotron]: https://comparotron.datahub.io/
+[initial effort]: https://github.com/datopian/comparotron/releases/tag/v0.1
+
+## Getting to an MVP
+
+A central part of the [original conception][original] was a rich experience for user's to find/select the data points they wanted to use. This made sense if you already had a database of government spending data. Even when I moved away from this idea to allow all kinds of numeric data (in comparotron v0.1 in 2012), this assumption continued to inform the approach and I spent most of my effort on the functionality and UX for searching for and selecting data ptoints (indeed, I spent plenty oof time wondering about where data would be stored and come from e.g. would it be in elastic search, where would I source GDP per capita from etc).
+
+[original]: https://github.com/datopian/comparotron/issues/1
+
+But thinking about this, we can simplify a lot:
+
+* Simplication 1: we can assume the user will find the data points and enter that info themselves => no need for fancy search or data sourcing
+* Simplication 2: that still leaves us with an editor (and backend) for people to create "compares" ... but what about just using static website tech and storing this in markdown+frontmapper => no need for an editor, backend or APIs -- just use your text editor, markdown files and git(hub) as backend
+
+Thanks to MVP approach we're gradually moving from building a complex 🚗 to making a much more manageable 🛹 Yeah 👌
+
+### Essential user flows
+
+What are the essential user flows? There are just two:
+
+* **Create**: create a "compare" by entering one or more "factoids" (plus a title)
+* **Show**: display the comparison in a beautiful and elegant way
+
+MVP approach to these:
+
+* **Create**: use a simple markdown file with frontmatter, edit it in a text editor, and push it to github (Even simpler: hand-craft this in a drawing app!)
+* **Show**: let's use a static site generator to build the site and some basic JS (or even CSS) for the visualization
+
+## Initial Examples
+
+Here's the hand-crafted examples with we did (with real data)!
+
+### US Spending on Military vs Aid
+
+![US Spending on Military vs Aid](/static/img/blog/comparotron-v0.2-march-2020-military-vs-aid.svg)
+
+### Coronavirus (COVID-19) vs Flu Mortality Rates
+
+![Coronavirus (COVID-19) vs Flu Mortality Rates](/static/img/blog/comparotron-v0.2-march-2020-coronavirus-vs-flu.svg)
+
+## Next Steps
+
+We're continuing to work on the project and you can follow the progress (and contribute!) on github here:
+
+https://github.com/datopian/comparotron
+
+First steps will be getting a stub website live at https://comparotron.datahub.io
+
+Check back soon for more updates! 👌
+]]></description><link>https://portaljs.com/blog/comparotron-a-simple-way-to-visualize-and-share-comparisons</link><guid isPermaLink="false">https://portaljs.com/blog/comparotron-a-simple-way-to-visualize-and-share-comparisons</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Sun, 08 Mar 2020 00:00:00 GMT</pubDate></item><item><title><![CDATA[New Machine Learning Datasets]]></title><description><![CDATA[
+We are happy to present new datasets extracted from [open-ml](https://www.openml.org/home) website. You can find them at our machine-learning datasets [page](https://www.datahub.io/machine-learning). OpenML is a hub for sharing interesting open source machine learning datasets. It links data to algorithms and people, so you can build on the state of the art and learn to teach machines to learn better. Some of the most popular datasets among our users for you to take a look at:
+
+* [Vehicle silhouettes](https://www.datahub.io/machine-learning/vehicle)
+* [Diabetes](https://www.datahub.io/machine-learning/diabetes)
+* [Musk](https://www.datahub.io/machine-learning/musk) 
+
+
+We extracted 100 most downloaded datasets from OpenML for you to practice and solve problems. We hope that you will find them useful and informative.
+]]></description><link>https://portaljs.com/blog/new-machine-learning-datasets</link><guid isPermaLink="false">https://portaljs.com/blog/new-machine-learning-datasets</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Mon, 10 Sep 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Automatically updated core datasets on DataHub]]></title><description><![CDATA[
+Check out a list of core datasets that are updated on a regular basis. From financial to reference data - it is the best place to find a wide range of up to date datasets.
+
+## Financial data
+
+* [VIX - CBOE Volatility Index](/core/finance-vix) :clock1: updated daily
+* [Natural gas prices](/core/natural-gas) :clock1: updated daily
+* [Oil prices](/core/oil-prices) :clock1: updated weekly
+* [10 year US Government Bond Yields](/core/bond-yields-us-10y) :clock1: updated monthly
+* [10 year UK Government Bond Yields](/core/bond-yields-uk-10y) :clock1: updated quarterly
+
+## Reference data
+
+* [Airport codes](/core/airport-codes) :clock1: updated daily
+* [Language codes](/core/language-codes) :clock1: updated monthly
+
+## Other
+
+* [Population growth estimates and projections](/core/population-growth-estimates-and-projections) :clock1: updated annually
+
+There will be more automated datasets on :datahub: so join our [community chat on :discord: Discord](https://discord.gg/KrRzMKU) and our Newsletter (insert link) to receive the latest news!
+]]></description><link>https://portaljs.com/blog/automatically-updated-core-datasets-on-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/automatically-updated-core-datasets-on-datahub</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 05 Sep 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Sports data on DataHub]]></title><description><![CDATA[
+Great news! We've expanded our range of datasets to include sports data. You can find football data that includes all the major European leagues and ATP tennis data. The football datasets are updated on weekly basis. Check out the publisher page for the `sports-data` now:
+
+https://datahub.io/sports-data
+
+For the sports betting enthusiasts and pros, we offer a Premium Data service (read more on [pricing page](/pricing)). We can customize the data, include additional data and have more regular updates and guarantee those updates with an SLA amongst other services.
+
+There will be more data in the future so don't forget to bookmark the link :smile:
+
+## New sports dataset available on :datahub:
+
+Below is the list of datasets that are published and available for you to use:
+
+* [ATP World Tour tennis data](/sports-data/atp-world-tour-tennis-data)
+* [English Premier League (football)](/sports-data/english-premier-league)
+* [Spanish La Liga (football)](/sports-data/spanish-la-liga)
+* [Italian Serie A (football)](/sports-data/italian-serie-a)
+* [German Bundesliga (football)](/sports-data/german-bundesliga)
+* [French Ligue 1 (football)](/sports-data/french-ligue-1)
+]]></description><link>https://portaljs.com/blog/sports-data-on-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/sports-data-on-datahub</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Fri, 31 Aug 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Attribute Relation File Format (ARFF)]]></title><description><![CDATA[
+We are happy to present a short description of ARFF format that is very useful for those interested in machine learning. In this post we shall explain some features of this format.
+
+## What is ARFF?
+
+ARFF stands for Attribute-Relation File Format. It is an ASCII text file that describes a list of instances sharing a set of attributes. ARFF files were developed by the Machine Learning Project at the Department of Computer Science of The University of Waikato for use with the Weka machine learning software. This document descibes the version of ARFF used with Weka versions 3.2 to 3.3; this is an extension of the ARFF format as described in the data mining book written by Ian H. Witten and Eibe Frank (the new additions are string attributes, date attributes, and sparse instances).
+
+This explanation was cobbled together by Gordon Paynter (gordon.paynter at ucr.edu) from the Weka 2.1 ARFF description, email from Len Trigg (lenbok at myrealbox.com) and Eibe Frank (eibe at cs.waikato.ac.nz), and some datasets. It has been edited by Richard Kirkby (rkirkby at cs.waikato.ac.nz). Contact Len if you're interested in seeing the ARFF 3 proposal.
+
+## Overview
+ARFF files have two distinct sections. The first section is the **Header** information, which is followed by the **Data** information.
+
+The Header of the ARFF file contains the name of the relation, a list of the attributes (the columns in the data), and their types. An example header on the standard IRIS dataset looks like this:
+
+   % 1. Title: Iris Plants Database
+   %
+   % 2. Sources:
+   %      (a) Creator: R.A. Fisher
+   %      (b) Donor: Michael Marshall (MARSHALL%PLU@io.arc.nasa.gov)
+   %      (c) Date: July, 1988
+   %
+   @RELATION iris
+
+   @ATTRIBUTE sepallength  NUMERIC
+   @ATTRIBUTE sepalwidth   NUMERIC
+   @ATTRIBUTE petallength  NUMERIC
+   @ATTRIBUTE petalwidth   NUMERIC
+   @ATTRIBUTE class        Iris-setosa,Iris-versicolor,Iris-virginica
+
+The Data of the ARFF file looks like the following:
+
+   @DATA
+   5.1,3.5,1.4,0.2,Iris-setosa
+   4.9,3.0,1.4,0.2,Iris-setosa
+   4.7,3.2,1.3,0.2,Iris-setosa
+   4.6,3.1,1.5,0.2,Iris-setosa
+   5.0,3.6,1.4,0.2,Iris-setosa
+   5.4,3.9,1.7,0.4,Iris-setosa
+   4.6,3.4,1.4,0.3,Iris-setosa
+   5.0,3.4,1.5,0.2,Iris-setosa
+   4.4,2.9,1.4,0.2,Iris-setosa
+   4.9,3.1,1.5,0.1,Iris-setosa
+
+Lines that begin with a % are comments. The @RELATION, @ATTRIBUTE and @DATA declarations are case insensitive.
+
+## Datahub examples
+You can find ARFF files in resources for our machine-learning datasets datahub.io/machine-learning that we extracted from [openml](https://www.openml.org/search?type=data) website. We hope that you will find them useful for your projects in macahine learning and data science.
+
+
+*Branko graduated physics at the University of Belgrade and his current work focuses on finding, extracting, formatting and publishing data on DataHub. In his free time he enjoys reading, coding and long walks on the beach in his landlocked home country of Serbia*
+]]></description><link>https://portaljs.com/blog/attribute-relation-file-format-arff</link><guid isPermaLink="false">https://portaljs.com/blog/attribute-relation-file-format-arff</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Thu, 23 Aug 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to use multiple DataHub accounts]]></title><description><![CDATA[
+If you are using `data` CLI tool for both personal and professional purposes, you would need to have more than 1 account. Below we explain how account configurations work and how you can manage them - it is simple and straightforward!
+
+## Accounts and config files
+
+You have config file per account, which is stored in `~/.config/datahub/` directory. By default, its name is `config.json` - try to 'cat' it to have a sense about how it looks like:
+
+```bash
+cat ~/.config/datahub/config.json
+```
+
+and you'd get following output:
+
+```json
+{
+    "token": "your-token",
+    "profile": {
+        "avatar_url": "...",
+        "email": "...",
+        "id": "...",
+        "join_date": "...",
+        "name": "...",
+        "provider_id": "...",
+        "username": "..."
+    }
+}
+```
+
+If you have multiple accounts, it is suggested to store config files in the same location so you always can list and quickly find them. For example, you can rename your personal config file to `my.json`, while your organization account configs would have `org.json` name. If you list files in your configs directory:
+
+```bash
+ls ~/.config/datahub/
+```
+
+you'd get:
+
+```bash
+my.json    org.json
+```
+
+## Switch between your accounts
+
+Once you have all config files locally with appropriate names, it is easy to switch between them. It can be done by setting `DATAHUB_JSON` environment variable. The CLI tool will use value of this variable to authenticate you in the system. Simply set it up for the current session, e.g., let's use your org account:
+
+```bash
+export DATAHUB_JSON=~/.config/datahub/org.json
+```
+
+## Check current account
+
+Although the `data` CLI tool doesn't have a command for checking which account you're using, you can print current value of your `DATAHUB_JSON` variable:
+
+```bash
+echo $DATAHUB_JSON
+```
+
+---
+
+*Originally published at https://datahub.io/docs/tutorials/how-to-use-multiple-datahub-accounts*
+]]></description><link>https://portaljs.com/blog/how-to-use-multiple-datahub-accounts</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-use-multiple-datahub-accounts</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 18 Jul 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[World Bank Indicators on DataHub]]></title><description><![CDATA[
+We have extracted 307 indicators from The World Bank and published them on DataHub:
+
+https://datahub.io/world-bank
+
+The World Bank Open Data website offers free access to comprehensive, downloadable indicators about development in countries around the globe. Most of the country-level, time-series data—including indicators in the WDI section are accessible through the standard World Bank data API. By using this API we have extracted and published all of the 307 datasets for world bank indicators from page https://data.worldbank.org/indicator?tab=all. Indicators are sorted in 20 different categories:
+
+- Agriculture & Rural Development
+- Aid Effectiveness
+- Climate Change
+- Economy & Growth
+- Education
+- Energy & Mining
+- Environment
+- External Debt
+- Financial Sector
+- Gender
+- Health
+- Infrastructure
+- Poverty
+- Private Sector
+- Public Sector
+- Science & Technology
+- Social Development
+- Social Protection & Labor
+- Trade
+- Urban Development
+]]></description><link>https://portaljs.com/blog/world-bank-indicators-on-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/world-bank-indicators-on-datahub</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Mon, 16 Jul 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Automated KPIs collection and visualization of the funnels]]></title><description><![CDATA[
+As a platform dedicated to providing access to high quality data and tooling we need to measure how useful our users find DataHub's services. Measurable values like how many users we have, site traffic, how many people run our `data` CLI tool, how many of our datasets are published etc. are all key performance indicators (KPIs) that demonstrate how effectively we do as a company in terms of achieving our key business objectives.
+
+In order to monitor our KPIs, we want to do the followings:
+
+* collect KPIs from Google Analytics and internal APIs so we can keep all stats in the one place;
+* package the CSV data and publish it to DataHub so we have a standardized, cleaned and validated dataset of our KPIs;
+* add visualizations to easily and quickly see insights.
+
+## The problem of KPIs tracking
+
+In order to keep up-to-date with the usage of our website and services, we collect stats from various sources - our SQL database, our search API, Google Analytics for datahub.io, etc. This process of collection had been done manually at first which presented significant problems for us - it was time consuming and prone to human error as it required tediously scrolling pages and clicking buttons for a long period of time that got longer the more stats we decided to collect.
+
+## Solution that we created to tackle tracking challenges
+
+To address these issues we have created a scalable model for stats collection outlined in a github repo [datahub-metrics](https://github.com/datahq/datahub-metrics) with the task of collecting daily, weekly and biweekly stats for datahub.io and its services. The script is written in Python and it is ran automatically via cronjob on Travis. After collecting these stats, CSV data files are created.
+
+Once we've automated KPIs collection, we wanted to output it on DataHub so our team can easily get insights.
+
+### Publish on DataHub
+
+First we needed to package CSV data files so they have a standard metadata. We then wanted to publish it on DataHub so the team can access cleaned, normalized and validated data.
+
+With our `data` CLI tool we can add metadata for our CSV files by running `data init`. This creates a JSON file `datapackage.json`, which contains information about the name, format and data type of the columns, encoding, missing values etc.:
+
+```json
+{
+    "name": "datahub-metrics",
+    "title": "Datahub metrics",
+    "resources": [...]
+}
+```
+
+*See full `datapackage.json` [here](https://github.com/datahq/datahub-metrics/blob/master/datapackage.json).*
+
+Once the data is packaged, we just need to upload it to DataHub. By running `data push` command from the root directory of the dataset we have following link of our published data:
+
+https://datahub.io/datahq/datahub-metrics
+
+### Visualization of the funnels
+
+Now we want to identify and visualize the funnels that gives us an idea about where we should improve.
+
+We have defined couple of initial funnels that we think is important. We consider ratio of important KPIs against total unique visitors. This way we can tell if decrease in certain area caused by our latest implementations. We will visualize following KPIs:
+
+1. New sign ups
+2. Number of CLI downloads from the website
+
+Below we have written how "views" property would look like in the `datapackage.json` file:
+
+:::info
+In order to define how the graphs should look like we add a "views" property to `datapackage.json` file that will tell DataHub platform to create graphs on our page. By just editing a few lines in "views" property we can easily change the appearance of our graphs on the whim. Things like which stats to create graph for, which time period to display, average and max values etc.
+:::
+
+```json
+{
+    "name": "datahub-metrics",
+    "title": "Datahub metrics",
+    "resources": ["..."],
+    "views": [
+      {
+        "name": "funnels",
+        "title": "Funnels",
+        "resources": [
+            {
+              "name": "biweekly_stats",
+              "transform": [
+                {
+                  "type": "formula",
+                  "expressions": [
+                    "data['Total new users'] * 100 / data['Total Unique Visitors']",
+                    "data['Downloads CLI (GA)'] * 100 / data['Total Unique Visitors']"
+                  ],
+                  "asFields": [
+                    "Percentage of total new users in the sprint",
+                    "Percentage of total CLI downloads from website in the sprint"
+                  ]
+                }
+              ]
+            }
+        ],
+        "specType": "simple",
+        "spec": {
+          "group": "Date",
+          "series": [
+            "Percentage of total new users in the sprint",
+            "Percentage of total CLI downloads from website in the sprint"
+          ],
+          "type": "line",
+          "ySuffix": "%"
+        }
+      }
+    ]
+}
+```
+
+These specifications are rendered as below on the DataHub:
+
+<iframe src="https://datahub.io/datahq/datahub-metrics/view/0" width="100%" height="475px" frameborder="0"></iframe>
+
+By taking a look at this graph, we could say that number of CLI downloads significantly decreased since May 3, while number of sign ups remain at the same level. This must be due to redesign that we have implemented in the beginning of the May.
+
+## Summary
+
+By creating 'datahub-metrics' and automating it via Travis CI we drastically shortened the time needed for collecting stats. That which would take at least a half an hour on a daily basis is now being done in no time and at assigned times with no possibility of human error. Once the stats are assembled in clean CSV files we use data-cli to package and publish it. The `datapackage.json` file is thus created and by adding a view section to it we can create and format customized visualizations on our dataset page. Every time the stats files are updated, so are the graphs.
+
+By doing this we have created a scalable model for stats collection and created reusable python modules for interacting with google analytics, sql database, google sheets etc. You can use our platform to keep track of stats for your website and services the same way we did. We hope that you will find our approach informative and useful in your projects where tracking user interactions with your website and services is paramount.
+]]></description><link>https://portaljs.com/blog/automated-kpis-collection-and-visualization-of-the-funnels</link><guid isPermaLink="false">https://portaljs.com/blog/automated-kpis-collection-and-visualization-of-the-funnels</guid><dc:creator><![CDATA[branko-dj]]></dc:creator><pubDate>Tue, 10 Jul 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Revamped awesome collections: data sets that are grouped by subject]]></title><description><![CDATA[
+Awesome pages are collections of data from DataHub and the web that are grouped and analyzed for your usage. Our goal is to cover all important subjects and users always can [suggest](#contribute) a new theme to consider. Visit and explore revamped awesome collections now:
+
+https://datahub.io/awesome
+
+## Find data sets by subject
+
+Below are some of awesome collections you may find useful.
+
+### Economic data
+
+Summary of all available economic indicators on DataHub:
+
+https://datahub.io/awesome/economic-data
+
+### Reference data
+
+This page is the place where you can find all reference data available on DataHub. Each dataset is easy-to-use and includes instructions on how to use it in different tools and programming languages:
+
+https://datahub.io/awesome/reference-data
+
+### Demographics
+
+Population data and data analytics:
+
+https://datahub.io/awesome/demographics
+
+### Stock market data
+
+Find and Explore ready-to-use Stock Market Datasets:
+
+https://datahub.io/awesome/stock-market-data
+
+### Other collections
+
+There are more collections available - to find out more please go to:
+
+https://datahub.io/awesome
+
+## Contribute
+
+You may notice a button on the right for editing existing awesome collection. Basically, you can open a pull request on https://github.com/datahq/awesome-data repository and our team will review and add your work.
+]]></description><link>https://portaljs.com/blog/revamped-awesome-collections-data-sets-that-are-grouped-by-subject</link><guid isPermaLink="false">https://portaljs.com/blog/revamped-awesome-collections-data-sets-that-are-grouped-by-subject</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 11 Jun 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Machine learning datasets]]></title><description><![CDATA[
+We have created a number of `machine learning` datasets that can be interesting for professionals and students from the field.
+
+You can see our current machine-learning datasets at https://datahub.io/machine-learning
+
+## Introduction
+
+Machine learning is the science of making computers learn like humans do and to also improve their capabilities to learn to act without being explicitly programmed. It is used as a general term for computational data analysis: using data to make inferences and predictions. It combines computational statistics, data analytics, data mining and a good portion of data science. Machine learning algorithms are often categorized as supervised or unsupervised (“data mining”).
+
+For more information please visit:
+https://datahub.io/awesome#machine-learning-statistical
+
+Example dataset:
+
+| Column 1 | Column 2 | Column 3 | Class |
+|----------|----------|----------|-------|
+| 0        | 1        | 2        | 0     |
+| 3        | 4        | 5        | 1     |
+| 6        | 7        | 8        | 2     |
+| 9        | 10       | 11       | 3     |
+| 12       | 13       | 14       | 4     |
+
+Using columns as input, machine learning algorithms can "learn" how to predict the appropriate output for any input.
+
+Some of the more famous algorithms for supervised learning include:
+* Neural networks
+* Naive Bayes
+* K - nearest neighbor
+* Decision tree
+* Support Vector Machines
+
+Some of the more famous algorithms for unsupervised learning include:
+* DB Scan
+* K - means
+
+All above algorithms can be applied on datasets that are located under the machine-learning user.
+
+## Available datasets
+
+Some interesting datasets you can take a look at:
+* [Seismic bumps](https://datahub.io/machine-learning/seismic-bumps)
+* [Hepatitis](https://datahub.io/machine-learning/hepatitis)
+* [Cervical cancer](https://datahub.io/machine-learning/cervical-cancer)
+* [Primary tumor](https://datahub.io/machine-learning/primary-tumor)
+* [Fertility](https://datahub.io/machine-learning/fertility)
+* [Breast cancer](https://datahub.io/machine-learning/breast-cancer)
+* [Speed dating](https://datahub.io/machine-learning/speed-dating)
+* [Dermatology](https://datahub.io/machine-learning/dermatology)
+* [Lymph](https://datahub.io/machine-learning/lymph)
+* [Tic Tac Toe Endgame](https://datahub.io/machine-learning/tic-tac-toe-endgame)
+* [EEG Eye State](https://datahub.io/machine-learning/eeg-eye-state)
+
+## Usage
+
+* For those new to data science and machine learning you can dive in with analysis and practicing on our prepared datasets. No need to modify the raw unprocessed online data, we have already taken care of that.
+
+* For those advanced in the study of machine learning you can get a wide range of well-prepared datasets (including well known ones) that you can practice on so that you can improve and focus your efforts on improving your understanding.
+
+* For machine learning practitioners you can find up to date datasets that you can use for implementing newest classificators so that you can contribute to machine learning community or create projects for any organization you may work with.
+
+Starting with machine learning will be shown on `hepatitis` dataset and in Python language:
+https://datahub.io/machine-learning/hepatitis#python
+
+### Getting a dataset
+First thing to do is install datapackage library
+
+```bash
+pip install datapackage
+```
+
+Then you need to get your dataset using the "Import into your tool" (option at the bottom of the page)
+
+```python
+from datapackage import Package
+
+package = Package('https://datahub.io/machine-learning/hepatitis/datapackage.json')
+
+# print list of all resources:
+print(package.resource_names)
+
+# print processed tabular data (if exists any)
+for resource in package.resources:
+    if resource.descriptor['datahub']['type'] == 'derived/csv':
+        print(resource.read())
+```
+
+### Input and output matrices
+
+In the `hepatitis` dataset last column represents the class attribute which holds the information about whether the patient lived or died.
+
+We will mark the number of columns with letter **m**, and number of instances with letter **n**
+
+Input matrix will contain all elements from all columns except class which means that it's dimension will be **n** x **m-1**.
+
+| n        | Column 1 | Column 2 | ...      | Column m-1 |
+|----------|----------|----------|----------|----------
+| 1        | x        | x        | ...      |  x
+| 2        | x        | x        | ...      |  x
+| ...      | ...      | ...      | ...      |  ...
+| n        | x        | x        | ...      |  x
+
+Output matrix will contain elements from class attribute and it's dimension will be **n**x**1**
+
+| n        | Column 1(class) |
+|----------|-----------------|
+| 1        | x               |
+| 2        | x               |
+| ...      | ...             |
+| n        | x               |
+
+By using those matrices you will be able to pass them as a parameter to any classifier method.
+
+
+## Summary
+
+By using DataHub you can easily get the datasets you need and just start working on them without necessary data-wrangling and focus on creating machine learning algorithms. We hope you find them useful and interesting.
+]]></description><link>https://portaljs.com/blog/machine-learning-datasets</link><guid isPermaLink="false">https://portaljs.com/blog/machine-learning-datasets</guid><dc:creator><![CDATA[svetozarstojkovic]]></dc:creator><pubDate>Fri, 25 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Auto-publish your datasets using Travis-CI]]></title><description><![CDATA[
+In this tutorial, we provide instructions on how to automate publishing your dataset via [Travis-CI]. If you prefer hosting and controlling your dataset on GitHub, you'd find this tutorial useful. Before reading further, please, make sure you're familiar with GitHub and Travis-CI as you'll need to enable builds for your repository.
+
+[Travis-CI]: https://travis-ci.org/
+
+Let's consider the request we've received recently for auto-publishing the dataset from the following repository:
+
+https://github.com/datasets/dac-crs-codes
+
+Please, read through the issue thread here to understand the problem: https://github.com/datahq/datahub-qa/issues/213.
+
+## Setup
+
+Our goal is to trigger a publishing on every commit to 'master' branch. To do so we'll use the [data] CLI tool for interacting with DataHub, which is available via [NPM]. Below is how the configuration file (`.travis.yml`) for Travis-CI would look like:
+
+```yaml
+language: node_js
+node_js:
+  - "8"
+install: npm install -g data-cli
+script: data push --public
+branches:
+  only:
+  - master
+```
+
+This instructs Travis-CI to install 'data' CLI tool via NPM and publish the dataset with 'public' option which makes it publicly available. It assumes that there is a `datapackage.json` file in the root directory of the repository.
+
+[data]: https://datahub.io/download
+[NPM]: https://www.npmjs.com/package/data-cli
+
+## Credentials
+
+If you try to trigger a build, it wouldn't publish anything to DataHub since you need to set credentials. Provide `token`, `id` and `username` values of your DataHub account as environment variables - go to your Travis-CI settings and add the required key-value pairs. We recommend not displaying values in build log for security reasons. Additionally, you may need to setup `env` variable with `test` value to overcome some Travis specific errors.
+
+![setting env variable test to overcome some travise specific errors](https://raw.githubusercontent.com/datahq/datahub-content/master/assets/img/travis-ci-env-vars.png)
+
+## Final steps
+
+Now, you should be able to trigger a Travis-CI build by pushing a commit into 'master' branch. If builds are not starting, make sure that 'Build pushed branches' option is enabled in the settings.
+]]></description><link>https://portaljs.com/blog/auto-publish-your-datasets-using-travis-ci</link><guid isPermaLink="false">https://portaljs.com/blog/auto-publish-your-datasets-using-travis-ci</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 23 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[JavaScript SDK for data deployment]]></title><description><![CDATA[
+Here we explain how you can use JavaScript SDK for data deployment purposes. If you need a detailed step-by-step tutorial, please, go to this article:
+
+https://datahub.io/docs/tutorials/js-sdk-tutorial
+
+## Prerequisites
+
+1. You need to have NodeJS (`>= 7.6`) and NPM.
+2. Installed `datahub-client` and `data.js` NPM packages:
+
+      `npm install datahub-client data.js --save`
+
+## Example of usage
+
+Following code snippet is a working example for basic usage. It uses credentials stored in `~/.config/datahub/config.json`, which is created when you login using [the CLI tool](https://datahub.io/download).
+
+```javascript
+const {DataHub, config, authenticate} = require('datahub-client')
+const {Dataset} = require('data.js')
+
+async function pushDataset(datasetPath) {
+  // First, authenticate user
+  const apiUrl = config.get('api')
+  const token = config.get('token')
+  const response = await authenticate(apiUrl, token)
+  if (!response.authenticated) {
+    console.error('Your credentials expired or missing.')
+    return
+  }
+  // Load dataset that we want to push
+  const dataset = await Dataset.load(datasetPath)
+  // Create an instance of the DataHub class, using the data from the user config
+  const configs = {
+   apiUrl,
+   token,
+   ownerid: config.get('profile') ? config.get('profile').id : config.get('id')
+  }
+  const datahub = new DataHub(configs)
+
+  // Now use the datahub instance to push the data
+  const res = await datahub.push(dataset, {findability: 'unlisted'})
+  console.log(res)
+}
+
+pushDataset('path/to/dataset')
+```
+
+This is an example of correct console output:
+
+```
+{ dataset_id: 'username/finance-vix',
+  errors: [],
+  flow_id: 'username/finance-vix/1',
+  success: true }
+```
+
+That is all needed to get your dataset deployed in DataHub!
+]]></description><link>https://portaljs.com/blog/javascript-sdk-for-data-deployment</link><guid isPermaLink="false">https://portaljs.com/blog/javascript-sdk-for-data-deployment</guid><dc:creator><![CDATA[acckiygerman]]></dc:creator><pubDate>Tue, 15 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to initialize a data package using data tool]]></title><description><![CDATA[
+In this article we explain how easy is adding a `datapackage.json` file for your data. You need to have `data` tool installed - [download it](https://datahub.io/download) and follow these [instructions](https://datahub.io/docs/getting-started/installing-data).
+
+:::info
+If you're not familiar with `datapackage.json`, please, read this article - https://datahub.io/docs/data-packages.
+:::
+
+Below is how our project looks like initially:
+
+```cli-output
+$ ls
+
+README.md   sample.csv   sample.json
+```
+
+We will use `data init` command to create a `datapackage.json` file for this project below.
+
+## Default mode
+
+By default, `data init` command runs in non-interactive mode. No arguments and options are required, it will scan current working directory and all nested directories for the available files:
+
+```cli-output
+$ data init
+
+\> This process initializes a new datapackage.json file.
+
+\> Once there is a datapackage.json file, you can still run 'data init' to update/extend it.
+
+\> Press ^C at any time to quit.
+
+\> Detected special file: README.md
+
+\> sample.csv is just added to resources
+
+\> sample.json is just added to resources
+
+\> Default "ODC-PDDL" license is added. If you would like to add a different license, run 'data init -i' or edit 'datapackage.json' manually.
+
+\> 💾 Descriptor is saved in "datapackage.json"
+```
+
+and now the project contains `datapackage.json`:
+
+```cli-output
+$ ls
+
+README.md  datapackage.json  sample.csv  sample.json
+```
+
+If you take a look at `datapackage.json`, you'd mention that:
+
+* it uses name of the current working directory as `name` property and generates `title` from it
+* it adds `sample.csv` and `sample.json` files into `resources` list with schema for tabular data
+* it detects `README.md` and uses its content in `readme` property; `description` property is the first 100 characters of the readme
+* it adds default `ODC-PDDL` license
+
+## Interactive mode
+
+If you need more control, e.g., you want to add only certain files, scan certain directories and add a different license, you can use `init` command in interactive mode:
+
+```
+$ data init -i
+```
+
+## What's next?
+
+You can now deploy your dataset to DataHub:
+
+```
+$ data push
+```
+
+Want to learn more? Visit our docs page - https://datahub.io/docs
+]]></description><link>https://portaljs.com/blog/how-to-initialize-a-data-package-using-data-tool</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-initialize-a-data-package-using-data-tool</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 14 May 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Validate your Data Package descriptor online]]></title><description><![CDATA[
+To help users with creation of Data Packages we have implemented a descriptor validation tool:
+
+https://datahub.io/tools/validate
+
+Now users can check the Data Package descriptor to be sure they have no errors in it.
+
+## How to use it
+
+The descriptor should be stored online, e.g. on the github.
+
+You should provide the URL to the descriptor (datapackage.json) file and press 'Validate' button.
+
+:::info
+Online validator tool validates only the descriptor file.
+
+Here you can read about the [full data validation on the DataHub](https://datahub.io/blog/data-validation-in-the-datahub).
+:::
+
+## How we validate
+
+We try to create a Data Package object using [datapackage-js](https://github.com/frictionlessdata/datapackage-js) and then show user any errors the Data Package has with `Package.valid` and `Package.errors` methods. For example, here we validate following [datapackage.json](https://raw.githubusercontent.com/frictionlessdata/test-data/master/packages/invalid-descriptor/datapackage.json) file that has invalid `name` property:
+
+![online-validation-tool-invalid-package](/static/img/docs/online-validation-tool-invalid-package.png)
+
+To create a valid Data Package, please read full datapackage.json specs here:
+
+https://frictionlessdata.io/docs/data-package/
+]]></description><link>https://portaljs.com/blog/online-validation-tool</link><guid isPermaLink="false">https://portaljs.com/blog/online-validation-tool</guid><dc:creator><![CDATA[acckiygerman]]></dc:creator><pubDate>Thu, 19 Apr 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Q1 2018 Review]]></title><description><![CDATA[
+We're sharing an update on all the progress we made in the first quarter of 2018. We massively improved our `data` command line tool, sped up data deployment 5-100x and introduced embeddable shareable data tables and visualizations.  We welcome feedback and ideas on how to keep improving the platform.
+
+## Polishing `data` command line tool and QA
+
+Q1 focused on polishing the `data push` flow and starting to improve the funnel of take up. We also improved `data` tool generally and added a few new features in the frontend such as embeddable tables and views.
+
+On `data` tool we did a lot of work on QA. We put in place a new QA process including a full breakdown of key processes, a new, more comprehensive testing system plus a new method for tracking issues in github.
+
+Summary of QA stats (as for 29 Mar 2018):
+
+* Total test cases: 203
+* Automated: ~50
+* Manual: ~150
+* Opened issues: ~100
+* Closed issues: ~70
+
+<iframe src="https://datahub.io/examples/datahub-qa-issues-tracker/view/0" width="100%" height="475px" frameborder="0"></iframe>
+
+*The graph above illustrates number of open issues by severity.*
+
+Issue trackers:
+
+* QA repo (and the main issue tracker) is now located at :github: https://github.com/datahq/datahub-qa/issues
+* We also have issue tracker dataset - :datahub: https://datahub.io/examples/datahub-qa-issues-tracker
+
+## Fixes and features
+
+### Data Factory
+
+* Processing speed improvements i.e. processing of 1MB CSV file was decreased from 45s to 29s and we're still working on it to make it even faster. During this process it validates and normalizes the dataset + generates cleaned CSV and JSON version of each tabular data file and ZIP version of a data package which also contains validaiton report.
+* Excel processing improvements - fixes for various bugs related to different coercion of data types in JS vs Python. This fix should enable publishers to work with most of data types in the Excel.
+
+### `data` command line tool and associated JS libraries
+
+* Windows version of the CLI and improved release management.
+* Progress bar on push so publishers have better UX while their files are being uploaded: ![Progress bar on push so publishers have better UX while their files are being uploaded](/static/img/docs/upload-progress-bar.png)
+* Parsing and ingest:
+  * support for various CSV delimiters such as semicolons, colons, pipes, tabs etc.
+  * support for various encodings
+* Skipping uploading files if already uploaded which dramatically improves push performance on repeated deployments.
+* `validate` command improvements: users now see process details, e.g., which file is being validated - useful when your data package has lots of files: ![`validate` command improvements: useful when your data package has lots of files](/static/img/docs/validate-details.png)
+* `info` command improvements: support for non-tabular files and improved information about datasets: ![`info` command improvements: support for non-tabular files and improved information about datasets](/static/img/docs/info-output.png)
+* `get` command works with files from GitHub and DataHub + getting datasets from Datahub now downloads zip version and unzips it for you.
+* `cat` command works with streamed data, e.g., from `stdin`: ![`cat` command works with streamed data](/static/img/docs/cat-streamed-data.png)
+* Error handling and messaging improvements throughout the CLI app.
+
+### Frontend
+
+* Shareable and embeddable views + HTML tables, read more about it here https://datahub.io/blog/new-features-and-improvements
+* Search improvements, e.g., now we're ignoring stop words.
+* Extended and improved instructions for using datasets from different programming languages and tools - now we have ready to use instructions for `data-cli`, `curl`, `R`, `Python`, `Pandas` and `JavaScript`.
+* Pagination on search and publisher pages as number of datasets on DataHub have increased.
+* Search in publisher page - now you can search datasets from specific publisher (e.g., core datasets - https://datahub.io/core).
+* Support for custom axis titles and suffixes in the ticks, which is important when you're creating graphs, read more about it here https://datahub.io/docs/features/views#axis-titles-and-suffixes-for-axis-ticks
+
+### Docs
+
+* Ability to give feedback or contribute to the docs, e.g., see https://datahub.io/docs/getting-started/installing-data - you can easily improve this docs article now.
+* Improved docs with GIFs so users understand how things work, e.g., see https://datahub.io/docs/getting-started/publishing-data
+* Improved and extended documentation about different commands
+
+## Summary
+
+In the Q1, the DataHub team focused on making the tools stable and useful for people - it was productive and exciting start of the year! There is a lot to be done in the Q2 so stay tuned for new updates and features!
+]]></description><link>https://portaljs.com/blog/q1-2018-review</link><guid isPermaLink="false">https://portaljs.com/blog/q1-2018-review</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 11 Apr 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[New Features and Improvements]]></title><description><![CDATA[
+Good day, dear data miners, scientists and statisticians!
+
+During the last month we were focused on polishing the existing product - DataHub platform and the **data-cli** tool. Also we added number of new features.
+
+## New ways to share data
+
+Say, you are creating PhD thesis or a blog article. And you need to share some data in a pretty-looking form? That's so easy with the DataHub - just [upload your data](https://datahub.io/docs/getting-started/publishing-data)  and follow steps below.
+
+### Share data tables
+
+Each dataset on the datahub.io has preview tables for tabular data. Now you can share or embed them:
+
+![preview tables for tabular data. Now you can share or embed them](/static/img/docs/share-embed-tables.png)
+
+The **Share link** opens the table in the full-screen mode. Your colleague can easily find data and copy the entire table (or some part of it) to the clipboard and paste into the excel file, google sheets etc.
+
+The **Embed snippet** allows you to integrate the table into your HTML document or a web-site:
+
+<iframe src="https://datahub.io/core/gini-index/r/0.html" width="100%" height="300px" frameborder="0"></iframe>
+
+**Note:** preview table contains only 2000 rows of original data to avoid possible browser crash cause of the big data.
+
+### Share views and graphs
+
+The same idea works with graphs - each view for a dataset could be easily shared or embedded into your web-page using the links under the view:
+
+![each view for a dataset could be easily shared or embedded into your web-page using the links](/static/img/docs/share-embed-graphs.png)
+
+and here is the embedded version right here:
+
+<iframe src="https://datahub.io/core/gini-index/view/0" width="100%" height="475px" frameborder="0"></iframe>
+
+## Other small features
+
+- Data push command now shows a progress-bar when uploading files
+- User can add custom titles and axis suffixes to the views
+- TSV files are supported now
+- DataHub [API documentation](https://datahub.io/docs/features/api) has been added.
+]]></description><link>https://portaljs.com/blog/new-features-and-improvements</link><guid isPermaLink="false">https://portaljs.com/blog/new-features-and-improvements</guid><dc:creator><![CDATA[acckiygerman]]></dc:creator><pubDate>Mon, 26 Mar 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Improved Reporting and Debugging of Data Publishing]]></title><description><![CDATA[
+We've integrated our pipelines system with the website to display more insights to our users. Any dataset you publish on DataHub could be in one of three states: **processing**, **succeeded** or **failed**. Below we explain each state in detail.
+
+## Processing
+
+While your dataset is being processed, you can see a dataset page with information about currently running steps. For instance, it might be creating a JSON version of your tabular data or validating it against a table schema:
+
+![dataset page with information about currently running steps](/static/img/docs/processing-dataset.gif)
+
+## Succeeded
+
+This is just a regular dataset page you have seen before:
+
+![Regular dataset page](/static/img/docs/succeeded-dataset.png)
+
+## Failed
+
+If processing a dataset has failed, you would see a notice about it with a pipeline title that caused the error. You can also expand the error to read the logs and find out the reason for the failure:
+
+![failed processing of dataset](/static/img/docs/failed-dataset.gif)
+
+
+## Different versions of your dataset
+
+Each time you publish your dataset, a revision process is triggered for it. You can consider a revision as a version of your dataset, e.g., if it is the first time you have published a particular dataset, it would have version 1 (and the next revision would increment version by 1 so it'd be 2):
+
+`https://datahub.io/<username>/<dataset>/v/1`
+
+It becomes useful when you've re-published your dataset several times and you want to get your data in a specific stage.
+
+:::info
+A version is a natural number (integer larger than 0) and you can access the specific version of a dataset by `/v/{number}`.
+:::
+]]></description><link>https://portaljs.com/blog/improved-reporting-and-debugging-of-data-publishing</link><guid isPermaLink="false">https://portaljs.com/blog/improved-reporting-and-debugging-of-data-publishing</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 29 Jan 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Data Validation in the DataHub]]></title><description><![CDATA[
+Users can now use the DataHub to validate their tabular data, for example checking that dates really are dates or that a column of daily revenue is always positive.
+
+Data validation is also integrated as part of the data publishing flow making it easier to debug general errors -- the most common issue we've found in our own publishing experience is a typo in a data value that then breaks graphing or other data presentation and processing.
+
+## How to use it
+
+Data Validation now happens automatically for you whenever you push data to the DataHub so to validate data in a file or data package just push it to the DataHub:
+
+```
+# Note: in this case DataHub will auto-infer the types of the columns
+data push myfile.csv
+
+# a data package
+cd my-data-datapackage
+data push
+```
+
+:::info
+You can find more about pushing data to the DataHub [here](http://datahub.io/docs/getting-started/publishing-data).
+:::
+
+You may need to customize the schema for your file -- perhaps DataHub has guessed the types wrong.
+
+## How we validate
+
+We use the Table Schema for your data file along with the powerful [goodtables library](https://github.com/frictionlessdata/goodtables-py) to validate your data and generate a JSON validation report.
+
+This report is then used in your dataset page to show you a human-readable version of the errors (a JSON version is also available).
+
+## Validation reporting on the Showcase Page
+
+Results of the report will be displayed in an easy to understand form. Specifically, if there are errors you will see a detailed report like this:
+
+![Results of the Validation report](/static/img/docs/validation-report-vix-daily.png)
+
+This table displays errors in a validation report. You can see that in the example above we have 3 badges indicating key details (`INVALID` `SCHEMA` `985`) and `Type or Format Error` message. It means 985 values have type or format errors when validating against the schema. Details can be expanded by clicking on "Error details" link on the right. You also can find values causing this error on the table - they have a red background colour. By default, we show first 10 rows but you can open more of them by clicking on "Show next 10 rows" link.
+
+In the screenshot below, you can see how a validation report looks like for "Minimum Constraint" error. Revenue value cannot be negative so we've set `constraints` property with a `minimum` attribute as 0 and validation process identified which value is not meeting that requirement:
+
+![validation report revenue](/static/img/docs/validation-report-revenue.png)
+
+Below are properties that you can use in a table schema for validation of your data:
+
+* `constraints` - you may use this property to validate field values, e.g., a column with "Daily Revenue" or "Sales" must be a positive number so you'd have a `minimum` attribute set to 0.
+* `type` is a string indicating the type of this field, e.g., `string` or `number`.
+* `format` is a string indicating a format for the field type, e.g., you can have `email` format for `string` type so it validates if values in the field are emails.
+* other properties such as `missing values` can be used to indicate a special value for empty entries, e.g., `-` or `N/A`.
+
+You can find full table schema specs here https://frictionlessdata.io/specs/table-schema.
+]]></description><link>https://portaljs.com/blog/data-validation-in-the-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/data-validation-in-the-datahub</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Wed, 24 Jan 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Which country spends the most on pharmaceutical drugs?]]></title><description><![CDATA[
+There are several graphs that illustrate pharmaceutical drug spendings from the list OECD countries. Data is clean and available in several formats such as csv, json, zip.
+
+> Pharmaceutical spending covers expenditure on prescription medicines and self-medication, often referred to as over-the-counter products. In some countries, other medical non-durable goods are also included - [click here to read more](https://data.oecd.org/healthres/pharmaceutical-spending.htm).
+
+
+This chart illustrates total spending by country in 2015:
+
+![This chart illustrates total spending by country in 2015](/static/img/docs/pharma-dataset1.png)
+
+For comparison, you can take a look at spendings per capita in the same year: 
+
+![spendings per capita in the same year](/static/img/docs/pharma-dataset2.png)
+
+As you can see Americans spend the most on drugs compared to the rest of the world, and below you can see a chart that breaks down total spendings in the United States since 2000 and it is growing gradually:
+
+![chart that breaks down total spendings in the United States since 2000 and it is growing gradually](/static/img/docs/pharma-dataset3.png)
+
+
+The table below describes Pharmaceutical Drug Spending dataset by countries with indicators such as a share of total health spending, in USD per capita (using economy-wide Purchasing Power Parity or PPP), as a share of GDP and total spending since 1970.
+
+![table describes Pharmaceutical Drug Spending dataset by countries in USD per capita as a share of GDP and total spending since 1970.](/static/img/docs/pharma-dataset4.png)
+
+
+
+The dataset is live on [DataHub]( https://datahub.io/core/pharmaceutical-drug-spending). Also, you can find other well-formatted, high-quality core datasets in [DataHub](http://datahub.io/search?q=core).]]></description><link>https://portaljs.com/blog/pharmaceutical-drug-spending</link><guid isPermaLink="false">https://portaljs.com/blog/pharmaceutical-drug-spending</guid><dc:creator><![CDATA[mikanebu]]></dc:creator><pubDate>Tue, 23 Jan 2018 00:00:00 GMT</pubDate></item><item><title><![CDATA[Introducing private datasets on the DataHub]]></title><description><![CDATA[
+Today we are releasing support for **private** datasets on the DataHub. Private datasets are exactly that: private and visible and accessible only to their owners.
+
+This feature is designed to support several use cases. First, simply storing (and sharing) private data. Second, keeping data private prior to publication -- now users have a way to push data, check it and only make it public when they are ready.
+
+The private datasets feature is available on a trial basis to all DataHub users. If you want to use it on an ongoing basis you'll want to sign up for premium membership:
+
+https://datahub.io/pricing
+
+## How to publish private datasets?
+
+You can use either the command line tool or the "Data" desktop app. Please, visit our download page to find out more about available tools:
+
+https://datahub.io/download
+
+### Publish using the "Data" app
+
+Once you are ready to publish your data, just select "private" option and then press "Go" button:
+
+![just select "private" option and then press "Go" button](/static/img/docs/push-private.png)
+
+:::info
+Learn more about using the "Data" app [here](http://datahub.io/blog/data-desktop-app-alpha-release).
+:::
+
+### Publish using the command line tool
+
+Simply pass `--private` flag when you "push" your data so once it is processed and online only you can view it:
+
+```
+$ data push myData --private
+```
+
+:::info
+Learn more about how to publish datasets using the CLI [here](http://datahub.io/docs/getting-started/publishing-data).
+:::
+
+
+## Making a Private Dataset Public
+
+Just publish the dataset again but set the findability to public.
+]]></description><link>https://portaljs.com/blog/introducing-private-datasets-on-the-datahub</link><guid isPermaLink="false">https://portaljs.com/blog/introducing-private-datasets-on-the-datahub</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 13 Dec 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Data desktop app - alpha release with drag and drop data publishing support]]></title><description><![CDATA[
+We are pleased to announce the launch of our new desktop application for DataHub users. The app brings drag and drop publishing of data. In addition, users can preview and validate their data prior to upload. Currently the app is in alpha and only available for MacOS -- but we plan Linux and Windows soon! Get the app now from:
+
+https://datahub.io/download
+
+## Drag and drop files
+
+Simply drag and drop any files (e.g. CSV) or Data Packages (datapackage.json) into the tray icon and you will start the publishing process.
+
+![drag and drop any files (e.g. CSV) or Data Packages (datapackage.json) into the tray icon](/static/img/docs/drag-n-drop.gif)
+
+## Preview showcase page and edit properties
+
+First, you'll get a preview of your dataset. Here you can preview how it would look like online and edit name and title properties for it:
+
+![A preview of your dataset. Here you can preview how it would look like online and edit name and title properties for it.](/static/img/docs/app-showcase.png)
+
+## Table Schema editor and validation info
+
+Scroll down the page and you can see "Field Information" table that contains details from table schema for the data. You can see validity information for each field and edit field type if necessary. Once you have made a change, it will re-validate and update validity message:
+
+!["Field Information" table that contains details from table schema for the data](/static/img/docs/app-field-info.png)
+
+## Publish it!
+
+Ready to publish your data? Just hit the "Go!" button on the top of the page and it will be published at given path on datahub.io website. Once publish process is finished, you will get a notification - click on it to open online showcase page in your default browser:
+
+![publish your data with go button](/static/img/docs/app-publish.png)
+
+## Command line tool is always up-to-date
+
+In addition, to drag and drop publishing the desktop app auto-installs the command line program and will automatically keep it up to date for you:
+
+![to drag and drop publishing the desktop app auto-installs the command line program](/static/img/docs/app-cli-update.png)
+]]></description><link>https://portaljs.com/blog/data-desktop-app-alpha-release</link><guid isPermaLink="false">https://portaljs.com/blog/data-desktop-app-alpha-release</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Fri, 01 Dec 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[How to use Data Packages from R]]></title><description><![CDATA[
+This tutorial demonstrates how to use Data Packages from R. We assume that you already know about [Data Packages](https://datahub.io/docs/data-packages) and its [specifications](https://frictionlessdata.io/specs/data-packages/).
+
+## Example
+
+Let's consider "VIX - CBOE Volatility Index" data here. The VIX dataset is a key measure of market expectations of near-term volatility conveyed by S&P 500 stock index option prices introduced in 1993:
+
+https://datahub.io/core/finance-vix
+
+There are several ways to get data in R, but in this tutorial, we are going to use robust, high performance JSON Parser `jsonlite` library:
+
+```r
+library("jsonlite")
+
+json_file <- 'https://datahub.io/core/finance-vix/datapackage.json'
+json_data <- fromJSON(paste(readLines(json_file), collapse=""))
+
+# get list of all resources:
+print(json_data$resources$name)
+```
+
+and you would get following table printed:
+
+![list of all resources](/static/img/docs/r-screenshot-resources.png)
+
+
+Our data is now available in different formats such as CSV, JSON, ZIP. To get it in the CSV format:
+
+```r
+# print all tabular data(if exists any)
+for(i in 1:length(json_data$resources$datahub$type)){
+  if(json_data$resources$datahub$type[i]=='derived/csv'){
+    path_to_file = json_data$resources$path[i]
+    data <- read.csv(url(path_to_file))
+    print(data)
+  }
+}
+```
+
+![all tabular printed data](/static/img/docs/r-screenshot-data.png)
+]]></description><link>https://portaljs.com/blog/how-to-use-data-packages-from-r</link><guid isPermaLink="false">https://portaljs.com/blog/how-to-use-data-packages-from-r</guid><dc:creator><![CDATA[mikanebu]]></dc:creator><pubDate>Thu, 16 Nov 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Import online data files directly with scheduling]]></title><description><![CDATA[
+Users can now import online data files directly into the DataHub using the `data` command line tool -- and setup scheduled re-imports at the same time.
+
+We're very excited about this feature as it is the first step in supporting automated scraping and doing this on a regular schedule. This is something we ourselves have long wanted for our [Core Data work][core data] and we're already using the feature ourselves.
+
+[core data]: https://datahub.io/core
+
+## An example
+
+We'll use an example of the "Energy consumption by sector" from the US Energy Information Administration. This data is updated on monthly basis so we want it to be re-imported every 30 days (~1 month):
+
+```
+data push https://www.eia.gov/totalenergy/data/browser/csv.php?tbl=T02.01 --schedule="every 30d" --format=csv
+```
+
+:::info
+By default, when you push datasets to DataHub, they are "unlisted" so only people with the link can see it. If you wish to make your dataset "published", you need to pass `--published` option: `data push URL --published`.
+:::
+
+Once the process is completed open your browser and check it out! It would generate a URL using your username, which will be copied to clipboard so you can just open a browser and paste it. You should see something similar to this page:
+
+![page generated with your name url](/static/img/docs/scheduled-data.png)
+
+Note: We've decided to still use the push command, even though unlike local data you are not "pushing" it but rather importing it. [Read more about the `push` command in our getting started guide][getting-started].
+
+[getting-started]: http://datahub.io/docs/getting-started/publishing-data
+
+### Set up a Schedule
+
+You can  setup a schedule so the DataHub will automatically re-import the remote file on a regular basis. E.g., `every 90s`, `every 5m`, `every 2d` etc. The number is always an integer, selector is `s/m/h/d/w` (second -> week) and you can’t schedule for less than 60 seconds.
+
+In our example above the dataset is updated on monthly basis so we have the schedule that runs every 30 days:
+
+```bash
+--schedule="every 30d"
+```
+
+This data file will then re-imported monthly.
+
+To read more including full details of the schedule format see our [full docs on importing online data to the DataHub].
+
+### Provide file format explicitly
+
+If the file URL does not contain conventional file name, you need to provide its format explicitly by using `--format` option. See how we did it in our example above:
+
+```bash
+--format=csv
+```
+]]></description><link>https://portaljs.com/blog/import-online-data-files-directly-with-scheduling</link><guid isPermaLink="false">https://portaljs.com/blog/import-online-data-files-directly-with-scheduling</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 14 Nov 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Core Data: Essential Datasets for Data Wranglers and Data Scientists]]></title><description><![CDATA[
+The "Core Data" project provides essential data for the data wranglers and data science community. Its online home is on the DataHub:
+
+https://datahub.io/core
+
+https://datahub.io/docs/core-data
+
+This post introduces you to the Core Data, presents a couple of examples and shows you how you can access and use core data easily from your own tools and systems including R, Python, Pandas and more.
+
+[[toc]]
+
+## Why Core Data
+
+If you build data driven applications or data driven insight you regularly find yourself wanting common "core" data, things like lists of countries, populations, geographic boundaries and more.
+
+However, finding good quality data has always been challenging. Professionals can spend lots of time finding and preparing data before they get to do any real work analysing or presenting it.
+
+To address this, a few years ago we started the "core data" project as part of the Frictionless Data initiative. Its purpose was to curate important, commonly used datasets including reference data like country codes, indicators like population and GDP, and geodata like country boundaries. It provides them in a high-quality, easy-to-use, and standard form.
+
+Recently the Core Data project has got even better with a new home on the newly upgraded DataHub and has expanded thanks to new partners like Datopian and John Snow Labs (more on this in a future post!).
+
+## Examples
+
+There are dozens of core datasets already available and many more being worked on, including a list of countries and their 2 digit codes, and a more extensive version.
+
+### List of Countries
+
+Ever needed to build a drop-down list of countries in a web application? Or ever needed to add country name labels for a graph and only had country codes?
+
+Then these datasets are for you!
+
+First up is the very simple "country-list" dataset:
+
+https://datahub.io/core/country-list
+
+You can see a preview table for the dataset on the showcase page:
+
+![preview table for the dataset on the showcase page](/static/img/docs/country-list-preview-table.png)
+
+You can download it in either CSV or JSON formats:
+
+![download it in either CSV or JSON formats](/static//docs/country-list-downloads.png)
+
+* CSV: https://datahub.io/core/country-list/r/data.csv
+* JSON: https://datahub.io/core/country-list/r/data.json
+
+### Country Codes
+
+Maybe the simple list of countries is not enough for you. Perhaps you need phone codes for each country, or want to know their currencies?
+
+We've got you covered with the more extensive country codes dataset:
+
+https://datahub.io/core/country-codes
+
+All the countries from Country List including number of associated codes - ISO 3166 codes, ITU dialing codes, ISO 4217 currency codes, and many others. This dataset includes **26** different codes and associated information.
+
+You can also preview the data and download in different formats just like it is described for Country List dataset above:
+
+* CSV: https://datahub.io/core/country-codes/r/country-codes.csv
+* JSON: https://datahub.io/core/country-codes/r/country-codes.json
+
+### Population
+
+This is another useful dataset for people: you regularly need population in order to do normalisations and calculate per capita figures as part of a statistical analysis.
+
+This dataset includes population figures for countries, regions (e.g. Asia) and the world. Data comes originally from World Bank and has been converted into standard tabular data package with CSV data and a table schema:
+
+https://datahub.io/core/population
+
+Preview the data on the showcase page:
+
+![Preview the population data on the showcase page](/static/img/docs/population-preview-table.png)
+
+Get the data in CSV or JSON formats just like for any other Core Datasets:
+
+* CSV: https://datahub.io/core/population/r/population.csv
+* JSON: https://datahub.io/core/population/r/population.json
+
+## Use Core Data from your favorite language or tool
+
+We have made Core Data easy-to-use from various programming languages and tools. We will walk through using our Country List example. But you can apply these instructions to any other Core Data in the DataHub.
+
+### CSV and JSON
+
+If you just need to get data, you have a direct link usable from any tool or app e.g. for the country list:
+
+* CSV - https://datahub.io/core/country-list/r/data.csv
+* JSON - https://datahub.io/core/country-list/r/data.json
+
+:::info
+For more read our "Getting Data" tutorial:
+
+https://datahub.io/docs/getting-started/getting-data
+:::
+
+
+### cURL
+
+Following commands help you to get the data using "cURL" tool. Use `-L` flag so "cURL" follows redirects:
+
+```bash
+# Get the data:
+curl -L https://datahub.io/core/country-list/r/data.csv
+
+# datapackage.json provides metadata and a list of all data files
+curl -L https://datahub.io/core/country-list/datapackage.json
+
+# See just the available data files (resources):
+curl -L https://datahub.io/core/country-list/datapackage.json | jq ".resources"
+```
+
+### R
+
+If you are using R here's how to get the data you want  quickly loaded:
+
+```r
+install.packages("jsonlite")
+library("jsonlite")
+
+json_file <- 'https://datahub.io/core/country-list/datapackage.json'
+json_data <- fromJSON(paste(readLines(json_file), collapse=""))
+
+# get list of all resources:
+print(json_data$resources$name)
+
+# print all tabular data(if exists any)
+for(i in 1:length(json_data$resources$datahub$type)){
+  if(json_data$resources$datahub$type[i]=='derived/csv'){
+    path_to_file = json_data$resources$path[i]
+    data <- read.csv(url(path_to_file))
+    print(data)
+  }
+}
+```
+
+### Python
+
+Here we take a look at how to get Country List in Python programming language:
+
+For Python, first install the `datapackage` library (all the datasets on DataHub are Data Packages):
+
+```bash
+pip install datapackage
+```
+
+Again, we'll use the `country-list` dataset:
+
+```python
+from datapackage import Package
+
+package = Package('https://datahub.io/core/country-list/datapackage.json')
+
+# get list of all resources:
+resources = package.descriptor['resources']
+resourceList = [resources[x]['name'] for x in range(0, len(resources))]
+print(resourceList)
+
+# print all tabular data(if exists any)
+resources = package.resources
+for resource in resources:
+    if resource.tabular:
+        print(resource.read())
+```
+
+### Pandas
+
+In order to work with Data Packages in Pandas you need to install the Frictionless Data data package library and the pandas:
+
+```bash
+pip install datapackage
+pip install pandas
+```
+
+To get the data run following code:
+
+```python
+import datapackage
+import pandas as pd
+
+data_url = 'https://datahub.io/core/country-list/datapackage.json'
+
+# to load Data Package into storage
+package = datapackage.Package(data_url)
+
+# to load only tabular data
+resources = package.resources
+for resource in resources:
+    if resource.tabular:
+        data = pd.read_csv(resource.descriptor['path'])
+        print (data)
+```
+
+### JavaScript and many more
+
+We also have support for JavaScript, SQL, and PHP. See our "Getting Data" tutorial for more:
+
+https://datahub.io/docs/getting-started/getting-data
+
+## Conclusion
+
+This post has shown how you can import datasets in a high quality, standard form quickly and easily.
+
+There are many more datasets to explore than the three we showed you here. You can find a full list here:
+
+https://datahub.io/core
+
+Finally, we would love collaborators to help us curate even more core datasets. If you're interested you can find out more about the Core Data Curator program here:
+
+https://datahub.io/docs/core-data/curators
+]]></description><link>https://portaljs.com/blog/core-data-essential-datasets-for-data-wranglers-and-data-scientists</link><guid isPermaLink="false">https://portaljs.com/blog/core-data-essential-datasets-for-data-wranglers-and-data-scientists</guid><dc:creator><![CDATA[rufuspollock]]></dc:creator><pubDate>Fri, 03 Nov 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[See events and activity related to datasets or publishers]]></title><description><![CDATA[
+You can now see publisher and dataset related events. As we are tracking processes happening in our system, users have ability to discover which publishers have been active or datasets are updated frequently.
+
+In the dashboard page, users can monitor their own private activity as well as their datasets' statuses:
+
+![dashboard page, users can monitor their own private activity as well as their datasets' statuses](/static/img/docs/dashboard-events.png)
+
+Publisher page has information about recent operations related to his/her datasets:
+
+![Publisher page has information about recent operations related to his/her datasets](/static/img/docs/publisher-events.png)
+
+If you want to see events for the specific dataset, you can check "events" page for it. Simply concatenate `/events` path for your dataset's URL - `https://datahub.io/{publisher}/{dataset}/events`. E.g., here is the "events" page for "finance-vix" dataset - https://datahub.io/core/finance-vix/events - it includes the most recent events for the dataset:
+
+![most recent events for the dataset](/static/img/docs/events-page.png)
+]]></description><link>https://portaljs.com/blog/see-events-and-activity-related-to-datasets-or-publishers</link><guid isPermaLink="false">https://portaljs.com/blog/see-events-and-activity-related-to-datasets-or-publishers</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 31 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Datasets in zip format]]></title><description><![CDATA[
+We are now generating compressed versions of datasets so users can download a dataset as a single file. You can find it in the “Data Files” table in the showcase page. For example, you can have a look at [finance-vix dataset][finance-vix]:
+
+![finance-vix dataset](/static/img/docs/data-files.png)
+
+[finance-vix]: /core/finance-vix
+]]></description><link>https://portaljs.com/blog/datasets-in-zip-format</link><guid isPermaLink="false">https://portaljs.com/blog/datasets-in-zip-format</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Thu, 19 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Previews for large datasets]]></title><description><![CDATA[
+We are now generating preview versions of large datasets so your web browser does not crash by loading large amount of data. The preview versions consist of first 5k rows of datasets (if a dataset is small enough, we skip generation of a preview version). For instance, take a look at [finance-vix dataset][finance-vix] preview table:
+
+![finance-vix dataset](/static/img/docs/preview-table.png)
+
+[finance-vix]: /core/finance-vix
+]]></description><link>https://portaljs.com/blog/previews-for-large-datasets</link><guid isPermaLink="false">https://portaljs.com/blog/previews-for-large-datasets</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Wed, 18 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Vega views upgrade - now using v3]]></title><description><![CDATA[
+As you know publishers can create various views using Vega visualizations in DataHub (learn more about views [here][views]). We have just upgraded our platform to use Vega specs v3, which means you can use the latest specifications to describe your views! A graph below is created by using Vega and taken from [this example dataset][example]:
+
+![vega graph example](/static/img/docs/vega-graph-example.png)
+
+[views]: /docs/features/views
+[example]: /examples/vega-views-tutorial-lines
+]]></description><link>https://portaljs.com/blog/vega-upgrade-spec-v3</link><guid isPermaLink="false">https://portaljs.com/blog/vega-upgrade-spec-v3</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Tue, 17 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Excel Files on the DataHub: Automated Previews and Data Extraction]]></title><description><![CDATA[
+In this tutorial, we will explain how to push Excel data to the DataHub. When an Excel file is pushed, we can extract data from selected sheets for previewing and downloading in alternative formats. By default, our CLI tool would process only first sheet of the Excel, but publishers can specify any sheets they want.
+
+## Get some Excel data
+
+If you have an Excel file you can use it for this tutorial. Otherwise, we have prepared an example file, which you can simply get by using the CLI tool:
+
+```
+data get https://github.com/datapackage-examples/excel/raw/master/excel.xlsx
+```
+
+which saves the file in the current working directory. You can inspect the contents before pushing:
+
+```
+data cat excel.xlsx
+```
+
+and it would prompt you to select a sheet. Let's select the first sheet so it will output a table with its content in the standard out:
+
+```cli-output
+| Mean   | Uncertainty |
+| ------ | ----------- |
+| 338.8  | 0.1         |
+| 339.99 | 0.1         |
+| 340.76 | 0.1         |
+
+...
+```
+
+## Push the data
+
+Now we can push the file to the DataHub:
+
+```bash
+data push excel.xlsx
+```
+
+By default, only first sheet is processed. You should get success message like this:
+
+```cli-output
+🙌  your data is published!
+
+🔗  https://datahub.io/{your-username}/{dataset-name} (copied to clipboard)
+```
+
+You can just open your browser and paste the link, which is already copied to your clipboard.
+
+## Your data's online!
+
+Once your data is online, you will see the following page:
+
+![your online data](/static/img/docs/showcase-excel-1.png)
+
+:::info
+DataHub may still be processing your data. In this case you will see an appropriate message on the page. Just allow it couple of moments and it will be there!
+:::
+
+We have converted the first sheet to CSV. If you take a look at downloads table, there are options to get data in CSV or JSON versions. Also, you still can download your original data:
+
+![download your original data in csv or json](/static/img/docs/showcase-downloads-excel-1.png)
+
+Scrolling down, you can find a preview table of your data:
+
+![preview table of your data](/static/img/docs/showcase-preview-excel-1.png)
+
+## Processing multiple sheets
+
+Sometimes, you need to process multiple sheets from your Excel file or you just need a sheet other than the first one. In such situations, you can use `--sheets` option when pushing your data to DataHub. In our sample data, we have 2 sheets and in the example above we have pushed only the first one. Now, let's push both of them:
+
+```bash
+data push excel.xlsx --sheets=all
+```
+
+We have used `--sheets=all` option to specify that we want to push "all" sheets. You also can list sheet numbers, e.g., `--sheets=1,2`. If you wanted to push only the second sheet, you would do `--sheets=2`.
+
+**Note:** *sheet number starts from 1.*
+
+Again, you should get a success message with the link to your data:
+
+```cli-output
+🙌  your data is published!
+
+🔗  https://datahub.io/{your-username}/{dataset-name} (copied to clipboard)
+```
+
+By opening the link, you would see the following page:
+
+![By opening the link, you would see the following page](/static/img/docs/showcase-excel-2.png)
+
+We have converted all sheets of the file to CSV so now you can download each of them in CSV or JSON formats:
+
+![converted all sheets of the file to CSV so now you can download each of them in CSV or JSON formats](/static/img/docs/showcase-downloads-excel-2.png)
+
+You also can find preview tables for each sheet by scrolling down the page.
+]]></description><link>https://portaljs.com/blog/excel-files-on-the-datahub-automated-previews-and-data-extraction</link><guid isPermaLink="false">https://portaljs.com/blog/excel-files-on-the-datahub-automated-previews-and-data-extraction</guid><dc:creator><![CDATA[anuveyatsu]]></dc:creator><pubDate>Mon, 16 Oct 2017 00:00:00 GMT</pubDate></item><item><title><![CDATA[Data Package v1 Specifications. What has Changed and how to Upgrade]]></title><description><![CDATA[
+This post walks you through the major changes in the Data Package v1 specs compared to pre-v1. It covers changes in the full suite of Data Package specifications including Data Resources and Table Schema. It is particularly valuable if:
+
+* you were using Data Packages pre v1 and want to know how to upgrade your datasets
+* if you are implementing Data Package related tooling and want to know how to upgrade your tools or want to support or auto-upgrade pre-v1 Data Packages for backwards compatibility
+
+It also includes a script we have created (in JavaScript) that we've been using ourselves to automate upgrades of the [Core Data][core-data].
+
+## The Changes
+
+Two major changes in v1 were presentational:
+
+* Creating Data Resource as a separate spec from Data Package. This did not change anything substantive in terms of how data packages worked but is important presentationally. In parallel, we also split out a Tabular Data Resource from the Tabular Data Package.
+* Renaming JSON Table Schema to just Table Schema
+
+In addition, there were a fair number of substantive changes. We summarize these in the sections below. For more detailed info see the [current specifications][specs] and [the old site containing the pre spec v1 specifications][prev1].
+
+### Table Schema
+
+Link to spec: https://specs.frictionlessdata.io/table-schema/
+
+<table class="table table-striped table-bordered">
+<thead>
+<th>Property</th>
+<th>Pre v1</th>
+<th>v1 Spec</th>
+<th>Notes</th>
+<th>Issue</th>
+</thead>
+<tbody>
+<tr>
+<td>id/name</td>
+<td>id</td>
+<td>name</td>
+<td>Renamed id to name to be consistent across specs</td>
+<td></td>
+</tr>
+<tr>
+<td>type/number</td>
+<td>format: currency</td>
+<td>format: currency - removed
+format: bareNumber
+format: decimalChar and groupChar</td>
+<td></td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/509">#509</a> <a href="https://github.com/frictionlessdata/specs/issues/246">#246</a></td>
+</tr>
+<tr>
+<td>type/integer</td>
+<td>No additional properties</td>
+<td>Additional properties: bareNumber</td>
+<td></td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/509">#509</a></td>
+</tr>
+<tr>
+<td>type/boolean</td>
+<td>true: [yes, y, true, t, 1],false: [no, n, false, f, 0]</td>
+<td>true: [ true, True, TRUE, 1],false: [false, False, FALSE, 0]</td>
+<td></td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/415">#415</a></td>
+</tr>
+<tr>
+<td>type/year + yearmonth</td>
+<td></td>
+<td>year and yearmonth NB: these were temporarily gyear and gyearmonth</td>
+<td></td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/346">#346</a></td>
+</tr>
+<tr>
+<td>type/duration</td>
+<td></td>
+<td>duration</td>
+<td></td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/210">#210</a></td>
+</tr>
+<tr>
+<td>type/rdfType</td>
+<td></td>
+<td>rdfType</td>
+<td>Support rich "semantic web" types for fields</td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/217">#217</a></td>
+</tr>
+<tr>
+<td>type/null</td>
+<td></td>
+<td>removed (see missingValue)</td>
+<td></td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/262">#262</a></td>
+</tr>
+<tr>
+<td>missingValues</td>
+<td></td>
+<td>missingValues</td>
+<td>Missing values support did not exist pre v1.</td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/97">#97</a></td>
+</tr>
+</tbody>
+</table>
+
+
+### Data Resource
+
+Link to spec: https://specs.frictionlessdata.io/data-resource/
+
+*Note: Data Resource did not exist as a separate spec pre-v1 so strictly we are comparing the Data Resource section of the old Data Package spec with the new Data Resource spec.*
+
+<table class="table table-striped table-bordered">
+<thead>
+<th>Property</th>
+<th>Pre v1</th>
+<th>v1 Spec</th>
+<th>Notes</th>
+<th>Issue</th>
+</thead>
+<tbody>
+<tr>
+<td>path</td>
+<td>path and url</td>
+<td>path only</td>
+<td>url merged into path and path can now be a url or local path</td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/250">#250</a></td>
+</tr>
+<tr>
+<td>path</td>
+<td>string</td>
+<td>string or array</td>
+<td>path can be an array to support a single resource split across multiple files</td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/228">#228</a></td>
+</tr>
+<tr>
+<td>name</td>
+<td>recommended</td>
+<td>required</td>
+<td>Made name required to enable access to resources by name consistently across tools</td>
+<td></td>
+</tr>
+<tr>
+<td>profile</td>
+<td></td>
+<td>recommended</td>
+<td>See profiles discussion</td>
+<td></td>
+</tr>
+<tr>
+<td>sources, licenses ...</td>
+<td></td>
+<td></td>
+<td>Inherited metadata from Data Package like sources or licenses upgraded inline with changes in Data Package</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+
+### Tabular Data Resource
+
+Link to spec: https://specs.frictionlessdata.io/data-resource/
+
+Just as Data Resource split out from Data Package so Tabular Data Resource split out from the old Tabular Data Package spec.
+
+There were no significant changes here beyond those in Data Resource.
+
+### Data Package
+
+Link to spec: https://specs.frictionlessdata.io/data-package/
+
+<table class="table table-striped table-bordered">
+<thead>
+<th>Property</th>
+<th>Pre v1</th>
+<th>v1 Spec</th>
+<th>Notes</th>
+<th>Issue</th>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td>required</td>
+<td>recommended</td>
+<td>Unique names are not essential to any part of the present tooling so we have have moved to recommended.</td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/237">#237</a></td>
+</tr>
+<tr>
+<td>id</td>
+<td></td>
+<td>id property-globally unique</td>
+<td>Globally unique id property</td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/237">#237</a></td>
+</tr>
+<tr>
+<td>licenses</td>
+<td>license - object or string. The object structure must contain a type property and a url property linking to the actual text</td>
+<td>licenses - is an array. Each item in the array is a License. Each must be an object. The object must contain a name property and/or a path property. It may contain a title property.</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>author</td>
+<td>author</td>
+<td>author is removed in favour of contributors</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>contributor</td>
+<td>name, email, web properties with name required</td>
+<td>title property required with roles, role property values must be one of - author, publisher, maintainer, wrangler, and contributor. Defaults to contributor.</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>sources</td>
+<td>name, web and email and none required</td>
+<td>title, path and email and title is required</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>resources</td>
+<td></td>
+<td>resources array is required</td>
+<td></td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/434">#434</a></td>
+</tr>
+<tr>
+<td>dataDependencies</td>
+<td>dataDependencies</td>
+<td></td>
+<td>Moved to a pattern until we have greater clarity on need.</td>
+<td><a href="https://github.com/frictionlessdata/specs/issues/341">#341</a></td>
+</tr>
+</tbody>
+</table>
+
+
+### Tabular Data Package
+
+Link to spec: https://specs.frictionlessdata.io/tabular-data-package/
+
+Tabular Data Package is unchanged.
+
+### Profiles
+
+Profiles arrived in v1:
+
+http://specs.frictionlessdata.io/profiles/
+
+Profiles are the first step on supporting a rich ecosystem of "micro-schemas" for data. They provide a very simple way to quickly state that your data follows a specific structure and/or schema. From the docs:
+
+> Different kinds of data need different formats for their data and metadata. To support these different data and metadata formats we need to extend and specialise the generic Data Package. These specialized types of Data Package (or Data Resource) are termed profiles.
+>
+> For example, there is a Tabular Data Package profile that specializes Data Packages specifically for tabular data. And there is a "Fiscal" Data Package profile designed for government financial data that includes requirements that certain columns are present in the data e.g. Amount or Date and that they contain data of certain types.
+
+We think profiles are an easy, lightweight way to starting adding more structure to your data.
+
+Profiles can be specified on both resources and packages.
+
+[core-data]: https://github.com/datahq/datapackage-normalize-js
+[specs]: https://specs.frictionlessdata.io/
+[prev1]: https://pre-v1.frictionlessdata.io/
+[normalization]: https://github.com/datahq/datapackage-normalize-js
+[ghrepo]: https://github.com/frictionlessdata/specs/
+
+
+
+## Automate upgrading your descriptor according to the spec v1
+
+We have created a [data package normalization script][norm-script] that you can use to automate the process of upgrading a `datapackage.json` or Table Schema from pre-v1 to v1.
+
+The script enables you to automate updating your `datapackage.json` for the following properties: `path`, `contributors`, `resources`, `sources` and `licenses`.
+
+[norm-script]: https://github.com/datahq/datapackage-normalize-js
+
+This is a simple script that you can download directly from here:
+
+https://raw.githubusercontent.com/datahq/datapackage-normalize-js/master/normalize.js
+
+e.g. using wget:
+```bash
+wget https://raw.githubusercontent.com/datahq/datapackage-normalize-js/master/normalize.js
+```
+
+```bash
+# path (optional) is the path to datapackage.json
+# if not provided looks in current directory
+normalize.js [path]
+
+# prints out updated datapackage.json
+```
+
+You can also use as a library:
+
+```bash
+# install it from npm
+npm install datapackage-normalize
+```
+
+so you can use it in your javascript:
+
+```javascript
+const normalize = require('datapackage-normalize')
+
+const path = 'path/to/datapackage.json'
+normalize(path)
+```
+
+## Conclusion
+
+The above summarizes the main changes for v1 of Data Package suite of specs and instructions on how to upgrade.
+
+If you want to see specification for more details, please visit [Data Package specifications][specs]. You can also visit the [Frictionless Data initiative for more information about Data Packages][fd].
+
+[fd]: http://frictionlessdata.io/
+]]></description><link>https://portaljs.com/blog/upgrade-to-data-package-specs-v1</link><guid isPermaLink="false">https://portaljs.com/blog/upgrade-to-data-package-specs-v1</guid><dc:creator><![CDATA[mikanebu]]></dc:creator><pubDate>Wed, 11 Oct 2017 00:00:00 GMT</pubDate></item></channel></rss>

--- a/site/scripts/generate-feeds.js
+++ b/site/scripts/generate-feeds.js
@@ -41,6 +41,7 @@ async function generateFeeds() {
           blogList.push({
             title: metadata.title,
             description: metadata.description,
+            content: parsed.content, // Full markdown content
             date: metadata.created || metadata.date,
             urlPath: urlPath,
             authors: metadata.authors || [],
@@ -73,7 +74,7 @@ async function generateFeeds() {
     blogsSorted.forEach((post) => {
       feed.item({
         title: post.title,
-        description: post.description || 'Read more...',
+        description: post.content || post.description || 'Read more...', // Full content for cross-posting
         url: `https://portaljs.com${post.urlPath}`,
         guid: `https://portaljs.com${post.urlPath}`,
         date: new Date(post.date),
@@ -103,7 +104,7 @@ ${blogsSorted.map(post => {
   const postUrl = `${siteUrl}${post.urlPath}`;
   const postDate = new Date(post.date).toISOString();
   const author = post.authors && post.authors.length > 0 ? post.authors[0] : 'Datopian';
-  const description = post.description || 'Read more...';
+  const content = post.content || post.description || 'Read more...';
   
   return `  <entry>
     <title>${escapeXml(post.title)}</title>
@@ -114,7 +115,8 @@ ${blogsSorted.map(post => {
     <author>
       <name>${escapeXml(author)}</name>
     </author>
-    <summary type="html">${escapeXml(description)}</summary>
+    <content type="html">${escapeXml(content)}</content>
+    <summary type="html">${escapeXml(post.description || 'Read more...')}</summary>
   </entry>`;
 }).join('\n')}
 </feed>`;


### PR DESCRIPTION
Add complete markdown content to RSS/Atom feeds to support proper cross-posting to platforms like Dev.to while maintaining canonical URLs back to original posts.

- Include full post content in RSS description field
- Add both content and summary elements to Atom feed
- Enable proper cross-posting with canonical URL preservation
- Maintain backward compatibility for feed readers

🤖 Generated with [Claude Code](https://claude.ai/code)