### PR TITLE
docs(site): Skills reference for /docs (po-t21)

### DIFF
--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -26,6 +26,39 @@
     ]
   },
   {
+    "title": "Skills",
+    "links": [
+      {
+        "title": "Skills reference",
+        "href": "/docs/skills"
+      },
+      {
+        "title": "/new-portal",
+        "href": "/docs/skills/new-portal"
+      },
+      {
+        "title": "/add-dataset",
+        "href": "/docs/skills/add-dataset"
+      },
+      {
+        "title": "/add-chart",
+        "href": "/docs/skills/add-chart"
+      },
+      {
+        "title": "/add-map",
+        "href": "/docs/skills/add-map"
+      },
+      {
+        "title": "/connect-ckan",
+        "href": "/docs/skills/connect-ckan"
+      },
+      {
+        "title": "/deploy",
+        "href": "/docs/skills/deploy"
+      }
+    ]
+  },
+  {
     "title": "More",
     "links": [
       {

--- a/site/content/docs/skills.md
+++ b/site/content/docs/skills.md
@@ -1,0 +1,55 @@
+---
+metatitle: PortalJS Skills – Agentic Commands That Build Your Portal
+metadescription: The six PortalJS skills — composable Claude Code commands that scaffold, load data, visualize, connect a backend, and deploy. Each produces plain, editable code you own.
+title: Skills reference
+description: PortalJS skills are first-class, composable commands that do the repetitive assembly — and produce plain, editable code with no lock-in.
+---
+
+PortalJS ships a set of **agentic skills** — Claude Code commands like
+`/new-portal` and `/add-dataset` that do the repetitive assembly of a data
+portal. You describe intent; the skill writes the code.
+
+## What makes them skills
+
+- **First-class.** Skills live in the repo alongside the template, are documented,
+  and are tested end to end. They are not hidden helpers — they are the product's
+  primary path.
+- **Composable.** Each skill does one job and hands off to the next: scaffold with
+  [`/new-portal`](/docs/skills/new-portal), load data with
+  [`/add-dataset`](/docs/skills/add-dataset), enrich with
+  [`/add-chart`](/docs/skills/add-chart) or [`/add-map`](/docs/skills/add-map),
+  swap the data source with [`/connect-ckan`](/docs/skills/connect-ckan), and go
+  live with [`/deploy`](/docs/skills/deploy).
+- **Plain, editable output.** Every skill writes ordinary Next.js, Tailwind, and
+  React code into your project — no magic runtime interpreting a config at request
+  time, nothing feature-gated behind a hosted product. You can clone, fork, and
+  hand-edit everything they produce. This is what _AI-native, not AI-only_ means.
+
+## The six skills
+
+| Skill | What it does |
+| ----- | ------------ |
+| [`/new-portal`](/docs/skills/new-portal) | Scaffold a new portal from a brief — copies the template, substitutes your project name and description, installs deps, verifies the build. |
+| [`/add-dataset`](/docs/skills/add-dataset) | Add a CSV, TSV, JSON, or GeoJSON dataset — copies the data in, generates a dataset page, and registers it on the home page catalog. |
+| [`/add-chart`](/docs/skills/add-chart) | Add a line, bar, area, pie, or scatter chart to a dataset page using `recharts`. |
+| [`/add-map`](/docs/skills/add-map) | Render a GeoJSON dataset on an interactive Leaflet map and register it on the home page. |
+| [`/connect-ckan`](/docs/skills/connect-ckan) | Wire the portal to a [CKAN](/ckan) backend over its API instead of static files. |
+| [`/deploy`](/docs/skills/deploy) | Build and publish the portal to Vercel or any static host — with a live URL at the end. |
+
+## Author your own
+
+Skills are designed to be extended. Anyone can write a new one — see the
+[skill authoring guide](https://github.com/datopian/portaljs/blob/main/.claude/AUTHORING.md).
+
+The roadmap extends this model across the whole data-portal lifecycle — ingest and
+migrate catalogs, wrangle and transform data, describe it with metadata, and
+publish — as a growing **library of agentic skills**. See the
+[PortalJS vision](https://github.com/datopian/portaljs/blob/main/VISION.md) for the
+upcoming skill families.
+
+## Where to go next
+
+- **[Quickstart](/docs/quickstart)** — install the skills and run them end to end.
+- **[Core concepts](/docs/core-concepts)** — the ideas behind the skills.
+
+<DocsPagination prev="/docs/core-concepts" next="/docs/skills/new-portal" />

--- a/site/content/docs/skills/add-chart.md
+++ b/site/content/docs/skills/add-chart.md
@@ -1,0 +1,71 @@
+---
+metatitle: /add-chart – Add a Line, Bar, Area, Pie, or Scatter Chart to PortalJS
+metadescription: The /add-chart skill installs recharts, writes a reusable Chart component, and embeds a visualization into a dataset page — reading the same data the table already uses.
+title: /add-chart
+description: Add a line, bar, area, pie, or scatter chart to a dataset page, reading the same data the table already uses.
+---
+
+`/add-chart` adds a visualization to an existing dataset page. It installs
+`recharts`, writes a reusable client-side `Chart` component into the portal's
+`components/`, and embeds a `<Chart />` into the target page next to its `<Table />`.
+The chart reads the same `/public/data/*` file the table already uses — no data is
+duplicated.
+
+## When to use it
+
+Run it after [`/add-dataset`](/docs/skills/add-dataset) has created the dataset
+page you want to chart.
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Dataset | Yes | The dataset slug or page path (e.g. `country-codes`). The page must already exist. |
+| X axis column | Yes | The column for the category / X axis (e.g. `year`). |
+| Y axis column(s) | Yes | One or more numeric columns to plot (e.g. `population` or `imports,exports`). |
+| Chart type | No | `line` (default), `bar`, `area`, `pie`, or `scatter`. |
+| Portal directory | No | Path to the portal project. Defaults to the current directory. |
+| Title | No | Chart heading. Defaults to one derived from the Y columns. |
+
+The skill validates that the requested columns exist in the data and warns if a Y
+column looks non-numeric (values are coerced with `Number()`). Pie and scatter use
+the first Y column only; pass extra Y columns for multi-series line, bar, or area
+charts.
+
+## Example
+
+```
+/add-chart country-codes --x year --y population --type line
+```
+
+In natural language:
+
+```
+/add-chart the population dataset — plot population over year as a line chart
+```
+
+## What it produces
+
+- `recharts` added to `package.json` (installed directly — not the heavier
+  `@portaljs/components` bundle).
+- A reusable `components/Chart.tsx` (written once; an existing customized component
+  is never overwritten).
+- A `<Chart />` block inserted into the dataset page above the `<Table />`, so the
+  visual summary leads and the raw table follows.
+
+It type-checks the project (`tsc --noEmit`) before reporting success. When it
+finishes:
+
+```
+✓ Chart added to country-codes
+  - Component: components/Chart.tsx (recharts)
+  - Page: pages/datasets/country-codes.tsx — <Chart type="line" x="year" y="population">
+  - Dependency: recharts@^2.12.0 added to package.json
+```
+
+## Where to go next
+
+- **[`/add-map`](/docs/skills/add-map)** — render geographic data on a map instead.
+- **[`/deploy`](/docs/skills/deploy)** — publish the portal once it looks right.
+
+<DocsPagination prev="/docs/skills/add-dataset" next="/docs/skills/add-map" />

--- a/site/content/docs/skills/add-dataset.md
+++ b/site/content/docs/skills/add-dataset.md
@@ -1,0 +1,74 @@
+---
+metatitle: /add-dataset – Add a CSV, TSV, JSON, or GeoJSON Dataset to PortalJS
+metadescription: The /add-dataset skill copies your data into the portal, generates a dataset page with a Table, and registers it on the home page catalog — all as plain, editable code.
+title: /add-dataset
+description: Add a CSV, TSV, JSON, or GeoJSON dataset — copies the data in, generates a dataset page, and registers it on the home page.
+---
+
+`/add-dataset` adds a dataset to an existing PortalJS portal. It copies the data
+into `/public/data/`, generates a dataset page that renders the data as a table,
+and registers the dataset on the home page catalog.
+
+## When to use it
+
+Run it after [`/new-portal`](/docs/skills/new-portal), once per dataset you want to
+publish. For geographic data you'd rather show on a map, use
+[`/add-map`](/docs/skills/add-map) instead (or in addition).
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Source | Yes | A local file path (`./data/file.csv`) or a public URL. |
+| Portal directory | No | Path to the portal project. Defaults to the current directory. |
+| Dataset name | No | Human-readable name. Defaults to the filename. |
+| Description | No | Optional one-line description shown on the page. |
+
+**Supported formats:** CSV, TSV, JSON (array), and GeoJSON. Anything else is
+rejected with a clear message to convert it first.
+
+## Example
+
+```
+/add-dataset ./data/air-quality.csv
+```
+
+With a name and description:
+
+```
+/add-dataset ./data/population.csv — Auckland population by area
+```
+
+From a public URL:
+
+```
+/add-dataset https://example.com/air-quality.csv — Air quality monitoring
+```
+
+## What it produces
+
+- The data file copied to `public/data/<slug>.<ext>`.
+- A dataset page at `pages/datasets/<slug>.tsx` — plain React that renders the data
+  through the template's `Table` component (one file per dataset, so no dynamic
+  routing is required).
+- A new entry in the `datasets` array on the home page (`pages/index.tsx`) so the
+  dataset appears in the catalog. Existing entries are preserved.
+
+If the home page has been heavily customized and the catalog array can't be found,
+the skill still creates the page and tells you to link it manually.
+
+When it finishes:
+
+```
+✓ Dataset added: Air quality monitoring
+  - Data file: public/data/air-quality.csv
+  - Page: pages/datasets/air-quality.tsx → http://localhost:3000/datasets/air-quality
+  - Home page: updated
+```
+
+## Where to go next
+
+- **[`/add-chart`](/docs/skills/add-chart)** — add a chart to the dataset page.
+- **[`/add-map`](/docs/skills/add-map)** — show geographic data on a map.
+
+<DocsPagination prev="/docs/skills/new-portal" next="/docs/skills/add-chart" />

--- a/site/content/docs/skills/add-map.md
+++ b/site/content/docs/skills/add-map.md
@@ -1,0 +1,71 @@
+---
+metatitle: /add-map – Render a GeoJSON Dataset on an Interactive Map in PortalJS
+metadescription: The /add-map skill installs react-leaflet, generates a reusable Map component, creates a map page, and registers it on the home page — rendering GeoJSON on an interactive Leaflet map.
+title: /add-map
+description: Render a GeoJSON dataset on an interactive Leaflet map and register it on the home page catalog.
+---
+
+`/add-map` adds an interactive map of a GeoJSON dataset to an existing PortalJS
+portal. It copies the GeoJSON into `/public/data/`, installs `react-leaflet` /
+`leaflet` (once), generates a reusable `Map` component, creates a map page, and
+registers it on the home page catalog.
+
+## When to use it
+
+Use it when your data is geographic (points, lines, polygons) and you want a map
+rather than the properties table that [`/add-dataset`](/docs/skills/add-dataset)
+produces for GeoJSON. You can run both on the same file to offer both views — the
+map page gets a `-map` suffix so the routes don't collide.
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Source | Yes | A local file path or public URL. Must be **GeoJSON** (a `Feature`, `FeatureCollection`, or geometry object). |
+| Portal directory | No | Path to the portal project. Defaults to the current directory. |
+| Map name | No | Human-readable name. Defaults to the filename. |
+| Description | No | Optional one-line description shown on the page. |
+
+The skill validates that the target is a PortalJS portal and that the source is
+valid GeoJSON before doing anything; non-GeoJSON sources are rejected with a
+pointer to `/add-dataset`.
+
+## Example
+
+```
+/add-map ./data/auckland-suburbs.geojson
+```
+
+From a public URL with a name:
+
+```
+/add-map https://example.com/cities.geojson — Major cities
+```
+
+## What it produces
+
+- The GeoJSON copied to `public/data/<slug>.geojson`.
+- `react-leaflet` and `leaflet` added to `package.json` (installed once).
+- A reusable `components/Map.tsx` plus `components/MapView.tsx` — split so Leaflet
+  is loaded with `dynamic(..., { ssr: false })` and never reaches the server
+  bundle. Every feature's `properties` become a click popup automatically.
+- A map page at `pages/datasets/<slug>.tsx` that fetches the GeoJSON client-side.
+- A new entry on the home page catalog (`pages/index.tsx`), preserving existing
+  entries.
+
+It runs the build before reporting success. When it finishes:
+
+```
+✓ Map added: Auckland suburbs
+  - Data file: public/data/auckland-suburbs.geojson
+  - Component: components/Map.tsx (+ MapView.tsx)
+  - Page: pages/datasets/auckland-suburbs.tsx → http://localhost:3000/datasets/auckland-suburbs
+  - Home page: updated
+```
+
+## Where to go next
+
+- **[`/add-chart`](/docs/skills/add-chart)** — add a chart to a tabular dataset.
+- **[`/deploy`](/docs/skills/deploy)** — publish the portal.
+
+<DocsPagination prev="/docs/skills/add-chart" next="/docs/skills/connect-ckan" />

--- a/site/content/docs/skills/connect-ckan.md
+++ b/site/content/docs/skills/connect-ckan.md
@@ -1,0 +1,77 @@
+---
+metatitle: /connect-ckan – Wire a PortalJS Portal to a CKAN Backend over its API
+metadescription: The /connect-ckan skill installs @portaljs/ckan, generates a CKAN-backed catalog home and dynamic dataset pages as plain editable code, and verifies the build — the decoupled, any-backend path.
+title: /connect-ckan
+description: Wire a portal to a CKAN backend over its API instead of static files — the decoupled, any-backend path.
+---
+
+`/connect-ckan` connects an existing PortalJS portal to a live [CKAN](/ckan)
+backend. The portal stops reading static files from `/public/data/` and instead
+lists and renders datasets straight from a CKAN instance's REST API
+(`package_search` / `package_show`) using the `@portaljs/ckan` client. The output
+is plain, editable Next.js code — no opaque framework wiring.
+
+## When to use it
+
+Use it for the **decoupled / any-backend** path: you have a CKAN data management
+system (your own or a public one) and want a browseable portal in front of it.
+CKAN calls run **server-side** in `getStaticProps` / `getStaticPaths`, so the
+`@portaljs/ckan` bundle never reaches the browser and the site can still be
+statically deployed.
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| CKAN base URL | Yes | The root of the instance, e.g. `https://demo.dev.datopian.com`. Must be publicly reachable. |
+| Org filter | No | One or more CKAN organization names to restrict the catalog to. |
+| Group filter | No | One or more CKAN group names to restrict the catalog to. |
+| Portal directory | No | Path to the portal project. Defaults to the current directory. |
+
+The skill verifies the CKAN API is reachable (and that any named orgs exist)
+before generating code.
+
+## Example
+
+```
+/connect-ckan https://demo.dev.datopian.com
+```
+
+Restricted to specific organizations:
+
+```
+/connect-ckan https://demo.dev.datopian.com --org transport,environment
+```
+
+## What it produces
+
+- `@portaljs/ckan` added to `package.json`, plus a `tsconfig.json` `paths` entry so
+  TypeScript resolves the client's types.
+- `lib/ckan.ts` — a small, editable client module. The CKAN URL is the default,
+  overridable at deploy time via the `DMS` env var; org/group filters and a
+  build-time page cap (`MAX_DATASETS`) are plain constants you can edit.
+- `pages/index.tsx` rewritten to list datasets from `package_search`.
+- `pages/datasets/[slug].tsx` — a dynamic route that pre-renders one page per
+  dataset via `package_show`, previewing CSV/TSV resources through the template's
+  `Table`.
+
+It verifies the build before reporting success. When it finishes:
+
+```
+✓ Connected to CKAN: https://demo.dev.datopian.com
+  - Client:    lib/ckan.ts (DMS overridable via env var)
+  - Home:      pages/index.tsx → lists datasets from package_search
+  - Dataset:   pages/datasets/[slug].tsx → package_show, CSV/TSV preview via <Table>
+```
+
+> The default is static generation (data fixed at build time — rebuild to pick up
+> new CKAN datasets). For always-live data, deploy to a Node host and switch to
+> `getServerSideProps` or `getStaticPaths` `fallback: 'blocking'`.
+
+## Where to go next
+
+- **[Core concepts](/docs/core-concepts)** — why the frontend is decoupled from the
+  backend.
+- **[`/deploy`](/docs/skills/deploy)** — publish the connected portal.
+
+<DocsPagination prev="/docs/skills/add-map" next="/docs/skills/deploy" />

--- a/site/content/docs/skills/deploy.md
+++ b/site/content/docs/skills/deploy.md
@@ -1,0 +1,81 @@
+---
+metatitle: /deploy – Publish a PortalJS Portal to Vercel or Static Hosting
+metadescription: The /deploy skill detects your target, builds the portal, and publishes it to Vercel or any static host — never reporting success on a failing build, with a live URL at the end.
+title: /deploy
+description: Build and publish the portal to Vercel or any static host — with a live URL at the end.
+---
+
+`/deploy` takes a PortalJS portal live in one shot. It detects the target, builds,
+verifies the build passes, and either publishes (Vercel) or produces a ready-to-
+upload `out/` directory (static hosting). It never reports success on a failing
+build.
+
+## When to use it
+
+Run it once the portal looks right locally. It's the last step in the typical flow
+after [`/new-portal`](/docs/skills/new-portal),
+[`/add-dataset`](/docs/skills/add-dataset), and any enrichment skills.
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Portal directory | No | Path to the portal project. Defaults to the current directory; must contain a Next.js `package.json`. |
+| Target | No | `vercel` or `static`. If omitted, the skill auto-detects and tells you what it chose. |
+
+**Two targets:**
+
+- **`vercel`** — pushes to Vercel via the `vercel` CLI. Handles SSR/ISR natively
+  and gives a live `*.vercel.app` URL (or your custom domain). Best default for
+  portals that may grow server-side features. Requires the CLI installed and logged
+  in (`vercel login`).
+- **`static`** — builds a fully static site (`output: 'export'` → `out/`) suitable
+  for any static host: GitHub Pages, Netlify, S3 + CloudFront, Cloudflare Pages, or
+  plain nginx. No server required.
+
+Auto-detection prefers Vercel if a `.vercel/` link exists, static if
+`next.config.js` already sets `output: 'export'`, and otherwise Vercel when its CLI
+is available (falling back to static).
+
+## Example
+
+```
+/deploy
+```
+
+Force a target, or promote a preview to production:
+
+```
+/deploy --static
+/deploy --prod
+```
+
+## What it produces
+
+- **Vercel:** no files changed; a deployment is created and a live URL printed.
+
+  ```
+  ✓ Deployed to Vercel
+    URL: https://auckland-council-open-data.vercel.app
+  ```
+
+- **Static:** `next.config.js` may be edited (to add `output: 'export'`,
+  `images: { unoptimized: true }`, and a base path if needed); an `out/` directory
+  of static HTML is produced. Nothing is uploaded unless you name a host.
+
+  ```
+  ✓ Static site built: out/  (12 pages)
+    Preview locally: npx serve out
+  ```
+
+> CKAN or SSR portals that rely on `getServerSideProps` need a server — use the
+> `vercel` target for those. Set env vars (e.g. `DMS`) in the Vercel dashboard
+> before deploying.
+
+## Where to go next
+
+- **[Skills reference](/docs/skills)** — the full set of skills.
+- **[`/connect-ckan`](/docs/skills/connect-ckan)** — point the portal at a live
+  backend before deploying.
+
+<DocsPagination prev="/docs/skills/connect-ckan" />

--- a/site/content/docs/skills/new-portal.md
+++ b/site/content/docs/skills/new-portal.md
@@ -1,0 +1,73 @@
+---
+metatitle: /new-portal – Scaffold a PortalJS Data Portal from a Brief
+metadescription: The /new-portal skill copies the canonical PortalJS template, substitutes your project name and description, installs dependencies, and verifies the build — a real, editable Next.js project.
+title: /new-portal
+description: Scaffold a production-ready PortalJS portal from a brief — a real, editable Next.js project you own.
+---
+
+`/new-portal` scaffolds a production-ready PortalJS data portal from a short
+brief. It copies the canonical lightweight template, substitutes your project
+tokens, installs dependencies, and verifies the build — so you start from a
+working project, not a blank page.
+
+## When to use it
+
+This is the first skill you run. Use it to create a new portal project; then load
+data with [`/add-dataset`](/docs/skills/add-dataset) and enrich from there.
+
+It works **both inside a clone of the portaljs repo and from any other project**:
+it prefers a local checkout of the template and otherwise fetches it from GitHub.
+
+## Inputs
+
+A short brief in natural language. From it the skill extracts:
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Project name | Yes | Used for the page title; also derives the project slug (lowercase, hyphenated). |
+| Description | No | One sentence describing the portal. Defaults to "An open data portal." |
+| Datasets | No | File paths or URLs mentioned in the brief — added later with `/add-dataset`. |
+
+If no project name is found, the skill stops and asks for one.
+
+By default it copies `examples/portaljs-template`. For a portal with **many
+datasets** (dozens or more), it can use the `examples/portaljs-catalog` variant
+instead, which renders every dataset through one dynamic route from a
+`datasets.json` manifest.
+
+## Example
+
+```
+/new-portal Auckland Council Open Data Portal — public datasets for the Auckland region
+```
+
+Or simply:
+
+```
+/new-portal "Auckland Council open data portal"
+```
+
+## What it produces
+
+- A new project directory named after your project slug (e.g.
+  `auckland-council-open-data/`) containing the full template — **plain Next.js,
+  Tailwind, and a few small React components** you can edit by hand.
+- Placeholder tokens (`__PROJECT_NAME__`, `__PROJECT_SLUG__`, `__DESCRIPTION__`)
+  substituted throughout the project with your real values.
+- Dependencies installed (`npm install`) and the build verified, so the project
+  runs immediately.
+
+When it finishes:
+
+```
+✓ Portal scaffolded at ./auckland-council-open-data
+✓ Run: cd auckland-council-open-data && npm run dev  →  http://localhost:3000
+```
+
+## Where to go next
+
+- **[`/add-dataset`](/docs/skills/add-dataset)** — load your first dataset into the
+  new portal.
+- **[Manual setup](/docs/manual-setup)** — the same project, built by hand.
+
+<DocsPagination prev="/docs/skills" next="/docs/skills/add-dataset" />


### PR DESCRIPTION
Second slice of the docs revamp (after the `/docs` spine): the **Skills reference**.

## What's here
- `/docs/skills` — overview: skills are first-class, composable, and emit plain editable code; a table of all six shipped skills; pointers to the authoring guide and the roadmap.
- One page per skill under `/docs/skills/*` — `new-portal`, `add-dataset`, `add-chart`, `add-map`, `connect-ckan`, `deploy`. Each covers what it does, when to use it, inputs, an example invocation, and what it produces. Derived from the `.claude/commands/*.md` definitions (single source of truth).
- Wired into the docs sidebar under a new **Skills** group.

## Verify
`tsc --noEmit` clean; `next build` 153/153 pages (+7, nested `/docs/skills/*` routing confirmed).

Part of the docs IA; remaining slices (Guides, Templates/Authoring/Backends, legacy coexistence banners, Cloud) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Skills documentation section with guides for six available commands
  * Included tutorials for creating portals, adding datasets, charts, and maps
  * Added instructions for CKAN integration and deployment options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->