### PR TITLE
docs(site): complete /docs IA — Guides, Templates, coexistence, Cloud

### DIFF
--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -59,11 +59,65 @@
     ]
   },
   {
+    "title": "Guides",
+    "links": [
+      {
+        "title": "Guides",
+        "href": "/docs/guides"
+      },
+      {
+        "title": "Add tabular data",
+        "href": "/docs/guides/add-tabular-data"
+      },
+      {
+        "title": "Add a chart",
+        "href": "/docs/guides/add-a-chart"
+      },
+      {
+        "title": "Render a map",
+        "href": "/docs/guides/render-a-map"
+      },
+      {
+        "title": "Connect a CKAN backend",
+        "href": "/docs/guides/connect-a-ckan-backend"
+      },
+      {
+        "title": "Deploy",
+        "href": "/docs/guides/deploy"
+      },
+      {
+        "title": "Theming",
+        "href": "/docs/guides/theming"
+      }
+    ]
+  },
+  {
+    "title": "Templates & extending",
+    "links": [
+      {
+        "title": "Templates",
+        "href": "/docs/templates"
+      },
+      {
+        "title": "Authoring skills",
+        "href": "/docs/authoring-skills"
+      },
+      {
+        "title": "Backends",
+        "href": "/docs/backends"
+      }
+    ]
+  },
+  {
     "title": "More",
     "links": [
       {
         "title": "Open-source framework docs",
         "href": "/opensource"
+      },
+      {
+        "title": "PortalJS Cloud (managed)",
+        "href": "/cloud/docs"
       }
     ]
   }

--- a/site/content/cloud/docs/index.md
+++ b/site/content/cloud/docs/index.md
@@ -3,6 +3,10 @@ title: "PortalJS Cloud Documentation"
 description: "Administrator guide for PortalJS Cloud: manage datasets, organizations, users, visualizations, and your public portal."
 ---
 
+> [!info] These are the PortalJS Cloud (managed) docs
+> This guide covers **PortalJS Cloud, the managed option** — a hosted portal you
+> administer from a dashboard. If you're building and self-hosting the open-source
+> framework instead, see the [PortalJS docs at /docs](/docs).
 
 User guide for PortalJS Cloud portal administrators. Each page walks through one feature area with step-by-step instructions and screenshots.
 

--- a/site/content/config.js
+++ b/site/content/config.js
@@ -101,7 +101,7 @@ const config = {
           href: '/faq',
         },
         {
-          name: 'Docs',
+          name: 'PortalJS Cloud docs (managed)',
           href: '/cloud/docs',
         },
         {
@@ -116,6 +116,20 @@ const config = {
         {
           name: 'Partners',
           href: '/partners',
+        },
+      ],
+    },
+    {
+      name: 'Docs',
+      href: '/docs',
+      subItems: [
+        {
+          name: 'PortalJS (AI-native)',
+          href: '/docs',
+        },
+        {
+          name: 'Classic',
+          href: '/opensource',
         },
       ],
     },

--- a/site/content/docs/authoring-skills.md
+++ b/site/content/docs/authoring-skills.md
@@ -1,0 +1,106 @@
+---
+metatitle: Authoring PortalJS Skills – Write Your Own Agentic Command
+metadescription: Write your own PortalJS skill. Skills are markdown files in .claude/commands — document required input, describe output, handle errors with the ERROR format, and test end to end.
+title: Authoring skills
+description: Write your own agentic command. Skills are markdown files with a clear input contract, described output, and structured errors.
+---
+
+PortalJS skills are designed to be extended — anyone can write a new one. A skill is
+just a **markdown file**, so authoring one is mostly writing clear instructions, not
+code. This page summarizes the conventions; the full reference is the
+[authoring guide](https://github.com/datopian/portaljs/blob/main/.claude/AUTHORING.md)
+in the repo.
+
+## Where skills live
+
+- `.claude/commands/` — open-source skills (no Datopian keys required). The filename
+  becomes the slash command, so `add-dataset.md` → `/add-dataset`.
+- `.claude/datopian/` — Datopian-internal skills that need API access. These carry a
+  header marking them internal and aren't for general OSS use.
+
+## File format
+
+Each skill is a markdown file with frontmatter and a body:
+
+```markdown
+---
+description: One sentence shown in /help and the command picker
+allowed-tools: Read, Write, Edit, Bash, WebFetch
+---
+
+# /skill-name
+
+One paragraph: what this skill does and when to use it.
+
+## Required input
+…
+
+## Steps
+…
+```
+
+Frontmatter fields:
+
+- `description` (**required**) — shown in `/help`.
+- `allowed-tools` (optional) — restricts which tools the assistant may call.
+
+## The input contract
+
+Every skill documents the **minimum required input** before doing any work:
+
+- At least one identifying noun (project name, file path, dataset name).
+- If a file path or URL is required, **state the supported formats explicitly**.
+
+**Prompting rule:** if required input is missing, emit one clarifying question and
+**stop** — don't guess, and don't proceed with placeholder values.
+
+## Describe the output
+
+Every skill says what it produces: files created (paths, formats), files modified
+(what changes), commands run (and expected exit codes), and what the user sees on
+success.
+
+## Handle errors with the `ERROR:` format
+
+On any hard failure, emit a structured block and stop — never continue silently past a
+failure:
+
+```
+ERROR: [SKILL_NAME] [CODE] <message> — <remediation hint>
+```
+
+For example:
+
+```
+ERROR: [add-dataset] UNSUPPORTED_FORMAT .xlsx files are not supported — convert to CSV first.
+```
+
+## Composing skills
+
+In v1, skills are user-invoked and don't call each other programmatically. If a skill's
+output is the natural input to another, point there at the end:
+
+```
+Done. Next: run /add-dataset to load a CSV into this portal.
+```
+
+## Definition of done
+
+A skill is done when it: (1) has frontmatter with `description`; (2) documents required
+input and supported formats; (3) describes its output; (4) uses the `ERROR:` format for
+failures; (5) has been tested end to end on at least one **real** project; and (6) ends
+with a "next step" pointer if another skill naturally follows.
+
+> [!note] Editing the template vs. editing the skill
+> When you change *page layouts, styles, or component usage*, edit the
+> [template](/docs/templates) files directly — `/new-portal` picks them up
+> automatically. Only edit a skill file when you change *how* the skill works (its
+> steps, error handling, or argument parsing).
+
+## Where to go next
+
+- **[Skills reference](/docs/skills)** — the six skills to model yours on.
+- **[The PortalJS vision](https://github.com/datopian/portaljs/blob/main/VISION.md)** —
+  the roadmap of upcoming skill families.
+
+<DocsPagination prev="/docs/templates" next="/docs/backends" />

--- a/site/content/docs/backends.md
+++ b/site/content/docs/backends.md
@@ -1,0 +1,94 @@
+---
+metatitle: PortalJS Backends – CKAN, DKAN, OpenMetadata, Purview, DataHub, GitHub
+metadescription: PortalJS is decoupled by default — the frontend talks to any backend over an API. Integration notes for CKAN, DKAN, OpenMetadata, Microsoft Purview, DataHub, GitHub, Frictionless, and custom backends.
+title: Backends
+description: PortalJS is decoupled by default — the frontend talks to any backend over an API. Integration notes per backend.
+---
+
+PortalJS is **decoupled by default**: the frontend is independent from the backend and
+talks to it over an API. The same portal frontend can sit in front of a catalog
+system, a Git repo, plain static files, or a backend you already run — and you can
+start with static files and point at a real catalog later without rewriting the
+frontend. See [Core concepts](/docs/core-concepts) for the model.
+
+> [!info] Start static, connect later
+> The default — no backend — reads CSV/JSON from `/public/data/`. When you're ready,
+> wire a real catalog with a skill like [`/connect-ckan`](/docs/guides/connect-a-ckan-backend).
+> The pattern (fetch server-side in `getStaticProps`/`getStaticPaths`, pass plain props
+> to components) is the same for any backend.
+
+## CKAN
+
+The first-class, skill-supported path. [`/connect-ckan`](/docs/guides/connect-a-ckan-backend)
+installs `@portaljs/ckan`, lists datasets from `package_search`, and renders each from
+`package_show`, with CSV/TSV resources previewed through the template's `<Table />`.
+Calls run server-side so the CKAN bundle never reaches the browser. See the
+[CKAN integration page](/ckan) and the
+[`examples/ckan`](https://github.com/datopian/portaljs/tree/main/examples/ckan) and
+[`examples/ckan-ssg`](https://github.com/datopian/portaljs/tree/main/examples/ckan-ssg)
+examples.
+
+## DKAN
+
+DKAN exposes a **CKAN-compatible API** (`/api/3/action/...`). Point the same
+`@portaljs/ckan` client (or plain `fetch`) at a DKAN instance's API root and the
+catalog/dataset pattern carries over. Confirm `package_search`/`package_show`
+availability on your DKAN version first.
+
+## OpenMetadata
+
+OpenMetadata is a metadata catalog with its own REST API. Fetch tables/datasets and
+their metadata server-side and render them with the same plain-props pattern. See the
+[OpenMetadata blog walkthrough](https://github.com/datopian/portaljs) for an
+end-to-end example of fronting OpenMetadata with PortalJS.
+
+## Microsoft Purview
+
+Purview is Microsoft's data governance and catalog service. Query its REST API
+(authenticated) on the server side, map the entities you want to surface into the
+portal's dataset shape, and render them — the frontend never needs to know it's
+Purview behind the API.
+
+## DataHub
+
+DataHub exposes both a GraphQL and a REST API. Fetch the datasets/entities you want to
+publish server-side, normalize them to the portal's dataset shape, and render. As with
+every backend, keep the client lean by querying only in
+`getStaticProps`/`getStaticPaths`.
+
+## GitHub
+
+Treat a GitHub repo as the catalog: data files (CSV/JSON/GeoJSON) live in the repo, and
+the portal reads them at build time. This is the simplest "backend" — no service to run.
+See [`examples/github-backed-catalog`](https://github.com/datopian/portaljs/tree/main/examples/github-backed-catalog).
+
+## Frictionless
+
+[Frictionless Data](https://frictionlessdata.io) packages (a `datapackage.json` plus
+data files) describe datasets in a portable, validated way. Read the package descriptor
+to drive dataset metadata and resource lists. See
+[`examples/dataset-frictionless`](https://github.com/datopian/portaljs/tree/main/examples/dataset-frictionless).
+
+## Custom backend
+
+Any system with an HTTP API works. The recipe is always the same:
+
+1. Fetch from your API **server-side** in `getStaticProps`/`getStaticPaths` (or
+   `getServerSideProps` for always-live data).
+2. Map the response into the portal's dataset shape (`slug`, `name`, `description`,
+   resources).
+3. Pass plain serializable props to the page; render with `<Table>`, `<Chart>`, `<Map>`,
+   or your own components.
+
+Because the output is plain editable code, there's no framework wiring to fight — and
+you can model a new backend skill on [`/connect-ckan`](/docs/skills/connect-ckan); see
+[Authoring skills](/docs/authoring-skills).
+
+## Where to go next
+
+- **[Connect a CKAN backend](/docs/guides/connect-a-ckan-backend)** — the worked
+  example.
+- **[Authoring skills](/docs/authoring-skills)** — package your backend integration as
+  a reusable skill.
+
+<DocsPagination prev="/docs/authoring-skills" />

--- a/site/content/docs/guides.md
+++ b/site/content/docs/guides.md
@@ -1,0 +1,35 @@
+---
+metatitle: PortalJS Guides – Task-Oriented How-Tos for Building Data Portals
+metadescription: Short, task-oriented guides for PortalJS — add tabular data, charts, and maps; connect a CKAN backend; deploy; and bring your own branding. Each shows the AI path and the by-hand path.
+title: Guides
+description: Task-oriented "how do I…" guides. Each shows the fast AI/skill path and the equivalent by-hand path — the same project either way.
+---
+
+These are short, task-oriented guides — "how do I add a chart?", "how do I deploy?"
+Each one shows two ways to get there: the **AI path** (run a skill) and the
+**by-hand path** (the same edits, done yourself). Both produce the same plain,
+editable code.
+
+If you're just starting, read [Get started](/docs) and the
+[Quickstart](/docs/quickstart) first — these guides assume you already have a portal
+scaffolded with [`/new-portal`](/docs/skills/new-portal).
+
+## The guides
+
+| Guide | What you'll do |
+| ----- | -------------- |
+| [Add tabular data](/docs/guides/add-tabular-data) | Add a CSV, TSV, or JSON dataset and render it as a sortable table. |
+| [Add a chart](/docs/guides/add-a-chart) | Add a line, bar, area, pie, or scatter chart to a dataset page. |
+| [Render a map](/docs/guides/render-a-map) | Put a GeoJSON dataset on an interactive map. |
+| [Connect a CKAN backend](/docs/guides/connect-a-ckan-backend) | Wire the portal to a live CKAN instance — the decoupled path. |
+| [Deploy](/docs/guides/deploy) | Publish to Vercel or any static host. |
+| [Theming](/docs/guides/theming) | Bring your own branding with a `DESIGN.md`. |
+
+## Where to go next
+
+- **[Skills reference](/docs/skills)** — the full list of agentic commands behind
+  these guides.
+- **[Core concepts](/docs/core-concepts)** — the ideas that make the by-hand path as
+  first-class as the AI path.
+
+<DocsPagination prev="/docs/skills/deploy" next="/docs/guides/add-tabular-data" />

--- a/site/content/docs/guides/add-a-chart.md
+++ b/site/content/docs/guides/add-a-chart.md
@@ -1,0 +1,79 @@
+---
+metatitle: Add a Chart to PortalJS – Line, Bar, Area, Pie, Scatter
+metadescription: Add a visualization to a PortalJS dataset page — line, bar, area, pie, or scatter — with /add-chart, or by hand with a small charting library. Reads the same data the table uses.
+title: Add a chart
+description: Add a line, bar, area, pie, or scatter chart to a dataset page — with /add-chart, or by hand.
+---
+
+**Goal:** add a chart to an existing dataset page, reading the same `/public/data/`
+file the table already uses — no data duplicated.
+
+> [!info] Before you start
+> Run [`/add-dataset`](/docs/guides/add-tabular-data) first so the dataset page
+> exists. You'll chart it by its slug (e.g. `country-codes`).
+
+## The AI path — `/add-chart`
+
+Tell [`/add-chart`](/docs/skills/add-chart) which dataset, which columns, and the
+chart type:
+
+```
+/add-chart country-codes --x year --y population --type line
+```
+
+…or in natural language:
+
+```
+/add-chart the population dataset — plot population over year as a line chart
+```
+
+It validates that the columns exist, installs a lightweight charting library, writes a
+reusable `components/Chart.tsx` (only if one doesn't already exist), and inserts a
+`<Chart />` block **above** the `<Table />` so the visual summary leads and the raw
+table follows. It type-checks the project before reporting success.
+
+Supported types: **line** (default), **bar**, **area**, **pie**, **scatter**. Pass
+several Y columns for multi-series line/bar/area charts; pie and scatter use the first
+Y column only.
+
+## The by-hand path
+
+The chart is just a small client component that reads the same data file. Install a
+lightweight, tree-shakeable charting library (the skill standardizes on a single
+small library rather than a heavy all-in-one bundle), add a `Chart` component to
+`components/`, and render it on the dataset page above the `<Table />`:
+
+```tsx
+import { Chart } from '../../components/Chart';
+// …inside the page, above <Table />:
+<section className="mb-10">
+  <h2 className="text-xl font-semibold text-gray-900 mb-4">Population over year</h2>
+  <Chart url="/data/population.csv" type="line" x="year" y="population" />
+</section>
+```
+
+The component fetches the CSV in the browser (reusing the template's `parseCsv`
+helper), coerces the Y columns to numbers, and renders with a `ResponsiveContainer`.
+Because it renders client-side like `Table`, it works under static export with no
+server code.
+
+> [!note] Why a small library, not a mega-bundle
+> The skill deliberately avoids the heavy all-in-one `@portaljs/components` blob
+> (which ships Leaflet, Vega, ag-grid, and pdf.js together). A single small,
+> tree-shakeable chart library keeps the bundle lean. If you prefer a different
+> charting library — Observable Plot, for instance — the by-hand path is the same:
+> install it and write your own `Chart` component.
+
+## Notes
+
+- **Numeric coercion:** CSV cells are strings; Y values run through `Number()`.
+  Non-numeric cells render as gaps — clean the data if you see holes.
+- **Large series:** SVG charts get sluggish past ~2,000 points. Pre-aggregate (e.g.
+  yearly buckets) for big datasets.
+
+## Where to go next
+
+- **[Render a map](/docs/guides/render-a-map)** — for geographic data.
+- **[Deploy](/docs/guides/deploy)** — publish once it looks right.
+
+<DocsPagination prev="/docs/guides/add-tabular-data" next="/docs/guides/render-a-map" />

--- a/site/content/docs/guides/add-tabular-data.md
+++ b/site/content/docs/guides/add-tabular-data.md
@@ -1,0 +1,82 @@
+---
+metatitle: Add Tabular Data to PortalJS – CSV, TSV, JSON Tables
+metadescription: Add a CSV, TSV, or JSON dataset to your PortalJS portal and render it as a sortable, paginated table — with /add-dataset, or by hand with the Table component.
+title: Add tabular data
+description: Add a CSV, TSV, or JSON dataset and render it as a sortable table — with /add-dataset, or by hand.
+---
+
+**Goal:** add a CSV, TSV, or JSON file to your portal and render it as a table on its
+own dataset page, linked from the home page catalog.
+
+> [!info] Before you start
+> You need a portal scaffolded with [`/new-portal`](/docs/skills/new-portal). Tabular
+> formats supported: **CSV, TSV, and JSON (array)**. For GeoJSON, see
+> [Render a map](/docs/guides/render-a-map).
+
+## The AI path — `/add-dataset`
+
+Point [`/add-dataset`](/docs/skills/add-dataset) at a local file or a public URL:
+
+```
+/add-dataset ./data/population.csv — Auckland population by area
+```
+
+```
+/add-dataset https://example.com/air-quality.csv — Air quality monitoring
+```
+
+It copies the data into `/public/data/`, generates a dataset page at
+`pages/datasets/<slug>.tsx` with a `<Table />`, and registers the dataset on the home
+page catalog. Run `npm run dev` and visit `/datasets/<slug>` to check it.
+
+## The by-hand path
+
+Drop the file into `/public/data/`:
+
+```bash
+cp ~/Downloads/population.csv public/data/population.csv
+```
+
+Create `pages/datasets/population.tsx`:
+
+```tsx
+import { Table } from '../../components/Table';
+import Head from 'next/head';
+
+export default function PopulationDataset() {
+  return (
+    <>
+      <Head><title>Population by area</title></Head>
+      <main className="max-w-6xl mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">Population by area</h1>
+        <Table url="/data/population.csv" fullWidth />
+      </main>
+    </>
+  );
+}
+```
+
+The `Table` component (in `components/Table.tsx`) fetches the file in the browser with
+`papaparse` and renders it with `@tanstack/react-table` — no server code, and it works
+under static export. For a **JSON array**, import the file and pass it as `data` with
+`cols` instead of a `url`; set `"resolveJsonModule": true` in `tsconfig.json` first.
+
+Finally, add a link to the new page from your home page catalog (`pages/index.tsx`).
+
+> [!note] Many datasets?
+> If you'll have dozens of datasets, use the
+> [catalog template](/docs/templates) — one dynamic `[slug].tsx` route driven by a
+> `datasets.json` manifest, so adding a dataset is a JSON entry plus a data file.
+
+## Notes
+
+- **TSV** works the same way — `papaparse` auto-detects the delimiter.
+- **Large files (>5MB)** load slowly in the browser; consider server-side pagination
+  for production.
+
+## Where to go next
+
+- **[Add a chart](/docs/guides/add-a-chart)** — visualize the data you just added.
+- **[Render a map](/docs/guides/render-a-map)** — for geographic data.
+
+<DocsPagination prev="/docs/guides" next="/docs/guides/add-a-chart" />

--- a/site/content/docs/guides/connect-a-ckan-backend.md
+++ b/site/content/docs/guides/connect-a-ckan-backend.md
@@ -1,0 +1,97 @@
+---
+metatitle: Connect a CKAN Backend to PortalJS – The Decoupled Path
+metadescription: Wire your PortalJS portal to a live CKAN instance over its API with /connect-ckan — the decoupled path. Lists and renders datasets straight from CKAN, no static files.
+title: Connect a CKAN backend
+description: Wire the portal to a live CKAN instance over its API — the decoupled path, with /connect-ckan or by hand.
+---
+
+**Goal:** stop reading static files from `/public/data/` and instead list and render
+datasets straight from a live [CKAN](/ckan) instance over its REST API — the
+decoupled, "any backend" path.
+
+> [!info] Before you start
+> You need a portal scaffolded with [`/new-portal`](/docs/skills/new-portal) and the
+> **root URL of a publicly reachable CKAN instance** (e.g.
+> `https://demo.dev.datopian.com`). The skill appends `/api/3/action/...` itself.
+
+## The AI path — `/connect-ckan`
+
+```
+/connect-ckan https://demo.dev.datopian.com
+```
+
+Optionally restrict the catalog to one or more organizations or groups:
+
+```
+/connect-ckan https://demo.dev.datopian.com — orgs: my-org
+```
+
+[`/connect-ckan`](/docs/skills/connect-ckan) verifies the CKAN API is reachable,
+installs `@portaljs/ckan`, generates a `lib/ckan.ts` client module, and rewrites the
+home page and dataset route to fetch from CKAN. It runs a full `next build` and
+reports how many dataset pages were generated.
+
+## How it works — the decoupled model
+
+The frontend is **independent from the backend** and talks to it over the API
+(`package_search` for the catalog, `package_show` for each dataset). The generated
+pages fetch CKAN **server-side** in `getStaticProps`/`getStaticPaths`, so the
+`@portaljs/ckan` bundle never reaches the browser — the client stays lean and the site
+can still deploy statically.
+
+It writes plain, editable code:
+
+- `lib/ckan.ts` — a shared `CKAN` client. The base URL defaults to what you passed and
+  is overridable at deploy time via the `DMS` env var; org/group filters and a
+  build-time `MAX_DATASETS` cap live here as plain constants.
+- `pages/index.tsx` — a catalog home that lists datasets from `package_search`.
+- `pages/datasets/[slug].tsx` — one statically generated page per dataset, with
+  CSV/TSV resources previewed through the template's local `<Table />`.
+
+> [!note] Keep CKAN calls server-side
+> Reference `ckan`, `DMS`, and the filters **only** inside
+> `getStaticProps`/`getStaticPaths`. If a component body imports them, Next.js bundles
+> the whole `@portaljs/ckan` package into the client. Pass plain serializable props to
+> components instead.
+
+## The by-hand path
+
+Install the client and create `lib/ckan.ts`:
+
+```bash
+npm install @portaljs/ckan@^0.1.0
+```
+
+```ts
+import { CKAN } from '@portaljs/ckan';
+export const ckan = new CKAN((process.env.DMS || 'https://demo.dev.datopian.com').replace(/\/+$/, ''));
+```
+
+Then call `ckan.packageSearch(...)` from `getStaticProps` on the home page and
+`ckan.getDatasetDetails(slug)` from a dynamic `pages/datasets/[slug].tsx`, passing the
+results as props.
+
+> [!note] TypeScript types for @portaljs/ckan
+> Under the template's `moduleResolution: "bundler"`, add a `paths` entry in
+> `tsconfig.json` so TypeScript finds the declarations:
+> `"@portaljs/ckan": ["./node_modules/@portaljs/ckan/dist/index.d.ts"]`. Without it the
+> build fails to type-check.
+
+## Notes
+
+- **Data freshness vs. static deploy:** the default is SSG — fast and statically
+  hostable, but data is fixed at build time (rebuild to pick up new datasets). For
+  always-live data, deploy to a Node host and switch to `getServerSideProps` or
+  `getStaticPaths` `fallback: 'blocking'`.
+- **Build time scales with dataset count:** each dataset is one request and one static
+  page. `MAX_DATASETS` caps it on large instances.
+- **CORS for previews:** the `<Table>` preview fetches resource URLs from the browser;
+  datastore-backed resources are the most reliable.
+
+## Where to go next
+
+- **[Backends](/docs/backends)** — integration notes for CKAN, DKAN, OpenMetadata,
+  Purview, DataHub, GitHub, Frictionless, and custom backends.
+- **[Deploy](/docs/guides/deploy)** — publish the portal (use Vercel for SSR portals).
+
+<DocsPagination prev="/docs/guides/render-a-map" next="/docs/guides/deploy" />

--- a/site/content/docs/guides/deploy.md
+++ b/site/content/docs/guides/deploy.md
@@ -1,0 +1,76 @@
+---
+metatitle: Deploy a PortalJS Portal – Vercel or Static Hosting
+metadescription: Publish your PortalJS portal with /deploy — to Vercel for SSR/ISR, or as a fully static site for GitHub Pages, Netlify, Cloudflare, S3, or nginx. Or deploy by hand.
+title: Deploy
+description: Publish to Vercel or any static host — with /deploy, or by hand.
+---
+
+**Goal:** take the portal live. Two targets: **Vercel** (handles SSR/ISR natively) or
+a **fully static** export you can host anywhere.
+
+> [!info] Which target?
+> Use **Vercel** for portals that may grow server-side features, or any CKAN/SSR portal
+> that relies on `getServerSideProps`. Use **static** for fully client-rendered portals
+> — GitHub Pages, Netlify, Cloudflare Pages, S3 + CloudFront, or plain nginx.
+
+## The AI path — `/deploy`
+
+```
+/deploy
+```
+
+[`/deploy`](/docs/skills/deploy) auto-detects the target (a `.vercel/` link or
+`output: 'export'` in `next.config.js`), builds, verifies the build passes, and either
+publishes to Vercel or produces a ready-to-upload `out/` directory. It **never reports
+success on a failing build**.
+
+Force a target if you want:
+
+```
+/deploy --target static
+```
+
+## The by-hand path
+
+**Vercel** — Vercel builds on its own infrastructure, so no local build is needed:
+
+```bash
+npx vercel        # preview
+npx vercel --prod # production
+```
+
+**Static export** — set `output: 'export'` and `images: { unoptimized: true }` in
+`next.config.js`, then build:
+
+```bash
+npm run build     # writes the static site to out/
+npx serve out     # preview locally
+```
+
+Upload `out/` to any static host:
+
+```bash
+npx gh-pages -d out                      # GitHub Pages
+netlify deploy --dir=out --prod          # Netlify
+npx wrangler pages deploy out            # Cloudflare Pages
+```
+
+## Notes
+
+- **Dynamic routes under static export** need `getStaticPaths` returning
+  `{ fallback: false }`. `/add-dataset` writes one file per dataset specifically to
+  avoid this; the [catalog template](/docs/templates) pre-renders every manifest entry.
+- **CKAN / SSR portals can't use static** if they rely on API routes or
+  `getServerSideProps` — use Vercel.
+- **Environment variables** (e.g. `DMS` for CKAN portals) must be set in the Vercel
+  dashboard or via `vercel env add`; for static export, inline client-side values at
+  build time with `NEXT_PUBLIC_*`.
+- **GitHub Pages subpath:** if deploying to `https://user.github.io/repo/`, also set
+  `basePath` and `assetPrefix` in `next.config.js`.
+
+## Where to go next
+
+- **[Theming](/docs/guides/theming)** — brand the portal before you ship it.
+- **[Templates](/docs/templates)** — the single-page vs. catalog template.
+
+<DocsPagination prev="/docs/guides/connect-a-ckan-backend" next="/docs/guides/theming" />

--- a/site/content/docs/guides/render-a-map.md
+++ b/site/content/docs/guides/render-a-map.md
@@ -1,0 +1,79 @@
+---
+metatitle: Render a Map in PortalJS – Interactive GeoJSON Maps
+metadescription: Render a GeoJSON dataset on an interactive Leaflet map in your PortalJS portal — with /add-map, or by hand with react-leaflet and a client-only Map component.
+title: Render a map
+description: Put a GeoJSON dataset on an interactive map — with /add-map, or by hand with react-leaflet.
+---
+
+**Goal:** render a GeoJSON dataset (points, lines, or polygons) on an interactive map
+on its own page, linked from the home page catalog.
+
+> [!info] Before you start
+> You need a portal scaffolded with [`/new-portal`](/docs/skills/new-portal). The
+> source must be **GeoJSON** — a `Feature`, `FeatureCollection`, or geometry object.
+> For tabular data, see [Add tabular data](/docs/guides/add-tabular-data).
+
+## The AI path — `/add-map`
+
+Point [`/add-map`](/docs/skills/add-map) at a local file or a public URL:
+
+```
+/add-map ./data/regions.geojson — Auckland region boundaries
+```
+
+It validates the GeoJSON, copies it into `/public/data/`, installs
+`react-leaflet`/`leaflet` (once), generates a reusable client-only `Map` component,
+creates a map page under `pages/datasets/`, and registers it on the home page. It
+runs a full `next build` before reporting success.
+
+> [!note] Map and table of the same file
+> `/add-dataset` renders GeoJSON as a properties table; `/add-map` renders it on a
+> map. Run both on the same file to offer both views — `/add-map` adds a `-map` suffix
+> to keep the routes distinct.
+
+## The by-hand path
+
+Drop the file into `/public/data/`, then install Leaflet directly:
+
+```bash
+npm install react-leaflet@^4 leaflet@^1.9 && npm install -D @types/leaflet
+```
+
+> [!note] Why react-leaflet v4
+> v4 targets React 18 (the template's React). Don't install v5 (React 19) unless
+> you've upgraded the portal to React 19.
+
+Leaflet touches `window` at module load, so it **must not** be server-rendered. Split
+the component in two: a `MapView.tsx` holding the Leaflet code, and a thin `Map.tsx`
+wrapper that loads it with `dynamic(() => import('./MapView'), { ssr: false })`. Only
+the prop type is imported across the boundary, so Leaflet never reaches the server
+bundle.
+
+The map page passes the GeoJSON as a `url` so the component fetches it client-side
+(the file is served statically from `/public/data/`), which sidesteps `.geojson`
+import quirks:
+
+```tsx
+import Map from '../../components/Map';
+// …
+<Map url="/data/regions.geojson" />
+```
+
+Then add a link from your home page catalog (`pages/index.tsx`).
+
+## Notes
+
+- **Coordinate order:** GeoJSON is `[longitude, latitude]`. Leaflet's `GeoJSON` layer
+  handles this — don't pre-swap.
+- **CRS:** Leaflet assumes WGS84 (EPSG:4326). Reproject projected data first or it
+  lands in the wrong place.
+- **Large files (>5MB):** thousands of features render slowly — simplify geometries
+  (e.g. with `mapshaper`) first.
+
+## Where to go next
+
+- **[Connect a CKAN backend](/docs/guides/connect-a-ckan-backend)** — serve datasets
+  from a live catalog instead of static files.
+- **[Deploy](/docs/guides/deploy)** — publish the portal.
+
+<DocsPagination prev="/docs/guides/add-a-chart" next="/docs/guides/connect-a-ckan-backend" />

--- a/site/content/docs/guides/theming.md
+++ b/site/content/docs/guides/theming.md
@@ -1,0 +1,72 @@
+---
+metatitle: Theming PortalJS – Bring Your Own Branding
+metadescription: Brand your PortalJS portal with your own colors, type, and layout. Hand your AI assistant a DESIGN.md brief, or edit Tailwind config and globals.css directly — plain, editable code.
+title: Theming
+description: Bring your own branding — hand your AI assistant a DESIGN.md, or edit Tailwind directly.
+---
+
+**Goal:** make the portal look like *yours* — your colors, type, and layout — without
+fighting a design system. The template is plain Next.js + Tailwind, so theming is just
+editing code.
+
+> [!info] No magic theme layer
+> PortalJS doesn't ship a theme runtime or a config you fight. Styling is ordinary
+> Tailwind utility classes on plain components — change them and the portal changes.
+
+## The AI path — bring your own `DESIGN.md`
+
+The cleanest way to brand a portal with an AI assistant is to hand it a **design
+brief** — a `DESIGN.md` in the repo that states your brand foundations: color tokens,
+type, and layout posture. The assistant reads it and applies those tokens across
+`tailwind.config.js`, `styles/globals.css`, and the components.
+
+A brief is short and concrete. For example:
+
+```markdown
+# Brand foundations
+
+## Color tokens
+- accent:  #2563eb   (primary)
+- bg:      near-white canvas
+- fg:      slate ink (#1e293b)
+- border:  hairline gray
+
+## Type
+- Display + body: Inter / system sans — weight contrast carries hierarchy.
+- Mono: JetBrains Mono — for IDs and code.
+
+## Layout posture
+- Generous whitespace, light canvas. Hairline 1px borders, 12–16px card radius,
+  no heavy shadows. One accent color.
+```
+
+Then ask: *"Apply the branding in DESIGN.md to this portal."* Because the output is
+plain code, you can review and tweak every change by hand afterward.
+
+## The by-hand path
+
+Everything the brief drives, you can edit directly:
+
+- **Colors and fonts** — extend the palette and `fontFamily` in
+  `tailwind.config.js` under `theme.extend`, then use the new utility classes in your
+  components.
+- **Global styles and CSS variables** — set brand tokens (e.g. `--accent`, `--bg`) in
+  `styles/globals.css` and reference them from components or Tailwind.
+- **Layout and components** — the components in `components/` (`Table`, `Chart`, `Map`)
+  are small and swappable. Edit their classes, or replace them entirely with your own
+  design-system components — the data-loading logic is independent of the markup.
+
+## Notes
+
+- **Bring your own stack:** the template never forces a frontend toolchain on a team
+  that already has one. Adopt the whole template, or lift the skills and components
+  into an existing app — see [Core concepts](/docs/core-concepts).
+- **Tailwind Typography:** the template includes `@tailwindcss/typography` (the `prose`
+  classes) for long-form text — handy for dataset descriptions and docs-style pages.
+
+## Where to go next
+
+- **[Templates](/docs/templates)** — the single-page vs. catalog starting points.
+- **[Deploy](/docs/guides/deploy)** — ship the branded portal.
+
+<DocsPagination prev="/docs/guides/deploy" next="/docs/templates" />

--- a/site/content/docs/templates.md
+++ b/site/content/docs/templates.md
@@ -1,0 +1,70 @@
+---
+metatitle: PortalJS Templates – Default Template vs Catalog Variant
+metadescription: PortalJS ships two starting points — the default template (one page file per dataset) and the catalog variant (one dynamic route driven by a datasets.json manifest). When to use which.
+title: Templates
+description: The default template vs the catalog variant — one page per dataset, or one dynamic route driven by a manifest. When to use which.
+---
+
+PortalJS ships two starting points. Both are real Next.js projects with the same
+lightweight `components/Table.tsx`, Tailwind setup, and Next 14 config — they differ
+only in how dataset pages are routed. [`/new-portal`](/docs/skills/new-portal) picks
+the right one for your brief; you can also clone either by hand.
+
+## The two templates
+
+| | `portaljs-template` (default) | `portaljs-catalog` |
+| --- | --- | --- |
+| Dataset pages | one `.tsx` file per dataset | one dynamic `[slug].tsx` for all |
+| Registration | hardcoded array in `index.tsx` | `datasets.json` manifest |
+| Adding a dataset | new page file + array entry | one JSON entry + a data file |
+| Best for | a handful of datasets | dozens to hundreds |
+
+## Default template — one page per dataset
+
+[`examples/portaljs-template`](https://github.com/datopian/portaljs/tree/main/examples/portaljs-template)
+is the canonical template. Each dataset is its own `pages/datasets/<slug>.tsx` file,
+registered in a `datasets` array on the home page. This is the simplest mental model —
+one file, one page — and it has no `getStaticPaths`, so it static-exports without
+fuss. [`/add-dataset`](/docs/skills/add-dataset) writes one file per dataset against
+this template.
+
+Clone it by hand with [degit](https://github.com/Rich-Harris/degit):
+
+```bash
+npx degit datopian/portaljs/examples/portaljs-template my-portal
+```
+
+## Catalog variant — one dynamic route
+
+[`examples/portaljs-catalog`](https://github.com/datopian/portaljs/tree/main/examples/portaljs-catalog)
+is for portals with **many datasets**. Instead of a file per dataset, the catalog is
+driven by a single `datasets.json` manifest and rendered by a dynamic
+`pages/datasets/[slug].tsx` route with `getStaticPaths`. Adding a dataset is one JSON
+entry plus a data file — no new page:
+
+```json
+{ "slug": "my-data", "name": "My Data", "description": "…", "file": "my-data.csv", "format": "csv" }
+```
+
+```bash
+npx degit datopian/portaljs/examples/portaljs-catalog my-catalog
+```
+
+## Which should I use?
+
+- **A handful of datasets, or you want each page to be its own editable file** → the
+  **default template**.
+- **Dozens to hundreds of datasets, driven from a manifest** → the **catalog variant**.
+- **A live backend (CKAN, etc.)** → start from either, then run
+  [`/connect-ckan`](/docs/guides/connect-a-ckan-backend) — it replaces the dataset route
+  with one that fetches from the backend.
+
+Both static-export cleanly (the catalog pre-renders every manifest entry via
+`getStaticPaths` with `fallback: false`).
+
+## Where to go next
+
+- **[Authoring skills](/docs/authoring-skills)** — write your own skill.
+- **[Backends](/docs/backends)** — connect a data management system.
+
+<DocsPagination prev="/docs/guides/theming" next="/docs/authoring-skills" />

--- a/site/content/opensource/docs/index.md
+++ b/site/content/opensource/docs/index.md
@@ -3,5 +3,11 @@ title: PortalJS Open Source Framework – Rapidly Build Rich Data Portals
 description: PortalJS is a JavaScript framework for rapidly building rich data portal frontends using a modern frontend approach.
 ---
 
+> [!info] Looking for the new AI-native docs?
+> These are the **classic** open-source framework docs. There's now an **AI-native**
+> way to build a PortalJS data portal — describe what you want and let your AI
+> assistant scaffold it — documented at [/docs](/docs). The classic framework docs
+> here are not going away.
+
 <Features/>
 <Community />


### PR DESCRIPTION
Completes the AI-native `/docs` information architecture. **Stacked on #1512 (Skills reference)** — base is `docs/skills-reference`; will auto-retarget to `main` once #1512 merges. Covers four beads: po-63q, po-6rs, po-zoh, po-gyj.

## Guides (`/docs/guides`) — po-63q
Task-oriented how-tos, each with the AI/skill path and the by-hand path: add tabular data, add a chart, render a map, connect a CKAN backend, deploy, theming (bring-your-own `DESIGN.md`). Plus a guides index.

## Templates / Authoring / Backends — po-6rs
- **Templates** — default vs catalog variant, when to use which.
- **Authoring skills** — how to write your own (from `.claude/AUTHORING.md`).
- **Backends** — per-backend integration notes (CKAN, DKAN, OpenMetadata, Purview, DataHub, GitHub, Frictionless, custom).

## Legacy coexistence — po-zoh
No removal, no redirects. Reverse `[!info]` banner on the classic `/opensource` docs pointing to `/docs`; nav **Docs** now points to `/docs` (AI-native) with a **Classic** sub-link; labels "PortalJS (AI-native)" vs "Classic".

## PortalJS Cloud docs — po-gyj
Reframed as the **managed** option via a banner, kept separate from the OSS framework docs; reachable in nav under the Cloud/managed context.

## Note
`/add-chart` ships with **recharts**, so the chart guide documents that (and treats Observable Plot/Framework as the by-hand / future option) rather than misstating the skill. Aligning the skill itself to Observable Plot is a possible follow-up.

## Verify
`tsc --noEmit` clean; `next build` 163/163 pages (+10; nested `/docs/guides/*` routing confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
