### PR TITLE
chore(site): drop dead Storybook nav link

### DIFF
--- a/site/content/assets/sidebar.json
+++ b/site/content/assets/sidebar.json
@@ -94,14 +94,5 @@
         "href": "/opensource/howtos/comments"
       }
     ]
-  },
-  {
-    "title": "Components",
-    "links": [
-      {
-        "title": "Storybook",
-        "href": "https://storybook.portaljs.org"
-      }
-    ]
   }
 ]


### PR DESCRIPTION
Removes the `Components → Storybook` nav entry (`https://storybook.portaljs.org`) from the site sidebar. Storybook was retired with nx in #1516, and the `portaljs-storybook` Vercel project that served that URL is outdated/failing — so the link is dead.

Companion to removing the `portaljs-storybook` Vercel project (like `site-portaljs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Components section from the sidebar navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->