### PR TITLE
chore(site): migrate to next-seo 7

### DIFF
--- a/site/components/JSONLD.tsx
+++ b/site/components/JSONLD.tsx
@@ -39,24 +39,24 @@ export default function JSONLD({
   if (isBlog) {
     Component = (
       <ArticleJsonLd
-        title={meta.metatitle || meta.title}
+        headline={meta.metatitle || meta.title}
         description={meta.metadescription || meta.description}
         type="BlogPosting"
         url={pageUrl}
         datePublished={meta.date}
-        authorName={meta.authors?.map(a => a.name) || "PortalJS Cloud"}
-        images={images}
+        author={meta.authors?.map(a => a.name) || "PortalJS Cloud"}
+        image={images}
       />
     );
   } else if (isDoc) {
     Component = (
       <ArticleJsonLd
         url={pageUrl}
-        title={meta.title}
-        images={images}
+        headline={meta.title}
+        image={images}
         datePublished={meta.date}
         dateModified={meta.date}
-        authorName={meta.authors?.map(a => a.name) || "PortalJS Cloud"}
+        author={meta.authors?.map(a => a.name) || "PortalJS Cloud"}
         description={meta.description}
       />
     );
@@ -64,12 +64,12 @@ export default function JSONLD({
   else if (isCaseStudy) {
     Component = (
       <ArticleJsonLd
-        title={meta.metatitle || meta.title}
+        headline={meta.metatitle || meta.title}
         description={meta.metadescription || meta.description}
         url={pageUrl}
         datePublished={meta.date}
-        authorName={meta.authors?.map(a => a.name) || "PortalJS Cloud"}
-        images={meta.images}
+        author={meta.authors?.map(a => a.name) || "PortalJS Cloud"}
+        image={meta.images}
         type="Article"
       />
     )

--- a/site/components/Layout.tsx
+++ b/site/components/Layout.tsx
@@ -1,5 +1,4 @@
 import siteConfig from '@/config/siteConfig'
-import { NextSeo } from 'next-seo'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'

--- a/site/components/schema/BlogStructuredData.tsx
+++ b/site/components/schema/BlogStructuredData.tsx
@@ -1,18 +1,21 @@
-import { BreadcrumbJsonLd, LogoJsonLd, NextSeo, WebPageJsonLd } from "next-seo";
+import { BreadcrumbJsonLd, OrganizationJsonLd } from "next-seo";
+import { generateNextSeo } from "next-seo/pages";
+import Head from "next/head";
 
 export function BlogStructuredData({ blogs }) {
 
   return (
     <>
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://www.portaljs.com"
         logo="https://www.portaljs.com/icon.png"
       />
-      <NextSeo
-        title="Blog"
-        description="Discover insights, updates and stories about PortalJS Cloud. Stay informed about open data solutions and enhance your data portal skills."
-        canonical="https://www.portaljs.com/blog"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "Blog",
+          description: "Discover insights, updates and stories about PortalJS Cloud. Stay informed about open data solutions and enhance your data portal skills.",
+          canonical: "https://www.portaljs.com/blog",
+          openGraph: {
           url: 'https://www.portaljs.com/blog',
           title: 'Blog',
           description: 'Discover insights, updates and stories about PortalJS Cloud. Stay informed about open data solutions and enhance your data portal skills.',
@@ -27,31 +30,24 @@ export function BlogStructuredData({ blogs }) {
               type: 'image/webp',
             },
           ],
-        }}
-        twitter={{
+        },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://www.portaljs.com',
           },
           {
-            position: 2,
             name: 'Blog',
             item: 'https://www.portaljs.com/blog',
           },
         ]}
-      />
-      <WebPageJsonLd
-        id="https://www.portaljs.com/blog#webpage"
-        url="https://www.portaljs.com/blog"
-        name="Blog"
-        description="Discover insights, updates and stories about PortalJS Cloud. Stay informed about open data solutions and enhance your data portal skills."
       />
     </>
   );

--- a/site/components/schema/CaseStudiesStructuredData.tsx
+++ b/site/components/schema/CaseStudiesStructuredData.tsx
@@ -1,19 +1,21 @@
-import { BreadcrumbJsonLd, LogoJsonLd, NextSeo, WebPageJsonLd } from "next-seo";
+import { BreadcrumbJsonLd, OrganizationJsonLd } from "next-seo";
+import { generateNextSeo } from "next-seo/pages";
+import Head from "next/head";
 
 export function CaseStudiesStructuredData({ casestudies }) {
 
   return (
     <>
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://www.portaljs.com"
         logo="https://www.portaljs.com/icon.png"
       />
-      <NextSeo
-        title="Showcase of Case Studies"
-        description="See our client stories."
-        canonical="https://www.portaljs.com/showcase"
-        openGraph={
-          {
+      <Head>
+        {generateNextSeo({
+          title: "Showcase of Case Studies",
+          description: "See our client stories.",
+          canonical: "https://www.portaljs.com/showcase",
+          openGraph: {
             url: 'https://www.portaljs.com/showcase',
             title: 'Showcase of Case Studies',
             description: 'See our client stories.',
@@ -28,32 +30,24 @@ export function CaseStudiesStructuredData({ casestudies }) {
                 type: 'image/webp',
               },
             ],
-          }
-        }
-        twitter={{
+          },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://www.portaljs.com',
           },
           {
-            position: 2,
             name: 'Showcase',
             item: 'https://www.portaljs.com/showcase',
           },
         ]}
-      />
-      <WebPageJsonLd
-        id="https://www.portaljs.com/showcase#webpage"
-        url="https://www.portaljs.com/showcase"
-        name="Showcase of Case Studies"
-        description="See our client stories."
       />
     </>
   )

--- a/site/components/schema/DataPortalStructuredData.tsx
+++ b/site/components/schema/DataPortalStructuredData.tsx
@@ -1,4 +1,6 @@
-import { BreadcrumbJsonLd, LogoJsonLd, NextSeo, WebPageJsonLd } from "next-seo";
+import { BreadcrumbJsonLd, OrganizationJsonLd } from "next-seo";
+import { generateNextSeo } from "next-seo/pages";
+import Head from "next/head";
 import { dataPortals } from "../Showcases";
 
 
@@ -6,16 +8,16 @@ export function DataPortalsStructuredData() {
 
   return (
     <>
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://www.portaljs.com"
         logo="https://www.portaljs.com/icon.png"
       />
-      <NextSeo
-        title="Showcase of Data Portals"
-        description="Discover data portals powered by PortalJS."
-        canonical="https://www.portaljs.com/showcase"
-        openGraph={
-          {
+      <Head>
+        {generateNextSeo({
+          title: "Showcase of Data Portals",
+          description: "Discover data portals powered by PortalJS.",
+          canonical: "https://www.portaljs.com/showcase",
+          openGraph: {
             url: 'https://www.portaljs.com/showcase',
             title: 'Showcase of Data Portals',
             description: 'Discover data portals powered by PortalJS.',
@@ -30,32 +32,24 @@ export function DataPortalsStructuredData() {
                 type: 'image/webp',
               },
             ],
-          }
-        }
-        twitter={{
+          },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://www.portaljs.com',
           },
           {
-            position: 2,
             name: 'Showcase',
             item: 'https://www.portaljs.com/showcase',
           },
         ]}
-      />
-      <WebPageJsonLd
-        id="https://www.portaljs.com/showcase#webpage"
-        url="https://www.portaljs.com/showcase"
-        name="Showcase of Data Portals"
-        description="Discover data portals powered by PortalJS."
       />
     </>
   )

--- a/site/components/schema/FaqStructuredData.tsx
+++ b/site/components/schema/FaqStructuredData.tsx
@@ -1,5 +1,7 @@
 import { questions } from "@/pages/faq";
-import { BreadcrumbJsonLd, FAQPageJsonLd, LogoJsonLd, NextSeo } from "next-seo";
+import { BreadcrumbJsonLd, FAQJsonLd, OrganizationJsonLd } from "next-seo";
+import { generateNextSeo } from "next-seo/pages";
+import Head from "next/head";
 
 export function FaqStructuredData() {
   function markdownToPlainText(md: string) {
@@ -16,15 +18,16 @@ export function FaqStructuredData() {
 
   return (
     <>
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://www.portaljs.com"
         logo="https://www.portaljs.com/icon.png"
       />
-      <NextSeo
-        title="FAQ"
-        description="Frequently Asked Questions about PortalJS Cloud. Get answers about pricing, features, deployment, and more."
-        canonical="https://www.portaljs.com/faq"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "FAQ",
+          description: "Frequently Asked Questions about PortalJS Cloud. Get answers about pricing, features, deployment, and more.",
+          canonical: "https://www.portaljs.com/faq",
+          openGraph: {
           url: 'https://www.portaljs.com/faq',
           title: 'FAQ',
           description: 'Frequently Asked Questions about PortalJS Cloud. Get answers about pricing, features, deployment, and more.',
@@ -39,31 +42,30 @@ export function FaqStructuredData() {
               type: 'image/webp',
             },
           ],
-        }}
-        twitter={{
+        },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://www.portaljs.com',
           },
           {
-            position: 2,
             name: 'FAQ',
             item: 'https://www.portaljs.com/faq',
           },
         ]}
       />
-      <FAQPageJsonLd
-        mainEntity={questions.flatMap(category =>
+      <FAQJsonLd
+        questions={questions.flatMap(category =>
           category.items.map(({ question, answer }) => ({
-            questionName: question,
-            acceptedAnswerText: markdownToPlainText(answer),
+            question,
+            answer: markdownToPlainText(answer),
           }))
         )}
       />

--- a/site/components/schema/HomePageStructuredData.tsx
+++ b/site/components/schema/HomePageStructuredData.tsx
@@ -1,4 +1,6 @@
-import { BreadcrumbJsonLd, FAQPageJsonLd, LogoJsonLd, NextSeo, WebPageJsonLd } from "next-seo";
+import { BreadcrumbJsonLd, FAQJsonLd, OrganizationJsonLd } from "next-seo";
+import { generateNextSeo } from "next-seo/pages";
+import Head from "next/head";
 import { homeFaqQuestions } from '@/lib/homeFaqQuestions';
 
 export function HomePageStructuredData() {
@@ -14,15 +16,16 @@ export function HomePageStructuredData() {
   }
   return (
     <>
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://www.portaljs.com"
         logo="https://www.portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS — Modern Open Data Portals & Headless Data Platform"
-        description="PortalJS is the simplest way to launch a modern, compliant open data portal. Designed for governments, nonprofits, and academic institutions."
-        canonical="https://www.portaljs.com"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS — Modern Open Data Portals & Headless Data Platform",
+          description: "PortalJS is the simplest way to launch a modern, compliant open data portal. Designed for governments, nonprofits, and academic institutions.",
+          canonical: "https://www.portaljs.com",
+          openGraph: {
           url: 'https://www.portaljs.com',
           title: 'PortalJS — Modern Open Data Portals & Headless Data Platform',
           description: 'PortalJS is the simplest way to launch a modern, compliant open data portal. Designed for governments, nonprofits, and academic institutions.',
@@ -37,31 +40,25 @@ export function HomePageStructuredData() {
               type: 'image/webp',
             },
           ],
-        }}
-        twitter={{
+        },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://www.portaljs.com',
           },
         ]}
       />
-      <WebPageJsonLd
-        id="https://www.portaljs.com#webpage"
-        url="https://www.portaljs.com"
-        name="PortalJS Cloud"
-        description="PortalJS Cloud is the simplest way to get started with open data. Designed for governments, nonprofits, and academic institutions, it lets you launch a modern, compliant portal in minutes."
-      />
-      <FAQPageJsonLd
-        mainEntity={homeFaqQuestions.map(({ question, answer }) => ({
-          questionName: question,
-          acceptedAnswerText: markdownToPlainText(answer),
+      <FAQJsonLd
+        questions={homeFaqQuestions.map(({ question, answer }) => ({
+          question,
+          answer: markdownToPlainText(answer),
         }))}
       />
     </>

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -29,7 +29,7 @@
         "mermaid": "^11.15.0",
         "next": "^13.5.11",
         "next-mdx-remote": "^6.0.0",
-        "next-seo": "^5.15.0",
+        "next-seo": "^7.2.0",
         "next-sitemap": "^4.2.2",
         "next-themes": "^0.2.1",
         "posthog-js": "^1.382.0",
@@ -13985,14 +13985,12 @@
       }
     },
     "node_modules/next-seo": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-5.15.0.tgz",
-      "integrity": "sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==",
-      "license": "MIT",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-7.2.0.tgz",
+      "integrity": "sha512-ST7/YB8g0SXGuEKNucBz9wiP6nCYVZ4v8qJB7rAz9Vr1X98mw5orWL9COr8td/dzqtCYd4xaIg0YVCq5Yy3PQA==",
       "peerDependencies": {
-        "next": "^8.1.1-canary.54 || >=9.0.0",
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
+        "next": ">=13.4.0",
+        "react": ">=18.2.0"
       }
     },
     "node_modules/next-sitemap": {

--- a/site/package.json
+++ b/site/package.json
@@ -36,7 +36,7 @@
     "mermaid": "^11.15.0",
     "next": "^13.5.11",
     "next-mdx-remote": "^6.0.0",
-    "next-seo": "^5.15.0",
+    "next-seo": "^7.2.0",
     "next-sitemap": "^4.2.2",
     "next-themes": "^0.2.1",
     "posthog-js": "^1.382.0",

--- a/site/pages/[...slug].tsx
+++ b/site/pages/[...slug].tsx
@@ -11,7 +11,9 @@ import { CustomAppProps } from './_app.jsx'
 import computeFields from '@/lib/computeFields'
 import { getAuthorsDetails } from '@/lib/getAuthorsDetails'
 import JSONLD from '@/components/JSONLD'
-import { BreadcrumbJsonLd, FAQPageJsonLd, NextSeo } from 'next-seo'
+import { BreadcrumbJsonLd, FAQJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import siteConfig from '@/config/siteConfig'
 
 export default function Page({ source, meta, sidebarTree }) {
@@ -30,7 +32,6 @@ export default function Page({ source, meta, sidebarTree }) {
   const urlSegments = meta.urlPath.split('/')
   const breadcrumbs = urlSegments.map((segment, i) => {
     return {
-      position: i + 1,
       name: i == urlSegments.length - 1 ? meta.title || segment : segment,
       item: '/' + urlSegments.slice(0, i + 1).join('/'),
     }
@@ -43,11 +44,12 @@ export default function Page({ source, meta, sidebarTree }) {
 
   return (
     <>
-      <NextSeo
-        title={title}
-        description={description}
-        canonical={canonicalUrl}
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: title,
+          description: description,
+          canonical: canonicalUrl,
+          openGraph: {
           url: canonicalUrl,
           title,
           description,
@@ -62,19 +64,20 @@ export default function Page({ source, meta, sidebarTree }) {
               alt: title,
             },
           ],
-        }}
-        twitter={{
+        },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
-      <BreadcrumbJsonLd itemListElements={breadcrumbs} />
+        },
+        })}
+      </Head>
+      <BreadcrumbJsonLd items={breadcrumbs} />
       <JSONLD meta={meta} source={source.compiledSource} />
       {meta.faqs && meta.faqs.length > 0 && (
-        <FAQPageJsonLd
-          mainEntity={meta.faqs.map(faq => ({
-            questionName: faq.question,
-            acceptedAnswerText: faq.answer
+        <FAQJsonLd
+          questions={meta.faqs.map(faq => ({
+            question: faq.question,
+            answer: faq.answer
           }))}
         />
       )}

--- a/site/pages/_app.tsx
+++ b/site/pages/_app.tsx
@@ -3,7 +3,8 @@ import '@/styles/prism.css';
 import '@/styles/docsearch.css';
 import 'tailwindcss/tailwind.css';
 import Script from 'next/script';
-import { DefaultSeo } from 'next-seo';
+import { generateDefaultSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import { NavGroup, NavItem, pageview, ThemeProvider } from '@portaljs/core';
 import siteConfig from '../config/siteConfig';
 import { useEffect } from 'react';
@@ -72,17 +73,18 @@ function MyApp({ Component, pageProps }) {
       defaultTheme="light"
       forcedTheme="light"
     >
-      <DefaultSeo
-        defaultTitle={siteConfig.title}
-        titleTemplate={'%s | ' + siteConfig.title}
-        description={siteConfig.description}
-        //titleTemplate="PortalJS - %s"
-        additionalMetaTags={[
+      <Head>
+        {generateDefaultSeo({
+          defaultTitle: siteConfig.title,
+          titleTemplate: '%s | ' + siteConfig.title,
+          description: siteConfig.description,
+          additionalMetaTags: [
           { name: 'author', content: siteConfig.author },
           { name: 'publisher', content: siteConfig.author },
-        ]}
-        {...siteConfig.nextSeo}
-      />
+        ],
+          ...siteConfig.nextSeo,
+        })}
+      </Head>
 
       {/* Global Site Tag (gtag.js) - Google Analytics */}
       {siteConfig.analytics && (

--- a/site/pages/blog.tsx
+++ b/site/pages/blog.tsx
@@ -3,7 +3,6 @@ import computeFields from "@/lib/computeFields";
 import clientPromise from "@/lib/mddb";
 import { BlogsList, SimpleLayout } from "@portaljs/core";
 import * as fs from "fs";
-import { NextSeo } from "next-seo";
 import { H1, H2 } from "@/components/custom/header";
 import { BlogStructuredData } from "@/components/schema/BlogStructuredData";
 export default function Blog({ blogs }) {

--- a/site/pages/case-studies.tsx
+++ b/site/pages/case-studies.tsx
@@ -1,7 +1,8 @@
 import Layout from '@/components/Layout'
 import computeFields from '@/lib/computeFields'
 import clientPromise from '@/lib/mddb'
-import { NextSeo } from 'next-seo'
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import fs from 'fs'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -11,11 +12,13 @@ import { CaseStudiesStructuredData } from '@/components/schema/CaseStudiesStruct
 export default function CaseStudiesPage(casestudies) {
   return (
     <Layout>
-      <NextSeo
-        title="Case Studies | PortalJS"
-        description="Discover how organizations worldwide build powerful data portals with PortalJS. Real client stories, implementations, and success stories."
-        canonical="https://portaljs.org/case-studies"
-      />
+      <Head>
+        {generateNextSeo({
+          title: "Case Studies | PortalJS",
+          description: "Discover how organizations worldwide build powerful data portals with PortalJS. Real client stories, implementations, and success stories.",
+          canonical: "https://portaljs.org/case-studies",
+        })}
+      </Head>
       <CaseStudiesStructuredData casestudies={casestudies.casestudies} />
       <section className="">
         <div>

--- a/site/pages/ckan.tsx
+++ b/site/pages/ckan.tsx
@@ -2,7 +2,9 @@ import Hero from '@/components/ckan/Hero'
 import SocialProof from '@/components/ckan/SocialProof'
 import { KeyFeatures } from '@/components/ckan/KeyFeatures'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Layout from '@/components/Layout'
 import { WhyCKANAndPortalJS } from '@/components/ckan/WhyCKANAndPortalJS'
 import { CommonUseCases } from '@/components/ckan/CommonUseCases'
@@ -13,39 +15,32 @@ export default function CKAN() {
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
-          <LogoJsonLd
+          <OrganizationJsonLd
             url="https://portaljs.com"
             logo="https://portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
-          <NextSeo
-            title="CKAN Data Management System Integration | Decoupled Open Data Frontend"
-            description="Build a modern, headless UI for CKAN with PortalJS. Enjoy copy-&-paste components, server-side rendering for SEO, and full branding control."
-            canonical="https://portaljs.com/ckan"
-            openGraph={{
+          <Head>
+            {generateNextSeo({
+              title: "CKAN Data Management System Integration | Decoupled Open Data Frontend",
+              description: "Build a modern, headless UI for CKAN with PortalJS. Enjoy copy-&-paste components, server-side rendering for SEO, and full branding control.",
+              canonical: "https://portaljs.com/ckan",
+              openGraph: {
               url: 'https://portaljs.com/ckan',
               title: 'CKAN Data Management System Integration | Decoupled Open Data Frontend',
               description: 'Build a modern, headless UI for CKAN with PortalJS. Enjoy copy-&-paste components, server-side rendering for SEO, and full branding control.',
               site_name: 'PortalJS',
-            }}
-          />
-          {/* 3. WebPage schema */}
-          <WebPageJsonLd
-            id="https://portaljs.com/ckan#webpage"
-            url="https://portaljs.com/ckan"
-            title="CKAN Data Management System Integration | Decoupled Open Data Frontend"
-            description="Build a modern, headless UI for CKAN with PortalJS. Enjoy copy-&-paste components, server-side rendering for SEO, and full branding control."
-          />
+            },
+            })}
+          </Head>
           {/* 4. Breadcrumb schema */}
           <BreadcrumbJsonLd
-            itemListElements={[
+            items={[
               {
-                position: 1,
                 name: 'Home',
                 item: 'https://portaljs.com',
               },
               {
-                position: 2,
                 name: 'CKAN',
                 item: 'https://portaljs.com/ckan',
               },

--- a/site/pages/compare/arcgis-hub.tsx
+++ b/site/pages/compare/arcgis-hub.tsx
@@ -1,6 +1,8 @@
 import Layout from '@/components/Layout'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -189,15 +191,16 @@ export default function PortalJSvsArcGISHub() {
   return (
     <Layout isHomePage={true}>
       {/* SEO */}
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS vs ArcGIS Hub | Open Source Data Portal Comparison"
-        description="Compare PortalJS with ArcGIS Hub: See how our open source data portal platform offers more flexibility, better cost control, and freedom from vendor lock-in."
-        canonical="https://portaljs.com/compare/arcgis-hub"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS vs ArcGIS Hub | Open Source Data Portal Comparison",
+          description: "Compare PortalJS with ArcGIS Hub: See how our open source data portal platform offers more flexibility, better cost control, and freedom from vendor lock-in.",
+          canonical: "https://portaljs.com/compare/arcgis-hub",
+          openGraph: {
           url: 'https://portaljs.com/compare/arcgis-hub',
           title: 'PortalJS vs ArcGIS Hub | Open Source Data Portal Comparison',
           description: 'Compare PortalJS with ArcGIS Hub: See how our open source data portal platform offers more flexibility, better cost control, and freedom from vendor lock-in.',
@@ -211,28 +214,20 @@ export default function PortalJSvsArcGISHub() {
           ],
           siteName: 'PortalJS',
           type: 'website'
-        }}
-      />
-      <WebPageJsonLd
-        id="https://portaljs.com/compare/arcgis-hub#webpage"
-        url="https://portaljs.com/compare/arcgis-hub"
-        name="PortalJS vs ArcGIS Hub | Open Source Data Portal Comparison"
-        description="Compare PortalJS with ArcGIS Hub: See how our open source data portal platform offers more flexibility, better cost control, and freedom from vendor lock-in."
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://portaljs.com',
           },
           {
-            position: 2,
             name: 'Compare',
             item: 'https://portaljs.com/compare',
           },
           {
-            position: 3,
             name: 'ArcGIS Hub',
             item: 'https://portaljs.com/compare/arcgis-hub',
           }

--- a/site/pages/compare/ckan.tsx
+++ b/site/pages/compare/ckan.tsx
@@ -1,6 +1,8 @@
 import Layout from '@/components/Layout'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -189,15 +191,16 @@ export default function PortalJSvsCKAN() {
   return (
     <Layout isHomePage={true}>
       {/* SEO */}
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS vs CKAN Classic | Modern Frontend vs Monolithic Architecture"
-        description="Compare PortalJS with CKAN Classic: See how our decoupled frontend approach delivers better performance, developer experience, and user experience than monolithic CKAN."
-        canonical="https://portaljs.com/compare/ckan"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS vs CKAN Classic | Modern Frontend vs Monolithic Architecture",
+          description: "Compare PortalJS with CKAN Classic: See how our decoupled frontend approach delivers better performance, developer experience, and user experience than monolithic CKAN.",
+          canonical: "https://portaljs.com/compare/ckan",
+          openGraph: {
           url: 'https://portaljs.com/compare/ckan',
           title: 'PortalJS vs CKAN Classic | Modern Frontend vs Monolithic Architecture',
           description: 'Compare PortalJS with CKAN Classic: See how our decoupled frontend approach delivers better performance, developer experience, and user experience than monolithic CKAN.',
@@ -211,28 +214,20 @@ export default function PortalJSvsCKAN() {
           ],
           siteName: 'PortalJS',
           type: 'website'
-        }}
-      />
-      <WebPageJsonLd
-        id="https://portaljs.com/compare/ckan#webpage"
-        url="https://portaljs.com/compare/ckan"
-        name="PortalJS vs CKAN Classic | Modern Frontend vs Monolithic Architecture"
-        description="Compare PortalJS with CKAN Classic: See how our decoupled frontend approach delivers better performance, developer experience, and user experience than monolithic CKAN."
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://portaljs.com',
           },
           {
-            position: 2,
             name: 'Compare',
             item: 'https://portaljs.com/compare',
           },
           {
-            position: 3,
             name: 'CKAN Classic',
             item: 'https://portaljs.com/compare/ckan',
           }

--- a/site/pages/compare/custom-solution.tsx
+++ b/site/pages/compare/custom-solution.tsx
@@ -1,6 +1,8 @@
 import Layout from '@/components/Layout'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -189,15 +191,16 @@ export default function PortalJSvsCustomSolution() {
   return (
     <Layout isHomePage={true}>
       {/* SEO */}
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS vs Custom Data Portal Development | Build vs Buy Comparison"
-        description="Compare PortalJS with building a custom data portal from scratch: See how our platform delivers faster time-to-market, lower costs, and reduced risk vs custom development."
-        canonical="https://portaljs.com/compare/custom-solution"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS vs Custom Data Portal Development | Build vs Buy Comparison",
+          description: "Compare PortalJS with building a custom data portal from scratch: See how our platform delivers faster time-to-market, lower costs, and reduced risk vs custom development.",
+          canonical: "https://portaljs.com/compare/custom-solution",
+          openGraph: {
           url: 'https://portaljs.com/compare/custom-solution',
           title: 'PortalJS vs Custom Data Portal Development | Build vs Buy Comparison',
           description: 'Compare PortalJS with building a custom data portal from scratch: See how our platform delivers faster time-to-market, lower costs, and reduced risk vs custom development.',
@@ -211,28 +214,20 @@ export default function PortalJSvsCustomSolution() {
           ],
           siteName: 'PortalJS',
           type: 'website'
-        }}
-      />
-      <WebPageJsonLd
-        id="https://portaljs.com/compare/custom-solution#webpage"
-        url="https://portaljs.com/compare/custom-solution"
-        name="PortalJS vs Custom Data Portal Development | Build vs Buy Comparison"
-        description="Compare PortalJS with building a custom data portal from scratch: See how our platform delivers faster time-to-market, lower costs, and reduced risk vs custom development."
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://portaljs.com',
           },
           {
-            position: 2,
             name: 'Compare',
             item: 'https://portaljs.com/compare',
           },
           {
-            position: 3,
             name: 'Custom Solution',
             item: 'https://portaljs.com/compare/custom-solution',
           }

--- a/site/pages/compare/dataverse.tsx
+++ b/site/pages/compare/dataverse.tsx
@@ -1,6 +1,8 @@
 import Layout from '@/components/Layout'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -189,15 +191,16 @@ export default function PortalJSvsDataverse() {
   return (
     <Layout isHomePage={true}>
       {/* SEO */}
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS vs Dataverse | Open Data Portal vs Research Data Repository"
-        description="Compare PortalJS with Dataverse research data repository: See how our open data portal approach delivers better public engagement and user experience for sharing research data."
-        canonical="https://portaljs.com/compare/dataverse"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS vs Dataverse | Open Data Portal vs Research Data Repository",
+          description: "Compare PortalJS with Dataverse research data repository: See how our open data portal approach delivers better public engagement and user experience for sharing research data.",
+          canonical: "https://portaljs.com/compare/dataverse",
+          openGraph: {
           url: 'https://portaljs.com/compare/dataverse',
           title: 'PortalJS vs Dataverse | Open Data Portal vs Research Data Repository',
           description: 'Compare PortalJS with Dataverse research data repository: See how our open data portal approach delivers better public engagement and user experience for sharing research data.',
@@ -211,28 +214,20 @@ export default function PortalJSvsDataverse() {
           ],
           siteName: 'PortalJS',
           type: 'website'
-        }}
-      />
-      <WebPageJsonLd
-        id="https://portaljs.com/compare/dataverse#webpage"
-        url="https://portaljs.com/compare/dataverse"
-        name="PortalJS vs Dataverse | Open Data Portal vs Research Data Repository"
-        description="Compare PortalJS with Dataverse research data repository: See how our open data portal approach delivers better public engagement and user experience for sharing research data."
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://portaljs.com',
           },
           {
-            position: 2,
             name: 'Compare',
             item: 'https://portaljs.com/compare',
           },
           {
-            position: 3,
             name: 'Dataverse',
             item: 'https://portaljs.com/compare/dataverse',
           }

--- a/site/pages/compare/dkan.tsx
+++ b/site/pages/compare/dkan.tsx
@@ -1,6 +1,8 @@
 import Layout from '@/components/Layout'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -189,15 +191,16 @@ export default function PortalJSvsDKAN() {
   return (
     <Layout isHomePage={true}>
       {/* SEO */}
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS vs DKAN | Modern React vs Drupal-based Data Portal"
-        description="Compare PortalJS with DKAN: See how our modern React frontend delivers better performance, easier maintenance, and lower costs than Drupal-based DKAN."
-        canonical="https://portaljs.com/compare/dkan"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS vs DKAN | Modern React vs Drupal-based Data Portal",
+          description: "Compare PortalJS with DKAN: See how our modern React frontend delivers better performance, easier maintenance, and lower costs than Drupal-based DKAN.",
+          canonical: "https://portaljs.com/compare/dkan",
+          openGraph: {
           url: 'https://portaljs.com/compare/dkan',
           title: 'PortalJS vs DKAN | Modern React vs Drupal-based Data Portal',
           description: 'Compare PortalJS with DKAN: See how our modern React frontend delivers better performance, easier maintenance, and lower costs than Drupal-based DKAN.',
@@ -211,28 +214,20 @@ export default function PortalJSvsDKAN() {
           ],
           siteName: 'PortalJS',
           type: 'website'
-        }}
-      />
-      <WebPageJsonLd
-        id="https://portaljs.com/compare/dkan#webpage"
-        url="https://portaljs.com/compare/dkan"
-        name="PortalJS vs DKAN | Modern React vs Drupal-based Data Portal"
-        description="Compare PortalJS with DKAN: See how our modern React frontend delivers better performance, easier maintenance, and lower costs than Drupal-based DKAN."
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://portaljs.com',
           },
           {
-            position: 2,
             name: 'Compare',
             item: 'https://portaljs.com/compare',
           },
           {
-            position: 3,
             name: 'DKAN',
             item: 'https://portaljs.com/compare/dkan',
           }

--- a/site/pages/compare/index.tsx
+++ b/site/pages/compare/index.tsx
@@ -1,5 +1,7 @@
 import Layout from '@/components/Layout'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Link from 'next/link'
 import Schedule from '@/components/home/Schedule'
@@ -70,15 +72,16 @@ export default function CompareIndex() {
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* SEO */}
-          <LogoJsonLd
+          <OrganizationJsonLd
             url="https://portaljs.com"
             logo="https://portaljs.com/icon.png"
           />
-          <NextSeo
-            title={title}
-            description={description}
-            canonical={canonical}
-            openGraph={{
+          <Head>
+            {generateNextSeo({
+              title: title,
+              description: description,
+              canonical: canonical,
+              openGraph: {
               url: 'https://portaljs.com/compare',
               title,
               description,
@@ -92,23 +95,16 @@ export default function CompareIndex() {
               ],
               siteName: 'PortalJS',
               type: 'website'
-            }}
-          />
-          <WebPageJsonLd
-            id="https://portaljs.com/compare#webpage"
-            url="https://portaljs.com/compare"
-            name={title}
-            description={description}
-          />
+            },
+            })}
+          </Head>
           <BreadcrumbJsonLd
-            itemListElements={[
+            items={[
               {
-                position: 1,
                 name: 'Home',
                 item: 'https://portaljs.com',
               },
               {
-                position: 2,
                 name: 'Compare',
                 item: 'https://portaljs.com/compare',
               }

--- a/site/pages/compare/opendatasoft.tsx
+++ b/site/pages/compare/opendatasoft.tsx
@@ -1,6 +1,8 @@
 import Layout from '@/components/Layout'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -164,15 +166,16 @@ export default function PortalJSvsOpenDataSoft() {
   return (
     <Layout isHomePage={true}>
       {/* SEO */}
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS vs OpenDataSoft | Open Source Data Portal Comparison"
-        description="Compare PortalJS with OpenDataSoft: See how our open source data portal platform stacks up against proprietary solutions in features, flexibility, and cost."
-        canonical="https://portaljs.com/compare/opendatasoft"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS vs OpenDataSoft | Open Source Data Portal Comparison",
+          description: "Compare PortalJS with OpenDataSoft: See how our open source data portal platform stacks up against proprietary solutions in features, flexibility, and cost.",
+          canonical: "https://portaljs.com/compare/opendatasoft",
+          openGraph: {
           url: 'https://portaljs.com/compare/opendatasoft',
           title: 'PortalJS vs OpenDataSoft | Open Source Data Portal Comparison',
           description: 'Compare PortalJS with OpenDataSoft: See how our open source data portal platform stacks up against proprietary solutions in features, flexibility, and cost.',
@@ -186,28 +189,20 @@ export default function PortalJSvsOpenDataSoft() {
           ],
           siteName: 'PortalJS',
           type: 'website'
-        }}
-      />
-      <WebPageJsonLd
-        id="https://portaljs.com/compare/opendatasoft#webpage"
-        url="https://portaljs.com/compare/opendatasoft"
-        name="PortalJS vs OpenDataSoft | Open Source Data Portal Comparison"
-        description="Compare PortalJS with OpenDataSoft: See how our open source data portal platform stacks up against proprietary solutions in features, flexibility, and cost."
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://portaljs.com',
           },
           {
-            position: 2,
             name: 'Compare',
             item: 'https://portaljs.com/compare',
           },
           {
-            position: 3,
             name: 'OpenDataSoft',
             item: 'https://portaljs.com/compare/opendatasoft',
           }

--- a/site/pages/compare/socrata.tsx
+++ b/site/pages/compare/socrata.tsx
@@ -1,6 +1,8 @@
 import Layout from '@/components/Layout'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -189,15 +191,16 @@ export default function PortalJSvsSocrata() {
   return (
     <Layout isHomePage={true}>
       {/* SEO */}
-      <LogoJsonLd
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />
-      <NextSeo
-        title="PortalJS vs Socrata | Open Source Data Portal Comparison"
-        description="Compare PortalJS with Socrata: See how our open source data portal platform delivers more flexibility, control, and cost savings than Socrata's proprietary solution."
-        canonical="https://portaljs.com/compare/socrata"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS vs Socrata | Open Source Data Portal Comparison",
+          description: "Compare PortalJS with Socrata: See how our open source data portal platform delivers more flexibility, control, and cost savings than Socrata's proprietary solution.",
+          canonical: "https://portaljs.com/compare/socrata",
+          openGraph: {
           url: 'https://portaljs.com/compare/socrata',
           title: 'PortalJS vs Socrata | Open Source Data Portal Comparison',
           description: 'Compare PortalJS with Socrata: See how our open source data portal platform delivers more flexibility, control, and cost savings than Socrata\'s proprietary solution.',
@@ -211,28 +214,20 @@ export default function PortalJSvsSocrata() {
           ],
           siteName: 'PortalJS',
           type: 'website'
-        }}
-      />
-      <WebPageJsonLd
-        id="https://portaljs.com/compare/socrata#webpage"
-        url="https://portaljs.com/compare/socrata"
-        name="PortalJS vs Socrata | Open Source Data Portal Comparison"
-        description="Compare PortalJS with Socrata: See how our open source data portal platform delivers more flexibility, control, and cost savings than Socrata's proprietary solution."
-      />
+        },
+        })}
+      </Head>
       <BreadcrumbJsonLd
-        itemListElements={[
+        items={[
           {
-            position: 1,
             name: 'Home',
             item: 'https://portaljs.com',
           },
           {
-            position: 2,
             name: 'Compare',
             item: 'https://portaljs.com/compare',
           },
           {
-            position: 3,
             name: 'Socrata',
             item: 'https://portaljs.com/compare/socrata',
           }

--- a/site/pages/data-portals.tsx
+++ b/site/pages/data-portals.tsx
@@ -1,16 +1,19 @@
 import Layout from '@/components/Layout'
 import Showcases from '@/components/Showcases'
-import { NextSeo } from 'next-seo'
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import { DataPortalsStructuredData } from '@/components/schema/DataPortalStructuredData'
 
 export default function DataPortalsPage() {
   return (
     <Layout>
-      <NextSeo
-        title="Data Portals Showcase | PortalJS"
-        description="Explore live data portals built with PortalJS. Government, research, and enterprise data portals showcasing real-world implementations."
-        canonical="https://portaljs.org/data-portals"
-      />
+      <Head>
+        {generateNextSeo({
+          title: "Data Portals Showcase | PortalJS",
+          description: "Explore live data portals built with PortalJS. Government, research, and enterprise data portals showcasing real-world implementations.",
+          canonical: "https://portaljs.org/data-portals",
+        })}
+      </Head>
       <DataPortalsStructuredData />
       <Showcases />
     </Layout>

--- a/site/pages/datahub.tsx
+++ b/site/pages/datahub.tsx
@@ -1,7 +1,9 @@
 import Hero from '@/components/openmetadata/Hero'
 import { KeyFeatures } from '@/components/openmetadata/KeyFeatures'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd, FAQPageJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd, FAQJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Layout from '@/components/Layout'
 import { CommonUseCases } from '@/components/openmetadata/CommonUseCases'
 import { FAQ } from '@/components/FAQ'
@@ -28,44 +30,38 @@ export default function DataHub() {
 
   return (
     <Layout isHomePage={true}>
-      <FAQPageJsonLd
-        mainEntity={faqItems.map(item => ({
-          questionName: item.question,
-          acceptedAnswerText: item.answer
+      <FAQJsonLd
+        questions={faqItems.map(item => ({
+          question: item.question,
+          answer: item.answer
         }))}
       />
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
-          <LogoJsonLd
+          <OrganizationJsonLd
             url="https://portaljs.com"
             logo="https://portaljs.com/icon.png"
           />
-          <NextSeo
-            title="Turn DataHub into a Business-Friendly Data Catalog"
-            description="Transform DataHub's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single DataHub instance."
-            canonical="https://portaljs.com/datahub"
-            openGraph={{
+          <Head>
+            {generateNextSeo({
+              title: "Turn DataHub into a Business-Friendly Data Catalog",
+              description: "Transform DataHub's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single DataHub instance.",
+              canonical: "https://portaljs.com/datahub",
+              openGraph: {
               url: 'https://portaljs.com/datahub',
               title: 'Turn DataHub into a Business-Friendly Data Catalog',
               description: 'Transform DataHub\'s technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single DataHub instance.',
               site_name: 'PortalJS',
-            }}
-          />
-          <WebPageJsonLd
-            id="https://portaljs.com/datahub#webpage"
-            url="https://portaljs.com/datahub"
-            title="Turn DataHub into a Business-Friendly Data Catalog"
-            description="Transform DataHub's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single DataHub instance."
-          />
+            },
+            })}
+          </Head>
           <BreadcrumbJsonLd
-            itemListElements={[
+            items={[
               {
-                position: 1,
                 name: 'Home',
                 item: 'https://portaljs.com',
               },
               {
-                position: 2,
                 name: 'DataHub',
                 item: 'https://portaljs.com/datahub',
               },

--- a/site/pages/faq.tsx
+++ b/site/pages/faq.tsx
@@ -3,7 +3,8 @@ import ReactMarkdown from 'react-markdown'
 import { H1 } from 'components/custom/header'
 import Layout from '@/components/Layout'
 import React from 'react'
-import { NextSeo } from 'next-seo'
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import { FaqStructuredData } from '@/components/schema/FaqStructuredData'
 
 export const questions = [
@@ -238,10 +239,12 @@ See more details on our [pricing page](https://portaljs.com/pricing).`,
 export default function FAQ() {
   return (
     <Layout>
-      <NextSeo
-        title="FAQ"
-        description="Frequently Asked Questions about PortalJS Cloud."
-      />
+      <Head>
+        {generateNextSeo({
+          title: "FAQ",
+          description: "Frequently Asked Questions about PortalJS Cloud.",
+        })}
+      </Head>
       <FaqStructuredData />
       <Tab.Group>
         <div className="mx-auto lg:my-20">

--- a/site/pages/git.tsx
+++ b/site/pages/git.tsx
@@ -1,7 +1,9 @@
 import Hero from '@/components/git/Hero'
 import { KeyFeatures } from '@/components/git/KeyFeatures'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd, FAQPageJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd, FAQJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Layout from '@/components/Layout'
 import { WhyGitAndPortalJS } from '@/components/git/WhyGitAndPortalJS'
 import { CommonUseCases } from '@/components/git/CommonUseCases'
@@ -14,66 +16,59 @@ export default function Git() {
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
-          <LogoJsonLd
+          <OrganizationJsonLd
             url="https://portaljs.com"
             logo="https://portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
-          <NextSeo
-            title="Git-Backed Data Portals | Version-Controlled Data with PortalJS"
-            description="Build modern data portals using Git as your data source. Leverage GitHub, GitLab, or any Git repository for version-controlled, collaborative data management with PortalJS."
-            canonical="https://portaljs.com/git"
-            openGraph={{
+          <Head>
+            {generateNextSeo({
+              title: "Git-Backed Data Portals | Version-Controlled Data with PortalJS",
+              description: "Build modern data portals using Git as your data source. Leverage GitHub, GitLab, or any Git repository for version-controlled, collaborative data management with PortalJS.",
+              canonical: "https://portaljs.com/git",
+              openGraph: {
               url: 'https://portaljs.com/git',
               title: 'Git-Backed Data Portals | Version-Controlled Data with PortalJS',
               description: 'Build modern data portals using Git as your data source. Leverage GitHub, GitLab, or any Git repository for version-controlled, collaborative data management with PortalJS.',
               site_name: 'PortalJS',
-            }}
-          />
-          {/* 3. WebPage schema */}
-          <WebPageJsonLd
-            id="https://portaljs.com/git#webpage"
-            url="https://portaljs.com/git"
-            title="Git-Backed Data Portals | Version-Controlled Data with PortalJS"
-            description="Build modern data portals using Git as your data source. Leverage GitHub, GitLab, or any Git repository for version-controlled, collaborative data management with PortalJS."
-          />
+            },
+            })}
+          </Head>
           {/* 4. Breadcrumb schema */}
           <BreadcrumbJsonLd
-            itemListElements={[
+            items={[
               {
-                position: 1,
                 name: 'Home',
                 item: 'https://portaljs.com',
               },
               {
-                position: 2,
                 name: 'Git Integration',
                 item: 'https://portaljs.com/git',
               },
             ]}
           />
           {/* 5. FAQ schema */}
-          <FAQPageJsonLd
-            mainEntity={[
+          <FAQJsonLd
+            questions={[
               {
-                questionName: 'How does a Git-backed data portal work?',
-                acceptedAnswerText: 'A Git-backed data portal uses Git repositories as the data source. Datasets are stored in repositories with metadata files, and PortalJS dynamically generates the portal interface by fetching data from Git APIs. This enables version control, collaboration, and distributed data management.',
+                question: 'How does a Git-backed data portal work?',
+                answer: 'A Git-backed data portal uses Git repositories as the data source. Datasets are stored in repositories with metadata files, and PortalJS dynamically generates the portal interface by fetching data from Git APIs. This enables version control, collaboration, and distributed data management.',
               },
               {
-                questionName: 'Can I use private Git repositories?',
-                acceptedAnswerText: 'Yes, PortalJS supports both public and private Git repositories. For private repositories, you can configure authentication tokens to access your data while maintaining security and access controls.',
+                question: 'Can I use private Git repositories?',
+                answer: 'Yes, PortalJS supports both public and private Git repositories. For private repositories, you can configure authentication tokens to access your data while maintaining security and access controls.',
               },
               {
-                questionName: 'Which Git platforms are supported?',
-                acceptedAnswerText: 'PortalJS works with GitHub, GitLab, Bitbucket, and any Git hosting platform that provides API access. You can also use self-hosted Git solutions like GitLab Community Edition or Gitea.',
+                question: 'Which Git platforms are supported?',
+                answer: 'PortalJS works with GitHub, GitLab, Bitbucket, and any Git hosting platform that provides API access. You can also use self-hosted Git solutions like GitLab Community Edition or Gitea.',
               },
               {
-                questionName: 'How do you handle large data files in Git?',
-                acceptedAnswerText: 'We use Git LFS (Large File Storage) combined with our open-source Giftless server to store large files in cloud storage (AWS S3, Cloudflare R2, Google Cloud Storage, Azure Blob Storage) while keeping lightweight pointers in Git. This gives you all the benefits of Git version control without file size limitations.',
+                question: 'How do you handle large data files in Git?',
+                answer: 'We use Git LFS (Large File Storage) combined with our open-source Giftless server to store large files in cloud storage (AWS S3, Cloudflare R2, Google Cloud Storage, Azure Blob Storage) while keeping lightweight pointers in Git. This gives you all the benefits of Git version control without file size limitations.',
               },
               {
-                questionName: 'How do I add new datasets to a Git-backed portal?',
-                acceptedAnswerText: 'Simply add your dataset files and metadata to the configured Git repositories. The portal automatically detects new datasets and updates the catalog. You can use Git workflows like pull requests for dataset review and approval.',
+                question: 'How do I add new datasets to a Git-backed portal?',
+                answer: 'Simply add your dataset files and metadata to the configured Git repositories. The portal automatically detects new datasets and updates the catalog. You can use Git workflows like pull requests for dataset review and approval.',
               },
             ]}
           />

--- a/site/pages/learn/index.tsx
+++ b/site/pages/learn/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FaBook, FaGraduationCap, FaShieldAlt, FaChartLine, FaDatabase, FaCogs } from "react-icons/fa";
-import { NextSeo } from "next-seo";
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Layout from "@/components/Layout";
 import LearnCard from "@/components/LearnCard";
 
@@ -57,21 +58,23 @@ const learningTopics = [
 const LearnPage = () => {
   return (
     <Layout>
-      <NextSeo
-        title="Learn Data Management"
-        description="Master the fundamentals of data management through our comprehensive learning paths. Choose a topic below to explore in-depth guides and best practices."
-        canonical="https://portaljs.com/learn"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "Learn Data Management",
+          description: "Master the fundamentals of data management through our comprehensive learning paths. Choose a topic below to explore in-depth guides and best practices.",
+          canonical: "https://portaljs.com/learn",
+          openGraph: {
           url: 'https://portaljs.com/learn',
           title: 'Learn Data Management',
           description: 'Master the fundamentals of data management through our comprehensive learning paths. Choose a topic below to explore in-depth guides and best practices.',
           site_name: 'PortalJS',
-        }}
-        twitter={{
+        },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
+        },
+        })}
+      </Head>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-primary dark:text-primary-dark mb-4">

--- a/site/pages/learn/metadata.tsx
+++ b/site/pages/learn/metadata.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FaArrowLeft, FaBook } from "react-icons/fa";
-import { NextSeo } from "next-seo";
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Link from "next/link";
 import Layout from "@/components/Layout";
 import LearnPostCard from "@/components/LearnPostCard";
@@ -33,21 +34,23 @@ const metadataPosts = [
 const MetadataLearnPage = () => {
   return (
     <Layout>
-      <NextSeo
-        title="Metadata Fundamentals | Learn Data Management"
-        description="Master the fundamentals of metadata—what it is, how it works, and why it's essential for data discovery and management. Learn about metadata schemas, standards, and best practices."
-        canonical="https://portaljs.com/learn/metadata"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "Metadata Fundamentals | Learn Data Management",
+          description: "Master the fundamentals of metadata—what it is, how it works, and why it's essential for data discovery and management. Learn about metadata schemas, standards, and best practices.",
+          canonical: "https://portaljs.com/learn/metadata",
+          openGraph: {
           url: 'https://portaljs.com/learn/metadata',
           title: 'Metadata Fundamentals | Learn Data Management',
           description: 'Master the fundamentals of metadata—what it is, how it works, and why it\'s essential for data discovery and management. Learn about metadata schemas, standards, and best practices.',
           site_name: 'PortalJS',
-        }}
-        twitter={{
+        },
+          twitter: {
           cardType: 'summary_large_image',
           site: '@PortalJS_',
-        }}
-      />
+        },
+        })}
+      </Head>
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Breadcrumb */}
         <div className="mb-8">

--- a/site/pages/openmetadata.tsx
+++ b/site/pages/openmetadata.tsx
@@ -1,7 +1,9 @@
 import Hero from '@/components/openmetadata/Hero'
 import { KeyFeatures } from '@/components/openmetadata/KeyFeatures'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd, FAQPageJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd, FAQJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Layout from '@/components/Layout'
 import { CommonUseCases } from '@/components/openmetadata/CommonUseCases'
 import { FAQ } from '@/components/FAQ'
@@ -29,48 +31,41 @@ export default function OpenMetadata() {
 
   return (
     <Layout isHomePage={true}>
-      <FAQPageJsonLd
-        mainEntity={faqItems.map(item => ({
-          questionName: item.question,
-          acceptedAnswerText: item.answer
+      <FAQJsonLd
+        questions={faqItems.map(item => ({
+          question: item.question,
+          answer: item.answer
         }))}
       />
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
-          <LogoJsonLd
+          <OrganizationJsonLd
             url="https://portaljs.com"
             logo="https://portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
-          <NextSeo
-            title="Turn OpenMetadata into a Business-Friendly Data Catalog"
-            description="Transform OpenMetadata's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single OpenMetadata instance."
-            canonical="https://portaljs.com/openmetadata"
-            openGraph={{
+          <Head>
+            {generateNextSeo({
+              title: "Turn OpenMetadata into a Business-Friendly Data Catalog",
+              description: "Transform OpenMetadata's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single OpenMetadata instance.",
+              canonical: "https://portaljs.com/openmetadata",
+              openGraph: {
               url: 'https://portaljs.com/openmetadata',
               title: 'Turn OpenMetadata into a Business-Friendly Data Catalog',
               description: 'Transform OpenMetadata\'s technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single OpenMetadata instance.',
               site_name: 'PortalJS',
-            }}
-          />
-          {/* 3. WebPage schema */}
-          <WebPageJsonLd
-            id="https://portaljs.com/openmetadata#webpage"
-            url="https://portaljs.com/openmetadata"
-            title="Turn OpenMetadata into a Business-Friendly Data Catalog"
-            description="Transform OpenMetadata's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single OpenMetadata instance."
-          />
+            },
+            })}
+          </Head>
           {/* 4. Breadcrumb schema */}
           <BreadcrumbJsonLd
-            itemListElements={[
+            items={[
               {
-                position: 1,
                 name: 'Home',
                 item: 'https://portaljs.com',
               },
               {
-                position: 2,
                 name: 'OpenMetadata',
                 item: 'https://portaljs.com/openmetadata',
               },

--- a/site/pages/opensource.tsx
+++ b/site/pages/opensource.tsx
@@ -1,4 +1,6 @@
-import { LogoJsonLd, NextSeo } from "next-seo";
+import { OrganizationJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Layout from '@/components/Layout';
 import Hero from "@/components/Hero";
 import Container from "@/components/Container";
@@ -8,11 +10,13 @@ export default function OSS() {
 
   return (
     <>
-      <NextSeo
-        title="The JavaScript framework for data portals"
-        description="Rapidly build rich data portals using a modern frontend framework. Native support for CKAN backend and more."
-      />
-      <LogoJsonLd
+      <Head>
+        {generateNextSeo({
+          title: "The JavaScript framework for data portals",
+          description: "Rapidly build rich data portals using a modern frontend framework. Native support for CKAN backend and more.",
+        })}
+      </Head>
+      <OrganizationJsonLd
         url="https://portaljs.org"
         logo="https://portaljs.org/icon.png"
       />

--- a/site/pages/partners.tsx
+++ b/site/pages/partners.tsx
@@ -1,5 +1,7 @@
 import Layout from '@/components/Layout';
-import { NextSeo, LogoJsonLd } from 'next-seo';
+import { OrganizationJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import ButtonLink from '@/components/ButtonLink';
 import { Player } from '@lottiefiles/react-lottie-player';
 import { useTheme } from 'next-themes';
@@ -96,11 +98,12 @@ export default function Partners() {
 
   return (
     <Layout isHomePage={true}>
-      <NextSeo
-        title="PortalJS Partnership Program | Collaborate on Open Data Portals"
-        description="Join the PortalJS Partnership Program to deliver innovative open data solutions across governments, non-profits, academia, and businesses."
-        canonical="https://portaljs.com/partners"
-        openGraph={{
+      <Head>
+        {generateNextSeo({
+          title: "PortalJS Partnership Program | Collaborate on Open Data Portals",
+          description: "Join the PortalJS Partnership Program to deliver innovative open data solutions across governments, non-profits, academia, and businesses.",
+          canonical: "https://portaljs.com/partners",
+          openGraph: {
           url: 'https://portaljs.com/partners',
           title: 'PortalJS Partnership Program | Collaborate on Open Data Portals',
           description: 'Join the PortalJS Partnership Program to deliver innovative open data solutions across governments, non-profits, academia, and businesses.',
@@ -113,9 +116,10 @@ export default function Partners() {
             }
           ],
           siteName: 'PortalJS',
-        }}
-      />
-      <LogoJsonLd
+        },
+        })}
+      </Head>
+      <OrganizationJsonLd
         url="https://portaljs.com"
         logo="https://portaljs.com/icon.png"
       />

--- a/site/pages/pricing.tsx
+++ b/site/pages/pricing.tsx
@@ -1,17 +1,20 @@
 import Layout from '@/components/Layout'
 import PricingPlans from '@/components/PricingPlans'
 import AddOns from '@/components/AddOns'
-import { NextSeo } from 'next-seo'
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import { H1, H3 } from '@/components/custom/header'
 import { H2 } from '@/components/custom/header'
 
 export default function Pricing() {
   return (
     <Layout>
-      <NextSeo
-        title="Pricing"
-        description="Find the best plan for you, our plans cover all ranges of budgets and needs. Leverage your Open Data Portal with optional add-ons."
-      />
+      <Head>
+        {generateNextSeo({
+          title: "Pricing",
+          description: "Find the best plan for you, our plans cover all ranges of budgets and needs. Leverage your Open Data Portal with optional add-ons.",
+        })}
+      </Head>
       <div className="overflow-hidden">
         <div className="">
           <div className="mx-auto ">

--- a/site/pages/purview.tsx
+++ b/site/pages/purview.tsx
@@ -1,7 +1,9 @@
 import Hero from '@/components/openmetadata/Hero'
 import { KeyFeatures } from '@/components/openmetadata/KeyFeatures'
 import Schedule from '@/components/home/Schedule'
-import { LogoJsonLd, NextSeo, WebPageJsonLd, BreadcrumbJsonLd, FAQPageJsonLd } from 'next-seo'
+import { OrganizationJsonLd, BreadcrumbJsonLd, FAQJsonLd } from 'next-seo';
+import { generateNextSeo } from 'next-seo/pages';
+import Head from 'next/head';
 import Layout from '@/components/Layout'
 import { CommonUseCases } from '@/components/openmetadata/CommonUseCases'
 import { FAQ } from '@/components/FAQ'
@@ -28,48 +30,41 @@ export default function Purview() {
 
   return (
     <Layout isHomePage={true}>
-      <FAQPageJsonLd
-        mainEntity={faqItems.map(item => ({
-          questionName: item.question,
-          acceptedAnswerText: item.answer
+      <FAQJsonLd
+        questions={faqItems.map(item => ({
+          question: item.question,
+          answer: item.answer
         }))}
       />
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
-          <LogoJsonLd
+          <OrganizationJsonLd
             url="https://portaljs.com"
             logo="https://portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
-          <NextSeo
-            title="Turn Microsoft Purview into a Business-Friendly Data Catalog"
-            description="Transform Microsoft Purview's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single Microsoft Purview instance."
-            canonical="https://portaljs.com/purview"
-            openGraph={{
+          <Head>
+            {generateNextSeo({
+              title: "Turn Microsoft Purview into a Business-Friendly Data Catalog",
+              description: "Transform Microsoft Purview's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single Microsoft Purview instance.",
+              canonical: "https://portaljs.com/purview",
+              openGraph: {
               url: 'https://portaljs.com/purview',
               title: 'Turn Microsoft Purview into a Business-Friendly Data Catalog',
               description: 'Transform Microsoft Purview\'s technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single Microsoft Purview instance.',
               site_name: 'PortalJS',
-            }}
-          />
-          {/* 3. WebPage schema */}
-          <WebPageJsonLd
-            id="https://portaljs.com/purview#webpage"
-            url="https://portaljs.com/purview"
-            title="Turn Microsoft Purview into a Business-Friendly Data Catalog"
-            description="Transform Microsoft Purview's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single Microsoft Purview instance."
-          />
+            },
+            })}
+          </Head>
           {/* 4. Breadcrumb schema */}
           <BreadcrumbJsonLd
-            itemListElements={[
+            items={[
               {
-                position: 1,
                 name: 'Home',
                 item: 'https://portaljs.com',
               },
               {
-                position: 2,
                 name: 'Microsoft Purview',
                 item: 'https://portaljs.com/purview',
               },

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -21,7 +21,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"


### PR DESCRIPTION
Deferred from 4c-4. next-seo 7 is a substantial API rewrite.

## Key change
v7 **no longer ships `NextSeo`/`DefaultSeo` as components** — they're `generateNextSeo()`/`generateDefaultSeo()` helpers that return meta-tag node arrays, rendered inside `next/head`'s `<Head>`. Migrated all usages across 30 files (the 7 SEO components + `_app`, `[...slug]`, and all `compare/*` + other pages).

## JSON-LD component changes
- `FAQPageJsonLd` → `FAQJsonLd` (`mainEntity`→`questions`, item prop renames)
- `LogoJsonLd` → folded into `OrganizationJsonLd` (`logo` field) — no duplicate Organization
- `WebPageJsonLd` → **removed** (no v7 equivalent)
- `ArticleJsonLd`/`BreadcrumbJsonLd` → v7 prop shapes (`headline`/`author`/`image`; `items[]` without explicit `position`). Same structured-data content.

## tsconfig
`moduleResolution` `node` → `bundler` — required for next-seo's `./pages` subpath `exports` to resolve; it's the correct setting for a Next.js project and also unblocks the TS6 upgrade. `paths` aliases still work.

## Verify
tsc clean; `next build` green (163/163). Live-checked rendered `<head>`: `<title>`, `og:title`, and `ld+json` all emit — Organization/BreadcrumbList/FAQPage on home, BlogPosting/Article + BreadcrumbList on blog/case-study pages. (WebPage intentionally dropped.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded next-seo library for improved SEO metadata generation
  * Updated structured data schema formats across all site pages for enhanced search engine compatibility
  * Refactored SEO implementation to use optimized metadata generation approach
  * Updated TypeScript configuration for improved build optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->