### PR TITLE
chore(site): upgrade to TypeScript 6

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -58,7 +58,7 @@
         "autoprefixer": "^10.5.0",
         "postcss": "^8.4.12",
         "tailwindcss": "^3.3.3",
-        "typescript": "^5.1.6"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20 <21"
@@ -21406,9 +21406,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/site/package.json
+++ b/site/package.json
@@ -65,7 +65,7 @@
     "autoprefixer": "^10.5.0",
     "postcss": "^8.4.12",
     "tailwindcss": "^3.3.3",
-    "typescript": "^5.1.6"
+    "typescript": "^6.0.3"
   },
   "volta": {
     "node": "20.19.5"

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@portaljs/core": ["node_modules/@portaljs/core/dist/src"],

--- a/site/types.d.ts
+++ b/site/types.d.ts
@@ -1,0 +1,6 @@
+// Allow side-effect imports of stylesheets. TypeScript 6 (with
+// moduleResolution: "bundler") requires a module declaration for these;
+// Next.js handles the actual bundling.
+declare module "*.css";
+declare module "*.scss";
+declare module "*.sass";


### PR DESCRIPTION
Deferred from 4c-4. **Stacked on #1528** (next-seo 7, which set `moduleResolution: bundler`) — base will retarget to main once #1528 merges.

## Changes
- site `typescript` 5.1 → **6.0**
- `ignoreDeprecations: "6.0"` — keeps `baseUrl` working (TS6 deprecates it). Fully dropping `baseUrl` would require rewriting the repo's bare `components/…` imports + more — a larger refactor TS7 will eventually force; out of scope for a compiler bump.
- `types.d.ts`: `declare module "*.css"` (+scss/sass) — TS6 under `moduleResolution: bundler` requires a declaration for side-effect style imports (`import '@/styles/global.css'`, `tailwindcss/tailwind.css`). Next.js does the actual bundling.

## Verify
`tsc --noEmit` clean; `next build` green (163/163).

Note: root `packages/*` still use TypeScript 5.x for their own builds — this PR only upgrades the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)