### PR TITLE
fix(core): widen peers for React 19 / Next 16

### DIFF
--- a/.changeset/core-react19-peer.md
+++ b/.changeset/core-react19-peer.md
@@ -1,0 +1,5 @@
+---
+"@portaljs/core": patch
+---
+
+Widen peer dependencies so the package installs on the modern stack without `--legacy-peer-deps`: `react`/`react-dom` now allow `^19` (in addition to `^18`), and `next` is `>=13.2.1` (allowing Next 14–16).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,10 +49,10 @@
   },
   "peerDependencies": {
     "mdx-mermaid": "2.0.0-rc7",
-    "next": "^13.2.1",
+    "next": ">=13.2.1",
     "next-themes": "^0.2.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
The clean fix behind #1531's `.npmrc legacy-peer-deps` workaround.

`@portaljs/core` pinned `react`/`react-dom` to `^18.2.0` and `next` to `^13.2.1`, so any consumer on the modern stack (the site is now **Next 16 + React 19**) couldn't install without `--legacy-peer-deps`. Widen the peers:

- `react` / `react-dom`: `^18.2.0 || ^19.0.0`
- `next`: `>=13.2.1` (allows 14–16)
- (`next-themes` / `mdx-mermaid` already matched)

Includes a **changeset** (patch → core `1.0.10`).

## Release flow
On merge, the changesets action opens a **"Version Packages"** PR (bumps core to 1.0.10 + consumes the changeset). Merging *that* publishes core 1.0.10 to npm. Once it's published, the site (which depends on `^1.0.6`) picks it up and we can drop `site/.npmrc` — I'll do that as a small follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended React compatibility to include version 19 alongside version 18
  * Expanded Next.js support to include versions 14 and later
  * Enables simpler installation without legacy dependency workarounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->