### PR TITLE
test: skill-triggering eval harness + register all skills in plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "portaljs",
   "version": "0.1.0",
-  "description": "Agentic skills for building PortalJS data portals — scaffold a portal, add datasets, charts, and maps, and deploy.",
+  "description": "Agentic skills for building PortalJS data portals — scaffold a portal, add datasets, charts, and maps, connect a CKAN backend, deploy, and audit data quality.",
   "author": {
     "name": "Datopian",
     "url": "https://www.datopian.com"
@@ -15,6 +15,8 @@
     "./.claude/commands/add-dataset.md",
     "./.claude/commands/add-chart.md",
     "./.claude/commands/add-map.md",
-    "./.claude/commands/deploy.md"
+    "./.claude/commands/connect-ckan.md",
+    "./.claude/commands/deploy.md",
+    "./.claude/commands/check-data-quality.md"
   ]
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ These are **behavioral evals of the PortalJS agentic skills**, not unit tests. T
 
 Checks, per skill: *does a **naive** prompt — one that never names the skill — trigger the correct skill?* This is what guards against the failure modes that silently break skills: a vague or overlapping `description`, or a skill that isn't registered in the plugin manifest.
 
-```
+```text
 tests/skill-triggering/
   prompts/<skill>.txt   # a realistic, indirect user prompt per skill
   run-test.sh           # run one (skill, prompt) → PASS/FAIL

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,42 @@
+# Tests
+
+These are **behavioral evals of the PortalJS agentic skills**, not unit tests. The skills are markdown (`.claude/commands/*.md`); what matters is whether a realistic user prompt makes the right skill fire. So the tests run the real agent and inspect what it does.
+
+## skill-triggering
+
+Checks, per skill: *does a **naive** prompt — one that never names the skill — trigger the correct skill?* This is what guards against the failure modes that silently break skills: a vague or overlapping `description`, or a skill that isn't registered in the plugin manifest.
+
+```
+tests/skill-triggering/
+  prompts/<skill>.txt   # a realistic, indirect user prompt per skill
+  run-test.sh           # run one (skill, prompt) → PASS/FAIL
+  run-all.sh            # run them all and summarize
+```
+
+### How it works
+
+`run-test.sh <skill> <prompt-file>` runs the prompt headlessly through Claude Code with the PortalJS skills loaded, captures the JSON transcript, and asserts the expected skill's `Skill` tool-call appears:
+
+```bash
+claude -p "<prompt>" --plugin-dir <repo-root> --max-turns 2 --output-format stream-json
+# PASS iff the transcript contains a Skill call for <skill>
+```
+
+`--max-turns` is intentionally low: we only need the **skill invocation** to show up, not for the skill to finish (some skills scaffold files, deploy, or install). Each run executes in a throwaway `mktemp` directory so nothing touches your working tree.
+
+### Requirements
+
+- The `claude` CLI on `PATH`
+- `ANTHROPIC_API_KEY` set
+
+These run the live model, so they **cost tokens and are non-deterministic** — run them **manually**, not as gating CI:
+
+```bash
+tests/skill-triggering/run-all.sh
+# or one skill:
+tests/skill-triggering/run-test.sh new-portal tests/skill-triggering/prompts/new-portal.txt
+# robustness check on a smaller model:
+CLAUDE_MODEL=claude-haiku-4-5 tests/skill-triggering/run-all.sh
+```
+
+When you add or rename a skill, add a matching `prompts/<skill>.txt` and an entry in `run-all.sh`'s `SKILLS` list — and make sure the skill is registered in `.claude-plugin/plugin.json`.

--- a/tests/skill-triggering/prompts/add-chart.txt
+++ b/tests/skill-triggering/prompts/add-chart.txt
@@ -1,0 +1,1 @@
+On my dataset page, I want to visualize the monthly readings as a line chart. Can you add that?

--- a/tests/skill-triggering/prompts/add-dataset.txt
+++ b/tests/skill-triggering/prompts/add-dataset.txt
@@ -1,0 +1,1 @@
+I have a file ./data/air-quality.csv with sensor readings. Add it to my PortalJS portal so it shows up as a dataset page in the catalog.

--- a/tests/skill-triggering/prompts/add-map.txt
+++ b/tests/skill-triggering/prompts/add-map.txt
@@ -1,0 +1,1 @@
+I've got a parks.geojson with park boundaries. I want it shown on an interactive map in my portal.

--- a/tests/skill-triggering/prompts/check-data-quality.txt
+++ b/tests/skill-triggering/prompts/check-data-quality.txt
@@ -1,0 +1,1 @@
+Before I publish this dataset, can you audit ./data/trash-collection.csv for data quality problems like missing values, duplicates, and weird columns?

--- a/tests/skill-triggering/prompts/connect-ckan.txt
+++ b/tests/skill-triggering/prompts/connect-ckan.txt
@@ -1,0 +1,1 @@
+My portal currently uses local files, but we run a CKAN instance at https://data.example.org. Wire the portal up to pull datasets from CKAN instead.

--- a/tests/skill-triggering/prompts/deploy.txt
+++ b/tests/skill-triggering/prompts/deploy.txt
@@ -1,0 +1,1 @@
+The portal looks good locally. I want to put it live on Vercel now.

--- a/tests/skill-triggering/prompts/new-portal.txt
+++ b/tests/skill-triggering/prompts/new-portal.txt
@@ -1,0 +1,1 @@
+I want to set up an open data portal for the City of Auckland to publish its public datasets. Can you get the site scaffolded for me?

--- a/tests/skill-triggering/run-all.sh
+++ b/tests/skill-triggering/run-all.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run every skill-triggering test and summarize. See run-test.sh for details.
+# Usage: ./run-all.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPTS="$SCRIPT_DIR/prompts"
+
+# One entry per shipped skill (.claude/commands/*.md).
+SKILLS=(
+  new-portal
+  add-dataset
+  add-chart
+  add-map
+  connect-ckan
+  deploy
+  check-data-quality
+)
+
+echo "=== PortalJS skill-triggering tests ==="
+PASS=0; FAIL=0; FAILED=()
+for skill in "${SKILLS[@]}"; do
+  prompt="$PROMPTS/${skill}.txt"
+  if [ ! -f "$prompt" ]; then
+    echo "⚠️  SKIP $skill (no prompt file)"; continue
+  fi
+  if "$SCRIPT_DIR/run-test.sh" "$skill" "$prompt"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1)); FAILED+=("$skill")
+  fi
+  echo ""
+done
+
+echo "=== Summary: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -gt 0 ] && { echo "Failed: ${FAILED[*]}"; exit 1; }
+exit 0

--- a/tests/skill-triggering/run-all.sh
+++ b/tests/skill-triggering/run-all.sh
@@ -22,7 +22,9 @@ PASS=0; FAIL=0; FAILED=()
 for skill in "${SKILLS[@]}"; do
   prompt="$PROMPTS/${skill}.txt"
   if [ ! -f "$prompt" ]; then
-    echo "⚠️  SKIP $skill (no prompt file)"; continue
+    echo "❌ FAIL $skill (no prompt file — every shipped skill needs one)"
+    FAIL=$((FAIL+1)); FAILED+=("$skill")
+    continue
   fi
   if "$SCRIPT_DIR/run-test.sh" "$skill" "$prompt"; then
     PASS=$((PASS+1))

--- a/tests/skill-triggering/run-test.sh
+++ b/tests/skill-triggering/run-test.sh
@@ -44,9 +44,11 @@ echo "=== Skill-triggering: $SKILL_NAME (max-turns=$MAX_TURNS${CLAUDE_MODEL:+, m
     --output-format stream-json \
     "${MODEL_ARGS[@]}" > "$LOG" 2>&1 ) || true
 
-# Match "skill":"new-portal" or "skill":"portaljs:new-portal"
+# Match "skill":"new-portal" or "skill":"portaljs:new-portal" — but only on a
+# line that is also the Skill tool-call, so the two fragments can't satisfy the
+# check from different stream-json events. (stream-json = one JSON record/line.)
 SKILL_PATTERN='"skill":"([^"]*:)?'"${SKILL_NAME}"'"'
-if grep -q '"name":"Skill"' "$LOG" && grep -qE "$SKILL_PATTERN" "$LOG"; then
+if grep -E '"name":"Skill"' "$LOG" | grep -qE "$SKILL_PATTERN"; then
   echo "✅ PASS: '$SKILL_NAME' triggered"
   RESULT=0
 else

--- a/tests/skill-triggering/run-test.sh
+++ b/tests/skill-triggering/run-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Skill-triggering test: does a NAIVE prompt (one that never names the skill)
+# make Claude fire the expected PortalJS skill?
+#
+# Usage: ./run-test.sh <skill-name> <prompt-file> [max-turns]
+# Example: ./run-test.sh new-portal ./prompts/new-portal.txt
+#
+# Requires: the `claude` CLI on PATH and an ANTHROPIC_API_KEY.
+# Set CLAUDE_MODEL to test triggering on a specific model (e.g. a small one).
+set -euo pipefail
+
+SKILL_NAME="${1:-}"
+PROMPT_FILE="${2:-}"
+MAX_TURNS="${3:-2}"
+
+if [ -z "$SKILL_NAME" ] || [ -z "$PROMPT_FILE" ]; then
+  echo "Usage: $0 <skill-name> <prompt-file> [max-turns]"
+  exit 2
+fi
+if [ ! -f "$PROMPT_FILE" ]; then
+  echo "Prompt file not found: $PROMPT_FILE"; exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# repo root is two levels up from tests/skill-triggering
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PROMPT="$(cat "$PROMPT_FILE")"
+OUT_DIR="$(mktemp -d)"          # isolate the FS: these skills scaffold/write files
+LOG="$OUT_DIR/claude-output.json"
+
+MODEL_ARGS=()
+[ -n "${CLAUDE_MODEL:-}" ] && MODEL_ARGS=(--model "$CLAUDE_MODEL")
+
+echo "=== Skill-triggering: $SKILL_NAME (max-turns=$MAX_TURNS${CLAUDE_MODEL:+, model=$CLAUDE_MODEL}) ==="
+
+# Run headless from the throwaway dir; load the PortalJS skills via --plugin-dir.
+# Low --max-turns: we only need the Skill tool-call to appear in the transcript,
+# not for the skill to finish (some skills deploy/install).
+( cd "$OUT_DIR" && timeout 300 claude -p "$PROMPT" \
+    --plugin-dir "$REPO_ROOT" \
+    --dangerously-skip-permissions \
+    --max-turns "$MAX_TURNS" \
+    --output-format stream-json \
+    "${MODEL_ARGS[@]}" > "$LOG" 2>&1 ) || true
+
+# Match "skill":"new-portal" or "skill":"portaljs:new-portal"
+SKILL_PATTERN='"skill":"([^"]*:)?'"${SKILL_NAME}"'"'
+if grep -q '"name":"Skill"' "$LOG" && grep -qE "$SKILL_PATTERN" "$LOG"; then
+  echo "✅ PASS: '$SKILL_NAME' triggered"
+  RESULT=0
+else
+  echo "❌ FAIL: '$SKILL_NAME' did NOT trigger"
+  RESULT=1
+fi
+
+echo "Skills triggered this run:"
+grep -oE '"skill":"[^"]*"' "$LOG" 2>/dev/null | sort -u | sed 's/^/  /' || echo "  (none)"
+echo "Log: $LOG"
+exit $RESULT


### PR DESCRIPTION
Adds a behavioral eval harness for the agentic skills, modeled on [obra/superpowers](https://github.com/obra/superpowers)' `skill-triggering` tests — and fixes a real plugin-registration bug it surfaced.

## The bug (fixed here)
`.claude-plugin/plugin.json` registered only **5 of 7** commands — **`connect-ckan` and `check-data-quality` were missing**, so they never loaded via the plugin. Now all 7 are registered.

## The harness
`tests/skill-triggering/` — per skill, a naive prompt that never names the skill, run headlessly and checked for the expected `Skill` tool-call:
```bash
claude -p "<prompt>" --plugin-dir <repo-root> --max-turns 2 --output-format stream-json
# PASS iff the transcript contains a Skill call for <skill>
```
- `run-test.sh` (one skill) / `run-all.sh` (all 7) + `prompts/<skill>.txt`.
- Runs in a throwaway `mktemp` dir (skills scaffold/deploy); low `--max-turns` catches the *invocation*, not the full run. `CLAUDE_MODEL=…` for weak-model robustness checks.
- `tests/README.md` documents the philosophy: live model → costs tokens, non-deterministic → **run manually, not gating CI** (same call superpowers makes).

## What it catches
Skill `description` drift/overlap (wrong or no skill fires) and registration gaps like the one above.

## Note
Syntax-verified (`bash -n`) and the usage guard works. Not run live here (running `claude -p` inside an agent session is unsafe); run `tests/skill-triggering/run-all.sh` in a normal shell with `ANTHROPIC_API_KEY` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added data-quality auditing capability for dataset analysis

* **Documentation**
  * New test documentation describing evaluation methodology, runtime requirements, and how to add/manage skill prompts

* **Tests**
  * Added behavioral test harness and runner plus scenario prompts for portal creation, dataset ingestion, visualization, CKAN hookup, data-quality checks, and deployment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->