### PR TITLE
fix(ckan): build independently of ckan-api-client-js build order (unblocks Release)

### DIFF
--- a/packages/ckan/tsconfig.json
+++ b/packages/ckan/tsconfig.json
@@ -20,7 +20,8 @@
     "noFallthroughCasesInSwitch": true,
 
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@portaljs/ckan-api-client-js": ["../ckan-api-client-js/src/index.ts"]
     }
   },
   "include": ["src"],

--- a/packages/ckan/vite.config.ts
+++ b/packages/ckan/vite.config.ts
@@ -18,7 +18,12 @@ export default defineConfig({
             fileName: (format) => `components.${format}.js`,
         },
         rollupOptions: {
-            external: ['react', 'react-dom', 'styled-components'],
+            external: [
+                'react',
+                'react-dom',
+                'styled-components',
+                '@portaljs/ckan-api-client-js',
+            ],
             output: {
                 globals: {
                     react: 'React',


### PR DESCRIPTION
**The Release workflow has been failing since #1523** (the ckan consolidation), which blocks *all* package publishes — including the `@portaljs/core@1.0.10` from #1532 that the site is waiting on.

## Root cause
`npm ci` (Release → Install Dependencies) runs each workspace's `prepare` (build). `@portaljs/ckan` now depends on the sibling workspace `@portaljs/ckan-api-client-js` (since #1523), but npm builds ckan **before** the api-client, so ckan's `tsc` can't find the api-client's `dist/index.d.ts` → `TS2307` → build fails. Removing nx (#1516) dropped its `dependsOn: ^build` ordering, and #1523 introduced the first cross-package build dep that needed it.

## Fix — make ckan build order-independent
- **tsconfig:** resolve `@portaljs/ckan-api-client-js` types from its **source** (`../ckan-api-client-js/src/index.ts`) via a path mapping, not its built `dist`.
- **vite:** **externalize** `@portaljs/ckan-api-client-js` (it's a dependency consumers install — no reason to bundle it).

## Verify
Removed `packages/ckan-api-client-js/dist` entirely and built ckan → **green** (275 modules, declaration files emitted), and the bundle keeps the import external (`import … from "@portaljs/ckan-api-client-js"`). So Release's `npm ci` no longer cares about build order.

Once merged, Release should go green → the changesets action opens the **Version Packages** PR → merging it publishes core 1.0.10 → then the site can drop `.npmrc legacy-peer-deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and module resolution settings to optimize dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->