### PR TITLE
feat(skills): interactive skills (interview, not dead-end) + align to 3-surface template

### DIFF
--- a/.claude/commands/add-chart.md
+++ b/.claude/commands/add-chart.md
@@ -1,80 +1,77 @@
 ---
-description: Add a chart (line, bar, area, pie, or scatter) to a PortalJS dataset page. Installs recharts, writes a reusable Chart component, and embeds the visualization in the page.
+description: Add a chart (line, bar, area, pie, or scatter) to a dataset's showcase in a PortalJS portal. Installs recharts, writes a reusable Chart component, and renders it in the showcase Views section.
 allowed-tools: Read, Write, Edit, Bash
 ---
 
 # /add-chart
 
-Add a visualization to an existing PortalJS dataset page. Installs `recharts` (added
-directly — **not** `@portaljs/components`), writes a reusable client-side `Chart`
-component into the portal's `components/`, and embeds a `<Chart />` into the target
-dataset page next to its `<Table />`.
+Add a visualization to a dataset's **showcase** in a `portaljs-catalog` portal. Installs
+`recharts` (added directly — **not** `@portaljs/components`), writes a reusable
+client-side `Chart` component into the portal's `components/`, and renders a `<Chart />`
+into the **Views** section of the showcase route `pages/[owner]/[slug].tsx` for the chosen
+dataset.
 
-Use this after `/add-dataset` has created a dataset page. The chart reads the same
-`/public/data/*.csv` (or `.json`) the table already uses — no data is duplicated.
+Use this after the dataset is registered in `datasets.json` (e.g. via `/add-dataset`). The
+chart reads the same `/public/data/<file>` the showcase's `<Table />` already uses — no
+data is duplicated.
 
-## Required input
+## Required input — ask, don't error
 
-- **Dataset** — the dataset slug or page path to chart (e.g. `country-codes` or
-  `pages/datasets/country-codes.tsx`). The page must already exist.
+- **Dataset** — which dataset to chart, by **slug** (e.g. `co2-emissions`) or `slug`
+  within a namespace. It must already be an entry in `datasets.json`.
 - **X axis column** — the column name for the category/X axis (e.g. `year`).
 - **Y axis column(s)** — one or more numeric column names to plot (e.g. `population`
   or `imports,exports`).
 - **Portal directory** — path to the portal project (defaults to current directory).
 - **Chart type** — `line` (default), `bar`, `area`, `pie`, or `scatter`.
 
-If the dataset is missing:
-```
-ERROR: [add-chart] MISSING_INPUT No dataset provided — give a dataset slug or page path, plus x and y columns.
-```
+**If the target dataset isn't specified, ask which one (by name/slug) — never dead-end
+with a missing-input error.**
 
 ## Steps
 
-### 1. Parse arguments from `$ARGUMENTS`
+### 1. Gather input from `$ARGUMENTS` (interview if thin)
 
 Extract:
-- `DATASET` — slug or page path (required)
+- `DATASET` — dataset slug (required)
 - `X` — x-axis column name (required)
 - `Y` — comma-separated y-axis column name(s) (required)
 - `TYPE` — chart type, one of `line|bar|area|pie|scatter` (default: `line`)
 - `PORTAL_DIR` — portal directory (default: `.`)
 - `TITLE` — chart heading (default: derived from Y columns, e.g. "Population over Year")
 
-If `$ARGUMENTS` is empty, ask:
+If the dataset (or X/Y) is missing, **ask** and wait. When the user doesn't know the slug,
+read `PORTAL_DIR/datasets.json` and list the available datasets (`name` → `slug`) so they
+can pick one:
 ```
 To add a chart I need:
-1. Dataset: slug or page path (e.g. country-codes)
+1. Which dataset? (slug — your catalog has: <name (slug)>, …)
 2. X axis column (e.g. year)
 3. Y axis column(s), comma-separated (e.g. population or imports,exports)
 4. Chart type [line] (line|bar|area|pie|scatter)
-5. Portal directory (press Enter for current directory)
+5. Portal directory (Enter for current directory)
 ```
 
-Validate `TYPE` is one of the five supported values. Otherwise:
-```
-ERROR: [add-chart] UNSUPPORTED_TYPE TYPE is not supported — use line, bar, area, pie, or scatter.
-```
+Validate `TYPE` is one of the five supported values. If not, tell the user and ask them to
+pick line, bar, area, pie, or scatter.
 
-### 2. Resolve the dataset page and data source
+### 2. Resolve the dataset from the manifest and its data source
 
-- Resolve `PAGE_PATH`: if `DATASET` ends in `.tsx`, use it; else use `PORTAL_DIR/pages/datasets/DATASET.tsx`.
-- If the page does not exist:
-  ```
-  ERROR: [add-chart] PAGE_NOT_FOUND PAGE_PATH does not exist — run /add-dataset first, or check the slug.
-  ```
-- Read the page. Find the data source from the existing `<Table .../>`:
-  - `url="/data/SLUG.csv"` → `DATA_URL = /data/SLUG.csv`, source is CSV-over-URL.
-  - `data={...}` import from `public/data/SLUG.json` → JSON; the chart will import the same JSON.
-- If no `<Table />` and no obvious data source is found, ask the user for the data file path under `/public/data/`.
+- Read `PORTAL_DIR/datasets.json` and find the entry whose `slug` matches `DATASET`
+  (if multiple namespaces share the slug, ask which `namespace`). Capture its
+  `namespace`, `file`, and `format`.
+- If no entry matches, tell the user and list the available slugs (don't error out) — they
+  may have meant a different one or need to run `/add-dataset` first.
+- The data source is the bare file served statically: `DATA_URL = /data/<file>`. The
+  showcase route is `pages/[owner]/[slug].tsx`; the page rendered for this dataset is
+  `/@<namespace>/<slug>`.
 
 ### 3. Validate the requested columns exist
 
-- For CSV: read `PORTAL_DIR/public/data/SLUG.csv` first line for headers.
-- For JSON: read the first object's keys from `PORTAL_DIR/public/data/SLUG.json`.
-- Confirm `X` and every `Y` column is present. If any is missing:
-  ```
-  ERROR: [add-chart] COLUMN_NOT_FOUND Column "COL" not in dataset — available: <comma-separated headers>.
-  ```
+- For CSV/TSV: read `PORTAL_DIR/public/data/<file>` first line for headers.
+- For JSON: read the first object's keys from `PORTAL_DIR/public/data/<file>`.
+- Confirm `X` and every `Y` column is present. If any is missing, tell the user which
+  column wasn't found and list the available headers so they can correct it.
 - Warn (do not fail) if a `Y` column's first non-empty value is non-numeric:
   ```
   Note: column "COL" looks non-numeric — chart values are coerced with Number(); non-numeric cells render as gaps.
@@ -86,10 +83,8 @@ ERROR: [add-chart] UNSUPPORTED_TYPE TYPE is not supported — use line, bar, are
 cd PORTAL_DIR && npm install recharts@^2.12.0
 ```
 
-Do **not** install `@portaljs/components`. If the install fails, report:
-```
-ERROR: [add-chart] INSTALL_FAILED npm install recharts failed — check network and package.json, then retry.
-```
+Do **not** install `@portaljs/components`. If the install fails, tell the user (check
+network and `package.json`) and retry.
 
 ### 5. Write the reusable Chart component
 
@@ -220,38 +215,56 @@ export function Chart({ url = '', data: initialData = [], type = 'line', x, y, h
 
 Note: `Chart` reuses `components/ui/parseCsv.ts`, which ships with the template
 (the same parser `Table` uses). If that file is absent the portal predates the
-current template — copy `parseCsv.ts` from `examples/portaljs-template/components/ui/`.
+current template — copy `parseCsv.ts` from `examples/portaljs-catalog/components/ui/`.
 
-### 6. Embed the chart in the dataset page
+### 6. Render the chart into the showcase's Views section
 
-Edit `PAGE_PATH`:
+The showcase `pages/[owner]/[slug].tsx` renders **every** dataset, so a chart must be
+applied **only for the chosen dataset** — gate it on the dataset's `(namespace, slug)` so
+other datasets' showcases are unaffected. The route already has a **Views placeholder**:
 
-1. Add the import after the `Table` import:
+```tsx
+{/* Views placeholder — charts and maps are added here by the
+    /add-chart and /add-map skills. */}
+<section className="mt-10 border-t border-gray-200 pt-6">
+  <h2 className="text-lg font-semibold text-gray-900">Views</h2>
+  <p className="mt-2 text-sm text-gray-400">
+    No views yet. Charts and maps for this dataset are added here.
+  </p>
+</section>
+```
+
+Edit `PORTAL_DIR/pages/[owner]/[slug].tsx`:
+
+1. Add the import near the top (after the `Table` import):
    ```tsx
    import { Chart } from '../../components/Chart'
    ```
-2. Insert the chart block above the `<Table .../>` (so the visual summary leads, the
-   raw table follows). Build `Y_PROP` as a single string `y="col"` for one column, or
-   `y={['a','b']}` for several.
+2. Replace the Views placeholder `<section>` so it conditionally renders the chart for the
+   target dataset and keeps the "no views yet" message for every other dataset. Build
+   `Y_PROP` as a single string `y="col"` for one column, or `y={['a','b']}` for several.
+   The data URL is the dataset's file served statically (`/data/<file>`):
 
-   **CSV-over-URL source** (matches the existing `<Table url="..." />`):
    ```tsx
-   <section className="mb-10">
-     <h2 className="text-xl font-semibold text-gray-900 mb-4">TITLE</h2>
-     <Chart url="/data/SLUG.csv" type="TYPE" x="X" Y_PROP />
+   <section className="mt-10 border-t border-gray-200 pt-6">
+     <h2 className="text-lg font-semibold text-gray-900">Views</h2>
+     {dataset.namespace === 'NAMESPACE' && dataset.slug === 'SLUG' ? (
+       <div className="mt-4">
+         <h3 className="text-base font-medium text-gray-800 mb-3">TITLE</h3>
+         <Chart url={`/data/${dataset.file}`} type="TYPE" x="X" Y_PROP />
+       </div>
+     ) : (
+       <p className="mt-2 text-sm text-gray-400">
+         No views yet. Charts and maps for this dataset are added here.
+       </p>
+     )}
    </section>
    ```
 
-   **JSON source** (page already imports the array as `data`):
-   ```tsx
-   <section className="mb-10">
-     <h2 className="text-xl font-semibold text-gray-900 mb-4">TITLE</h2>
-     <Chart data={data} type="TYPE" x="X" Y_PROP />
-   </section>
-   ```
-
-If the page has been heavily customized and no `<Table />` anchor is found, insert the
-chart block directly after the `<h1>` heading instead, and tell the user where it landed.
+If a previous `/add-chart` or `/add-map` run already replaced this section with a
+view-dispatch block, **extend** that block with another `dataset.namespace === … &&
+dataset.slug === …` branch rather than overwriting it, so multiple datasets can each have
+their own views.
 
 ### 7. Verify the build
 
@@ -259,20 +272,19 @@ chart block directly after the `<h1>` heading instead, and tell the user where i
 cd PORTAL_DIR && npx tsc --noEmit
 ```
 
-If type-checking fails, report the first error with the `ERROR:` format and stop:
-```
-ERROR: [add-chart] TYPECHECK_FAILED <first tsc error> — fix before running the portal.
-```
+If type-checking fails, tell the user the first `tsc` error and fix it before reporting
+success.
 
 ### 8. Report success
 
 ```
 ✓ Chart added to DATASET
   - Component: components/Chart.tsx (recharts)
-  - Page: PAGE_PATH — <Chart type="TYPE" x="X" y=...>
+  - Showcase:  pages/[owner]/[slug].tsx Views section — <Chart type="TYPE" x="X" y=...>
+  - Renders at: /@NAMESPACE/SLUG
   - Dependency: recharts@^2.12.0 added to package.json
 
-Next: run `npm run dev` and visit http://localhost:3000/datasets/SLUG to verify the chart renders.
+Next: run `npm run dev` and visit http://localhost:3000/@NAMESPACE/SLUG to verify the chart renders.
 ```
 
 ## Notes
@@ -286,6 +298,9 @@ Next: run `npm run dev` and visit http://localhost:3000/datasets/SLUG to verify 
 - **Pie/scatter use the first `y` only.** Pie maps `x` → slice name, `y[0]` → slice
   value. Scatter plots `x` (numeric) against `y[0]` (numeric). Pass extra `y` columns
   only for line/bar/area (multi-series).
+- **One showcase route, many datasets:** `pages/[owner]/[slug].tsx` renders every dataset,
+  so always gate a view on the dataset's `(namespace, slug)` — otherwise the chart would
+  appear on every dataset's showcase.
 - **Client-side rendering:** the chart fetches in the browser like `Table`, so it works
   with static export and needs no server code.
 - **Large datasets:** recharts renders all points to SVG; over ~2,000 points gets

--- a/.claude/commands/add-dataset.md
+++ b/.claude/commands/add-dataset.md
@@ -1,68 +1,82 @@
 ---
-description: Add a dataset (CSV, TSV, JSON, or GeoJSON) to an existing PortalJS portal. Creates a dataset page and adds it to the home page catalog.
+description: Add a dataset (CSV, TSV, JSON, or GeoJSON) to an existing PortalJS portal. Appends an entry to datasets.json so the catalog and showcase render it automatically.
 allowed-tools: Read, Write, Edit, Bash, WebFetch
 ---
 
 # /add-dataset
 
-Add a dataset to an existing PortalJS portal. Copies the data to `/public/data/`, generates a dataset page, and registers it on the home page.
+Add a dataset to an existing PortalJS (`portaljs-catalog`) portal. Copies the data into
+`/public/data/` and appends one entry to `datasets.json` — the **single source of truth**
+for the catalog. No per-dataset page is created: the catalog at `/search` lists it and the
+dynamic showcase route `pages/[owner]/[slug].tsx` renders it automatically at
+`/@<namespace>/<slug>`.
 
-## Required input
+## Required input — ask, don't error
 
 - **Source** — a local file path (`./data/file.csv`) or a public URL (`https://example.com/data.csv`)
 - **Portal directory** — path to the portal project (defaults to current directory)
+- **Namespace** — the dataset's namespace value (the portal's `NAMESPACE_TYPE` group:
+  a subject for `'theme'` portals, a publisher for `'owner'` portals)
 
 Supported formats: **CSV, TSV, JSON (array), GeoJSON**
 
-If source is missing:
-```
-ERROR: [add-dataset] MISSING_INPUT No dataset source provided — provide a local file path or public URL.
-```
+**If the source is missing, ask for it — never dead-end.** The user can say "use defaults"
+to accept the defaults below.
 
 ## Steps
 
-### 1. Parse arguments from `$ARGUMENTS`
+### 1. Gather input from `$ARGUMENTS` (interview if thin)
 
-Extract:
+Extract what's present:
 - `SOURCE` — file path or URL
 - `PORTAL_DIR` — portal directory (default: `.`)
 - `DATASET_NAME` — human-readable name (default: derived from filename)
 - `DATASET_SLUG` — URL slug (default: lowercase hyphenated filename without extension)
 - `DESCRIPTION` — optional one-line description
+- `NAMESPACE` — namespace value (default: read the existing first entry's `namespace`
+  from `datasets.json`, else `reference`)
 
-If `$ARGUMENTS` is empty, ask:
+If `SOURCE` is missing, ask (one focused prompt) and wait:
 ```
 To add a dataset I need:
-1. Source: local file path or public URL
-2. Portal directory (press Enter for current directory)
-3. Dataset name (press Enter to use filename)
+1. Source: local file path or public URL (required)
+2. Portal directory (Enter for current directory)
+3. Dataset name (Enter to use the filename)
+4. Namespace value — the group this dataset belongs to
+   (subject if the portal is "theme" mode, publisher if "owner" mode; Enter to reuse the catalog's existing namespace)
 ```
 
-### 2. Detect format and fetch/copy data
+Check the portal's namespace mode if helpful: read `NAMESPACE_TYPE` from
+`PORTAL_DIR/lib/datasets.ts` so you can phrase the namespace question correctly ("subject"
+vs "publisher").
+
+### 2. Validate the portal directory
+
+The target must be a `portaljs-catalog` portal. Confirm `PORTAL_DIR/datasets.json`,
+`PORTAL_DIR/package.json`, and `PORTAL_DIR/pages/[owner]/[slug].tsx` exist. If
+`datasets.json` is missing, tell the user this portal isn't the catalog template (it may
+be an older single-page template) and ask how to proceed rather than failing silently.
+
+### 3. Detect format and fetch/copy data
 
 **If SOURCE is a URL:**
-- Fetch the URL and check status code. If not 200:
-  ```
-  ERROR: [add-dataset] FETCH_FAILED Could not fetch SOURCE (HTTP STATUS) — check the URL is publicly accessible and supports CORS.
-  ```
-- Detect format from Content-Type header or URL extension.
+- Fetch the URL and check the status code. If not 200, tell the user the fetch failed
+  (with the HTTP status) and ask them to confirm the URL is publicly accessible / supports
+  CORS, then retry.
+- Detect format from the Content-Type header or URL extension.
 
 **If SOURCE is a local file path:**
-- Check the file exists. If not:
-  ```
-  ERROR: [add-dataset] FILE_NOT_FOUND SOURCE does not exist — check the path and retry.
-  ```
-- Detect format from file extension.
+- Check the file exists. If not, tell the user the path wasn't found and ask for a correct
+  path.
+- Detect format from the file extension.
 
 **Format detection rules:**
 - `.csv` or `text/csv` → CSV
 - `.tsv` or `text/tab-separated-values` → TSV
 - `.geojson` or `application/geo+json` or (JSON-parseable and `parsed.type === "FeatureCollection"`) → GeoJSON
 - `.json` or `application/json` → JSON array
-- Anything else:
-  ```
-  ERROR: [add-dataset] UNSUPPORTED_FORMAT FORMAT is not supported — convert to CSV, TSV, JSON array, or GeoJSON first.
-  ```
+- Anything else: tell the user the format isn't supported and ask them to convert to CSV,
+  TSV, JSON array, or GeoJSON first.
 
 **Copy to portal:**
 ```bash
@@ -71,153 +85,70 @@ cp SOURCE PORTAL_DIR/public/data/DATASET_SLUG.EXT
 # or for URLs: curl -L SOURCE -o PORTAL_DIR/public/data/DATASET_SLUG.EXT
 ```
 
-### 3. Detect column structure (CSV/TSV/JSON only)
+The `file` field in the manifest is the **bare filename** (e.g. `parks.csv`) — the
+showcase serves it from `/data/<file>` and the `Table` preview fetches it client-side.
 
-For CSV/TSV: read the first line to get column headers.
-For JSON: read the first object's keys.
-For GeoJSON: skip — use Map component instead.
+### 4. Append the entry to `datasets.json`
 
-Extract up to 5 representative columns to show in the page preview. If there are more than 10 columns, add a note that the full table is paginated.
+Open `PORTAL_DIR/datasets.json` (a JSON array) and append one entry, keeping all existing
+entries. Match the `Dataset` shape from `lib/datasets.ts`:
 
-### 4. Generate the dataset page
-
-Write to `PORTAL_DIR/pages/datasets/DATASET_SLUG.tsx`.
-
-**For CSV/TSV:**
-```tsx
-import { Table } from '../../components/Table'
-import Head from 'next/head'
-
-export default function DatasetPage() {
-  return (
-    <>
-      <Head><title>DATASET_NAME</title></Head>
-      <main className="max-w-6xl mx-auto px-4 py-8">
-        <nav className="mb-6 text-sm text-gray-500">
-          <a href="/" className="hover:text-gray-700">Home</a>
-          <span className="mx-2">/</span>
-          <span>DATASET_NAME</span>
-        </nav>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">DATASET_NAME</h1>
-        {DESCRIPTION && <p className="text-gray-500 mb-8">DESCRIPTION</p>}
-        <Table url="/data/DATASET_SLUG.csv" fullWidth />
-      </main>
-    </>
-  )
+```json
+{
+  "slug": "DATASET_SLUG",
+  "namespace": "NAMESPACE",
+  "name": "DATASET_NAME",
+  "description": "DESCRIPTION",
+  "file": "DATASET_SLUG.EXT",
+  "format": "csv"
 }
 ```
 
-**For JSON (array):**
-```tsx
-import { Table } from '../../components/Table'
-import Head from 'next/head'
-import data from '../../public/data/DATASET_SLUG.json'
+- `format` is one of `csv | tsv | json | geojson` (lowercase), matching the detected format.
+- `namespace` is the value gathered in Step 1. `(namespace, slug)` must be **unique**
+  across the manifest — if a clash exists, ask the user for a different slug or namespace.
+- Drop `description` only if there genuinely is none (it's optional in the type).
 
-export default function DatasetPage() {
-  const cols = Object.keys(data[0] || {}).map(k => ({ key: k, name: k }))
-  return (
-    <>
-      <Head><title>DATASET_NAME</title></Head>
-      <main className="max-w-6xl mx-auto px-4 py-8">
-        <nav className="mb-6 text-sm text-gray-500">
-          <a href="/" className="hover:text-gray-700">Home</a>
-          <span className="mx-2">/</span>
-          <span>DATASET_NAME</span>
-        </nav>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">DATASET_NAME</h1>
-        {DESCRIPTION && <p className="text-gray-500 mb-8">DESCRIPTION</p>}
-        <Table data={data} cols={cols} fullWidth />
-      </main>
-    </>
-  )
-}
+That is the entire registration. `getStaticPaths` in `pages/[owner]/[slug].tsx` picks up
+the new `(namespace, slug)` pair at build time, and the catalog at `/search` filters over
+it. **Do not create any page file** — there is no `pages/datasets/[slug].tsx` in this
+template.
+
+### 5. Verify the build
+
+```bash
+cd PORTAL_DIR
+npx next build > /tmp/add-dataset-build.log 2>&1
+BUILD_EXIT=$?
+tail -20 /tmp/add-dataset-build.log
 ```
 
-Note: update `tsconfig.json` to include `"resolveJsonModule": true` if not already set.
+If `BUILD_EXIT` is non-zero, print the log and fix the error (commonly malformed JSON in
+`datasets.json`) before reporting success.
 
-**For GeoJSON:**
-
-Extract feature properties from the GeoJSON file and render as a table. Read the file to get `features[0].properties` keys for column headers. Guard against empty feature collections.
-
-```tsx
-import { Table } from '../../components/Table'
-import Head from 'next/head'
-import geojson from '../../public/data/DATASET_SLUG.geojson'
-
-type GeoJSON = { features: { properties: Record<string, string> }[] }
-
-const gj = geojson as GeoJSON
-const rows = Array.isArray(gj.features) ? gj.features.map((f) => f.properties) : []
-const cols = Object.keys(rows[0] ?? {}).map((k) => ({ key: k, name: k }))
-
-export default function DatasetPage() {
-  return (
-    <>
-      <Head><title>DATASET_NAME</title></Head>
-      <main className="max-w-6xl mx-auto px-4 py-8">
-        <nav className="mb-6 text-sm text-gray-500">
-          <a href="/" className="hover:text-gray-700">Home</a>
-          <span className="mx-2">/</span>
-          <span>DATASET_NAME</span>
-        </nav>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">DATASET_NAME</h1>
-        {DESCRIPTION && <p className="text-gray-500 mb-8">DESCRIPTION</p>}
-        <Table data={rows} cols={cols} fullWidth />
-        <p className="mt-6 text-sm text-gray-400">
-          <a href="/data/DATASET_SLUG.geojson" className="underline">Download GeoJSON</a>
-          {' · '}
-          {rows.length} features
-        </p>
-      </main>
-    </>
-  )
-}
-```
-
-Note: update `tsconfig.json` to include `"resolveJsonModule": true` if not already set.
-
-### 5. Register dataset on home page
-
-Open `PORTAL_DIR/pages/index.tsx`. Find the `datasets` array:
-```tsx
-const datasets = [
-  // populated by /add-dataset
-]
-```
-
-Add an entry:
-```tsx
-const datasets = [
-  // populated by /add-dataset
-  { slug: 'DATASET_SLUG', name: 'DATASET_NAME', description: 'DESCRIPTION' },
-]
-```
-
-If multiple datasets already exist, append without removing existing entries.
-
-If the datasets array is not found (home page has been customised):
-- Add the dataset page but skip home page registration
-- Tell the user: "Dataset page created at /datasets/DATASET_SLUG. Add it to your home page manually."
-
-### 6. Create datasets directory index if it doesn't exist
-
-If `PORTAL_DIR/pages/datasets/` is new, Next.js needs the directory. No index file is required — individual dataset pages use the `[slug].tsx` pattern, OR you can write separate files per dataset (preferred for simplicity in v1).
-
-Use separate files per dataset (not dynamic `[slug].tsx`) for v1. This avoids the need for `getStaticPaths`.
-
-### 7. Report success
+### 6. Report success
 
 ```
 ✓ Dataset added: DATASET_NAME
   - Data file: public/data/DATASET_SLUG.EXT
-  - Page: pages/datasets/DATASET_SLUG.tsx → http://localhost:3000/datasets/DATASET_SLUG
-  - Home page: updated
+  - Manifest:  datasets.json (entry appended)
+  - Showcase:  /@NAMESPACE/DATASET_SLUG  (rendered by pages/[owner]/[slug].tsx)
+  - Catalog:   appears in /search automatically
 
-Next: run `npm run dev` and visit http://localhost:3000/datasets/DATASET_SLUG to verify.
+Next: run `npm run dev` and visit http://localhost:3000/@NAMESPACE/DATASET_SLUG to verify,
+or run /add-chart or /add-map to add a view to its showcase.
 ```
 
 ## Notes
 
-- **File size warning:** datasets over 5MB will load slowly in the browser. Add this note to the page: `<!-- Large dataset: consider server-side pagination for production use -->`.
-- **TSV files:** `<Table url="/data/file.tsv" />` — papaparse detects the delimiter automatically.
-- **Column names with spaces:** papaparse preserves them. Tailwind table headers handle wrapping — no fix needed.
+- **No per-dataset page.** Registration is one JSON entry. The dynamic route
+  `pages/[owner]/[slug].tsx` renders metadata + a `Table` data preview + a Download & API
+  section + a Views placeholder for every manifest entry.
+- **CSV/TSV preview** via the template's `<Table />`, which fetches `/data/<file>` in the
+  browser and auto-detects the delimiter (papaparse). JSON / GeoJSON entries show a
+  download link in the showcase instead of a table; use `/add-map` for a Leaflet view of
+  GeoJSON.
+- **File size warning:** datasets over ~5MB load slowly in the browser; consider a backend
+  (e.g. `/connect-ckan`) or server-side pagination for production use.
+- **Column names with spaces** are preserved by papaparse and wrap fine in the table — no
+  fix needed.

--- a/.claude/commands/add-map.md
+++ b/.claude/commands/add-map.md
@@ -1,78 +1,99 @@
 ---
-description: Render a GeoJSON dataset on an interactive Leaflet map in an existing PortalJS portal. Installs react-leaflet, generates a Map component, creates a map page, and registers it on the home page.
+description: Render a GeoJSON dataset on an interactive Leaflet map in the Views section of a dataset's showcase. Installs react-leaflet and a Map component, then renders the map for the chosen dataset.
 allowed-tools: Read, Write, Edit, Bash, WebFetch
 ---
 
 # /add-map
 
-Add an interactive map of a GeoJSON dataset to an existing PortalJS portal. Copies the GeoJSON to `/public/data/`, installs `react-leaflet`/`leaflet` (once), generates a reusable `Map` component, creates a map page, and registers it on the home page catalog.
+Add an interactive Leaflet map as a **view on a dataset's showcase** in a
+`portaljs-catalog` portal. Installs `react-leaflet`/`leaflet` (once), generates a reusable
+`Map` component, and renders the map into the **Views** section of the showcase route
+`pages/[owner]/[slug].tsx` for the chosen GeoJSON dataset.
 
-Use this when the data is geographic (points, lines, polygons) and the user wants a map rather than the table that `/add-dataset` produces for GeoJSON.
+Use this when a dataset's data is geographic (points, lines, polygons) and you want a map
+view in addition to the showcase's default metadata + download. The dataset should already
+be registered in `datasets.json` (e.g. via `/add-dataset`) with `format: "geojson"`; if
+it isn't yet, this skill can copy the file and add the entry first.
 
-## Required input
+## Required input — ask, don't error
 
-- **Source** — a local file path (`./data/file.geojson`) or a public URL (`https://example.com/file.geojson`). Must be **GeoJSON** (a `Feature`, `FeatureCollection`, or geometry object).
-- **Portal directory** — path to the portal project (defaults to current directory)
+- **Dataset** — which dataset to map, by **slug**. It should be a `geojson` entry in
+  `datasets.json`. If a source file/URL is given for a not-yet-registered dataset, the
+  skill copies it into `/public/data/` and appends a manifest entry.
+- **Portal directory** — path to the portal project (defaults to current directory).
+- **Source** (only if the dataset isn't registered yet) — a local file path
+  (`./data/file.geojson`) or public URL. Must be **GeoJSON** (a `Feature`,
+  `FeatureCollection`, or geometry object).
 
-If source is missing:
-```
-ERROR: [add-map] MISSING_INPUT No GeoJSON source provided — provide a local file path or public URL.
-```
+**If the target dataset isn't specified, ask which one (by name/slug) — never dead-end
+with a missing-input error.**
 
 ## Steps
 
-### 1. Parse arguments from `$ARGUMENTS`
+### 1. Gather input from `$ARGUMENTS` (interview if thin)
 
 Extract:
-- `SOURCE` — file path or URL
+- `DATASET` — dataset slug (the map target)
+- `SOURCE` — file path or URL (only needed if the dataset isn't already in the manifest)
 - `PORTAL_DIR` — portal directory (default: `.`)
+- `MAP_SLUG` — slug for a new dataset (default: lowercase hyphenated filename)
 - `MAP_NAME` — human-readable name (default: derived from filename)
-- `MAP_SLUG` — URL slug (default: lowercase hyphenated filename without extension)
+- `NAMESPACE` — namespace for a new dataset (default: the catalog's existing namespace)
 - `DESCRIPTION` — optional one-line description
 
-If `$ARGUMENTS` is empty, ask:
+If neither a dataset nor a source is given, **ask** and wait. When the user doesn't know
+the slug, read `PORTAL_DIR/datasets.json` and list the GeoJSON datasets so they can pick:
 ```
-To add a map I need:
-1. Source: local file path or public URL to a GeoJSON file
-2. Portal directory (press Enter for current directory)
-3. Map name (press Enter to use filename)
+To add a map I need either:
+1. Which existing dataset to map? (slug — GeoJSON datasets in your catalog: <name (slug)>, …)
+   …or a GeoJSON source to add and map:
+2. Source: local file path or public URL to a GeoJSON file
+3. Portal directory (Enter for current directory)
 ```
 
 ### 2. Validate the portal directory
 
-The target must be a PortalJS portal. Check `PORTAL_DIR/package.json` and `PORTAL_DIR/pages` exist:
-```
-ERROR: [add-map] NOT_A_PORTAL PORTAL_DIR is not a PortalJS portal (no package.json/pages) — run /new-portal first.
-```
+The target must be a `portaljs-catalog` portal. Confirm `PORTAL_DIR/datasets.json`,
+`PORTAL_DIR/package.json`, and `PORTAL_DIR/pages/[owner]/[slug].tsx` exist. If they don't,
+tell the user this isn't the catalog template and ask how to proceed rather than failing
+silently.
 
-### 3. Fetch/copy and validate the GeoJSON
+### 3. Resolve (or register) the GeoJSON dataset
 
-**If SOURCE is a URL:**
-- Fetch it. If the status is not 200:
+**If `DATASET` is already in `datasets.json`:** read its entry and capture `namespace`,
+`slug`, and `file` (must be served from `/public/data/<file>`). Confirm `format` is
+`geojson`; if it's tabular, tell the user `/add-map` only renders GeoJSON and ask whether
+they meant a different dataset (or `/add-chart`).
+
+**If a `SOURCE` was given for a not-yet-registered dataset:** fetch/copy and validate it,
+then append a manifest entry so the showcase exists:
+
+- URL: fetch it; if the status isn't 200, tell the user (with the HTTP status) and ask
+  them to confirm the URL is publicly accessible / supports CORS.
+- Local path: if the file doesn't exist, tell the user and ask for a correct path.
+- **Validate it is GeoJSON:** parse as JSON and confirm `type` is one of
+  `FeatureCollection`, `Feature`, `GeometryCollection`, `Point`, `MultiPoint`,
+  `LineString`, `MultiLineString`, `Polygon`, or `MultiPolygon`. If not, tell the user it
+  isn't valid GeoJSON (for tabular data use `/add-dataset`) and stop.
+- Copy and register:
+  ```bash
+  mkdir -p PORTAL_DIR/public/data
+  cp SOURCE PORTAL_DIR/public/data/MAP_SLUG.geojson
+  # or for URLs: curl -L SOURCE -o PORTAL_DIR/public/data/MAP_SLUG.geojson
   ```
-  ERROR: [add-map] FETCH_FAILED Could not fetch SOURCE (HTTP STATUS) — check the URL is publicly accessible and supports CORS.
+  Then append to `datasets.json` (matching the `Dataset` shape in `lib/datasets.ts`):
+  ```json
+  {
+    "slug": "MAP_SLUG",
+    "namespace": "NAMESPACE",
+    "name": "MAP_NAME",
+    "description": "DESCRIPTION",
+    "file": "MAP_SLUG.geojson",
+    "format": "geojson"
+  }
   ```
 
-**If SOURCE is a local file path:**
-- Check the file exists. If not:
-  ```
-  ERROR: [add-map] FILE_NOT_FOUND SOURCE does not exist — check the path and retry.
-  ```
-
-**Validate it is GeoJSON.** Parse the content as JSON and confirm `type` is one of
-`FeatureCollection`, `Feature`, `GeometryCollection`, `Point`, `MultiPoint`,
-`LineString`, `MultiLineString`, `Polygon`, or `MultiPolygon`. If parsing fails or
-`type` is none of these:
-```
-ERROR: [add-map] NOT_GEOJSON SOURCE is not valid GeoJSON — /add-map only renders GeoJSON. For tabular data use /add-dataset.
-```
-
-**Copy to portal:**
-```bash
-mkdir -p PORTAL_DIR/public/data
-cp SOURCE PORTAL_DIR/public/data/MAP_SLUG.geojson
-# or for URLs: curl -L SOURCE -o PORTAL_DIR/public/data/MAP_SLUG.geojson
-```
+Capture the final `NAMESPACE`, `SLUG`, and `FILE` for use when rendering the map.
 
 ### 4. Install map dependencies (once)
 
@@ -85,10 +106,7 @@ cd PORTAL_DIR && npm install react-leaflet@^4 leaflet@^1.9 && npm install -D @ty
 
 Tell the user first: `Installing map dependencies (react-leaflet, leaflet)...`
 
-If install fails:
-```
-ERROR: [add-map] INSTALL_FAILED npm install failed — check Node.js >=18 and network access, then retry.
-```
+If install fails, tell the user (check Node.js >=18 and network access) and retry.
 
 > Why `react-leaflet@^4`: v4 targets React 18 (the template's React). Do not install v5 (React 19) unless the portal has been upgraded to React 19.
 
@@ -220,66 +238,55 @@ export default function Map(props: MapProps) {
 }
 ```
 
-### 6. Choose the page path (avoid clobbering `/add-dataset`)
+### 6. Render the map into the showcase's Views section
 
-Map pages live under `pages/datasets/` so they share the home-page catalog with
-`/add-dataset`. If `PORTAL_DIR/pages/datasets/MAP_SLUG.tsx` already exists (e.g. a table
-page from `/add-dataset` for the same data), use `MAP_SLUG-map` for both the page slug
-and the route so both views can coexist. Call the final value `PAGE_SLUG`.
-
-### 7. Generate the map page
-
-Write `PORTAL_DIR/pages/datasets/PAGE_SLUG.tsx`. The page passes the GeoJSON `url` —
-the `Map` component fetches it client-side (the file is served statically from
-`/public/data/`), which sidesteps the fact that `.geojson` imports are not covered by
-`resolveJsonModule`.
+The showcase `pages/[owner]/[slug].tsx` renders **every** dataset, so the map must be
+applied **only for the chosen dataset** — gate it on the dataset's `(namespace, slug)`. The
+route already has a **Views placeholder**:
 
 ```tsx
-import Head from 'next/head'
-import Map from '../../components/Map'
-
-export default function MapPage() {
-  return (
-    <>
-      <Head><title>MAP_NAME</title></Head>
-      <main className="max-w-6xl mx-auto px-4 py-8">
-        <nav className="mb-6 text-sm text-gray-500">
-          <a href="/" className="hover:text-gray-700">Home</a>
-          <span className="mx-2">/</span>
-          <span>MAP_NAME</span>
-        </nav>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">MAP_NAME</h1>
-        {DESCRIPTION && <p className="text-gray-500 mb-8">DESCRIPTION</p>}
-        <Map url="/data/MAP_SLUG.geojson" />
-        <p className="mt-6 text-sm text-gray-400">
-          <a href="/data/MAP_SLUG.geojson" className="underline">Download GeoJSON</a>
-        </p>
-      </main>
-    </>
-  )
-}
+{/* Views placeholder — charts and maps are added here by the
+    /add-chart and /add-map skills. */}
+<section className="mt-10 border-t border-gray-200 pt-6">
+  <h2 className="text-lg font-semibold text-gray-900">Views</h2>
+  <p className="mt-2 text-sm text-gray-400">
+    No views yet. Charts and maps for this dataset are added here.
+  </p>
+</section>
 ```
 
-When writing the file, substitute `MAP_NAME`, `MAP_SLUG`, and `DESCRIPTION` with the real
-values. Drop the `{DESCRIPTION && ...}` line entirely if there is no description.
+Edit `PORTAL_DIR/pages/[owner]/[slug].tsx`. The `Map` component fetches the GeoJSON
+client-side from `/data/<file>` (the file is served statically from `/public/data/`),
+which sidesteps the fact that `.geojson` imports are not covered by `resolveJsonModule`.
 
-### 8. Register on the home page
+1. Add the import near the top (after the other component imports):
+   ```tsx
+   import Map from '../../components/Map'
+   ```
+2. Replace the Views placeholder `<section>` so it conditionally renders the map for the
+   target dataset and keeps the "no views yet" message for every other dataset:
 
-Open `PORTAL_DIR/pages/index.tsx` and find the `datasets` array:
-```tsx
-const datasets: { slug: string; name: string; description?: string }[] = []
-```
+   ```tsx
+   <section className="mt-10 border-t border-gray-200 pt-6">
+     <h2 className="text-lg font-semibold text-gray-900">Views</h2>
+     {dataset.namespace === 'NAMESPACE' && dataset.slug === 'SLUG' ? (
+       <div className="mt-4">
+         <Map url={`/data/${dataset.file}`} />
+       </div>
+     ) : (
+       <p className="mt-2 text-sm text-gray-400">
+         No views yet. Charts and maps for this dataset are added here.
+       </p>
+     )}
+   </section>
+   ```
 
-Append an entry (keep existing entries):
-```tsx
-{ slug: 'PAGE_SLUG', name: 'MAP_NAME', description: 'DESCRIPTION' },
-```
+If a previous `/add-chart` or `/add-map` run already replaced this section with a
+view-dispatch block, **extend** that block with another `dataset.namespace === … &&
+dataset.slug === …` branch (or add the `<Map />` alongside an existing `<Chart />` for the
+same dataset) rather than overwriting it.
 
-If the `datasets` array is not found (home page has been customised):
-- Keep the map page; skip registration.
-- Tell the user: "Map page created at /datasets/PAGE_SLUG. Add it to your home page manually."
-
-### 9. Verify the build
+### 7. Verify the build
 
 ```bash
 cd PORTAL_DIR
@@ -291,23 +298,26 @@ tail -20 /tmp/add-map-build.log
 If `BUILD_EXIT` is non-zero, print the log and fix the error before reporting success.
 Do not report success while the build is failing.
 
-### 10. Report success
+### 8. Report success
 
 ```
-✓ Map added: MAP_NAME
-  - Data file: public/data/MAP_SLUG.geojson
+✓ Map added to DATASET
+  - Data file: public/data/SLUG.geojson (manifest entry: format "geojson")
   - Component: components/Map.tsx (+ MapView.tsx)
-  - Page: pages/datasets/PAGE_SLUG.tsx → http://localhost:3000/datasets/PAGE_SLUG
-  - Home page: updated
+  - Showcase:  pages/[owner]/[slug].tsx Views section
+  - Renders at: /@NAMESPACE/SLUG
 
-Next: run `npm run dev` and visit http://localhost:3000/datasets/PAGE_SLUG to verify.
+Next: run `npm run dev` and visit http://localhost:3000/@NAMESPACE/SLUG to verify the map renders.
 ```
 
 ## Notes
 
-- **Tabular vs. map:** `/add-dataset` renders GeoJSON as a properties table; `/add-map`
-  renders it on a map. Run both on the same file to offer both views — the `-map` suffix
-  keeps the routes distinct.
+- **One showcase route, many datasets:** `pages/[owner]/[slug].tsx` renders every dataset,
+  so always gate the map on the dataset's `(namespace, slug)` — otherwise it would appear
+  on every dataset's showcase.
+- **Table vs. map:** the showcase already shows tabular data via `<Table />` and offers a
+  download; `/add-map` adds the geographic view in the Views section. A GeoJSON dataset
+  shows a download link by default (no table), so the map is its primary preview.
 - **Property popups:** every feature's `properties` become a click popup automatically.
 - **Coordinate order:** GeoJSON is `[longitude, latitude]`. Leaflet handles this for you
   via the `GeoJSON` layer — do not pre-swap coordinates.

--- a/.claude/commands/connect-ckan.md
+++ b/.claude/commands/connect-ckan.md
@@ -1,14 +1,16 @@
 ---
-description: Wire a scaffolded PortalJS portal to a CKAN backend over its API. Installs @portaljs/ckan, generates a CKAN-backed catalog home and dynamic dataset pages as plain editable code, and verifies the build.
+description: Wire a scaffolded PortalJS portal to a CKAN backend over its API. Installs @portaljs/ckan and feeds the /search catalog and /@<namespace>/<slug> showcases from CKAN instead of datasets.json.
 allowed-tools: Read, Write, Edit, Bash, WebFetch
 ---
 
 # /connect-ckan
 
-Connect an existing PortalJS portal to a live CKAN backend. The portal stops reading
-static files from `/public/data/` and instead lists and renders datasets straight from a
-CKAN instance's REST API (`package_search` / `package_show`) using the `@portaljs/ckan`
-client. Output is plain, editable Next.js code — no opaque framework wiring.
+Connect an existing `portaljs-catalog` portal to a live CKAN backend. The portal stops
+reading the static `datasets.json` manifest (and files in `/public/data/`) and instead
+feeds its two data surfaces — the **`/search` catalog** and the **`/@<namespace>/<slug>`
+showcases** — straight from a CKAN instance's REST API (`package_search` / `package_show`)
+using the `@portaljs/ckan` client. Output is plain, editable Next.js code — no opaque
+framework wiring.
 
 Use this for the "decoupled / any backend" path: the user has a CKAN data management
 system (their own or a public one) and wants a browseable portal in front of it.
@@ -17,7 +19,7 @@ The generated pages fetch CKAN **server-side** in `getStaticProps`/`getStaticPat
 the `@portaljs/ckan` bundle never reaches the browser — the client stays lean and the
 site can be statically deployed.
 
-## Required input
+## Required input — ask, don't error
 
 - **CKAN base URL** (required) — e.g. `https://demo.dev.datopian.com`. The root of the
   CKAN instance; the skill appends `/api/3/action/...` itself. Must be publicly reachable.
@@ -25,14 +27,12 @@ site can be statically deployed.
 - **Group filter** (optional) — one or more CKAN group names to restrict the catalog to.
 - **Portal directory** (optional) — path to the portal project (default: current directory).
 
-If the CKAN base URL is missing:
-```
-ERROR: [connect-ckan] MISSING_INPUT No CKAN base URL provided — pass the root URL of a CKAN instance, e.g. https://demo.dev.datopian.com.
-```
+**If the CKAN base URL is missing, ask for it (and the optional org/group filter) — never
+dead-end with a missing-input error.**
 
 ## Steps
 
-### 1. Parse arguments from `$ARGUMENTS`
+### 1. Gather input from `$ARGUMENTS` (interview if thin)
 
 Extract:
 - `CKAN_URL` — base URL, with any trailing slash stripped.
@@ -40,22 +40,22 @@ Extract:
 - `GROUP_FILTER` — list of group names (default: empty = all groups).
 - `PORTAL_DIR` — portal directory (default: `.`).
 
-If `$ARGUMENTS` is empty, ask once and stop:
+If the CKAN base URL is missing, **ask** and wait for the answer:
 ```
 To connect a CKAN backend I need:
-1. CKAN base URL (e.g. https://demo.dev.datopian.com)
-2. Optional org filter (press Enter for all organizations)
-3. Optional group filter (press Enter for all groups)
-4. Portal directory (press Enter for current directory)
+1. CKAN base URL (e.g. https://demo.dev.datopian.com)  — required
+2. Optional org filter (Enter for all organizations)
+3. Optional group filter (Enter for all groups)
+4. Portal directory (Enter for current directory)
 ```
 
 ### 2. Validate the portal directory
 
-The target must be a PortalJS portal. Confirm `PORTAL_DIR/package.json` and
-`PORTAL_DIR/pages` exist:
-```
-ERROR: [connect-ckan] NOT_A_PORTAL PORTAL_DIR is not a PortalJS portal (no package.json/pages) — run /new-portal first.
-```
+The target must be a `portaljs-catalog` portal. Confirm `PORTAL_DIR/package.json` and
+`PORTAL_DIR/pages` exist (the catalog template also has `datasets.json`,
+`pages/search.tsx`, and `pages/[owner]/[slug].tsx`, which this skill rewires). If it isn't
+a portal, tell the user and suggest running `/new-portal` first rather than failing
+silently.
 
 ### 3. Verify the CKAN backend is reachable
 
@@ -64,20 +64,17 @@ Hit `package_search` with a tiny page to confirm the URL is a working CKAN API:
 curl -s -m 20 "CKAN_URL/api/3/action/package_search?rows=1"
 ```
 The response must be JSON with `"success": true`. If the request fails, times out, or
-`success` is not `true`:
-```
-ERROR: [connect-ckan] CKAN_UNREACHABLE Could not reach a CKAN API at CKAN_URL (api/3/action/package_search) — check the URL is a CKAN root and is publicly accessible.
-```
+`success` is not `true`, tell the user the URL didn't resolve to a working CKAN API and
+ask them to confirm it's a CKAN root that's publicly accessible, then retry — don't
+dead-end.
 
 If `ORG_FILTER` is set, validate each org exists:
 ```bash
 curl -s -m 20 "CKAN_URL/api/3/action/organization_show?id=ORG"
 ```
-If any returns `success: false`, warn the user and list valid orgs from
-`organization_list`, then stop:
-```
-ERROR: [connect-ckan] ORG_NOT_FOUND Organization 'ORG' not found on CKAN_URL — check the org name (see api/3/action/organization_list).
-```
+If any returns `success: false`, tell the user that org wasn't found, list the valid orgs
+from `organization_list`, and ask which one they meant (or to drop the filter) before
+continuing.
 
 ### 4. Install `@portaljs/ckan` (once)
 
@@ -87,10 +84,7 @@ Tell the user first: `Installing @portaljs/ckan...`
 cd PORTAL_DIR && npm install @portaljs/ckan@^0.1.0
 ```
 
-If install fails:
-```
-ERROR: [connect-ckan] INSTALL_FAILED npm install failed — check Node.js >=18 and network access, then retry.
-```
+If install fails, tell the user (check Node.js >=18 and network access) and retry.
 
 ### 5. Patch `tsconfig.json` so TypeScript resolves the CKAN types
 
@@ -133,6 +127,22 @@ export const MAX_DATASETS = 200
 // Shared client. Used ONLY in getStaticProps/getStaticPaths (server side),
 // so the @portaljs/ckan bundle never reaches the browser.
 export const ckan = new CKAN(DMS)
+
+// A card is the serializable shape passed to client components from the
+// server-side data functions (never pass the raw CKAN client across this seam).
+export type DatasetCard = {
+  slug: string
+  namespace: string
+  name: string
+  description?: string
+}
+
+// Canonical showcase URL — keeps the template's /@<namespace>/<slug> structure.
+// The CKAN organization name is the namespace (it groups datasets by publisher,
+// i.e. the 'owner' namespace mode); falls back to 'dataset' when an org is absent.
+export function datasetHref(d: { namespace: string; slug: string }): string {
+  return `/@${d.namespace}/${d.slug}`
+}
 ```
 
 Substitute `CKAN_URL` with the real URL and fill `ORG_FILTER`/`GROUP_FILTER` with quoted
@@ -143,18 +153,19 @@ org/group names (e.g. `['my-org']`), or leave them as `[]` if no filter was give
 > the whole `@portaljs/ckan` package into the client. Pass plain serializable props to
 > components instead.
 
-### 7. Generate the catalog home page
+### 7. Generate the CKAN-backed catalog at `/search`
 
-Overwrite `PORTAL_DIR/pages/index.tsx`. It lists datasets from `package_search` and links
-each to `/datasets/[slug]` (slug = CKAN package `name`).
+The home page (`pages/index.tsx`) stays the search-first landing — its search box and chips
+already navigate to `/search`. Wire the **catalog list** at `PORTAL_DIR/pages/search.tsx`
+to read from CKAN instead of `datasets.json`. It lists datasets from `package_search` and
+links each to its showcase at `/@<namespace>/<slug>` via `datasetHref` (namespace = CKAN
+org name; slug = CKAN package `name`).
 
 ```tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import type { GetStaticProps } from 'next'
-import { ckan, ORG_FILTER, GROUP_FILTER, MAX_DATASETS } from '../lib/ckan'
-
-type DatasetCard = { slug: string; name: string; description?: string; org?: string }
+import { ckan, datasetHref, ORG_FILTER, GROUP_FILTER, MAX_DATASETS, type DatasetCard } from '../lib/ckan'
 
 export const getStaticProps: GetStaticProps<{ datasets: DatasetCard[]; count: number }> = async () => {
   const { datasets, count } = await ckan.packageSearch({
@@ -166,21 +177,25 @@ export const getStaticProps: GetStaticProps<{ datasets: DatasetCard[]; count: nu
   })
   const cards: DatasetCard[] = datasets.map((d) => ({
     slug: d.name,
+    namespace: d.organization?.name || 'dataset',
     name: d.title || d.name,
     description: d.notes ? d.notes.slice(0, 200) : '',
-    org: d.organization?.title || d.organization?.name || '',
   }))
   return { props: { datasets: cards, count } }
 }
 
-export default function Home({ datasets, count }: { datasets: DatasetCard[]; count: number }) {
+export default function Search({ datasets, count }: { datasets: DatasetCard[]; count: number }) {
   return (
     <>
-      <Head><title>__PROJECT_NAME__</title></Head>
+      <Head><title>Search — __PROJECT_NAME__</title></Head>
       <main className="max-w-5xl mx-auto px-4 py-12">
-        <header className="mb-12">
-          <h1 className="text-4xl font-bold text-gray-900">__PROJECT_NAME__</h1>
-          <p className="mt-3 text-lg text-gray-500">__DESCRIPTION__</p>
+        <header className="mb-8">
+          <nav className="mb-4 text-sm text-gray-500">
+            <Link href="/" className="hover:text-gray-700">Home</Link>
+            <span className="mx-2">/</span>
+            <span>Search</span>
+          </nav>
+          <h1 className="text-3xl font-bold text-gray-900">Datasets</h1>
           <p className="mt-1 text-sm text-gray-400">{count} datasets in catalog</p>
         </header>
 
@@ -193,12 +208,12 @@ export default function Home({ datasets, count }: { datasets: DatasetCard[]; cou
           <div className="grid gap-4">
             {datasets.map((ds) => (
               <Link
-                key={ds.slug}
-                href={`/datasets/${ds.slug}`}
+                key={`${ds.namespace}/${ds.slug}`}
+                href={datasetHref(ds)}
                 className="block rounded-lg border border-gray-200 p-6 hover:border-blue-400 hover:shadow-sm transition-all"
               >
                 <h2 className="text-xl font-semibold text-gray-900">{ds.name}</h2>
-                {ds.org && <p className="mt-1 text-xs uppercase tracking-wide text-gray-400">{ds.org}</p>}
+                <p className="mt-1 text-xs uppercase tracking-wide text-gray-400">@{ds.namespace}</p>
                 {ds.description && <p className="mt-2 text-gray-500">{ds.description}</p>}
               </Link>
             ))}
@@ -210,17 +225,21 @@ export default function Home({ datasets, count }: { datasets: DatasetCard[]; cou
 }
 ```
 
-Substitute `__PROJECT_NAME__` and `__DESCRIPTION__` with the portal's real values if the
-existing `index.tsx` had them (read it before overwriting). If the home page was heavily
-customised, preserve the layout and only swap the data source — do not blindly clobber a
-hand-edited home page; tell the user what you changed.
+Substitute `__PROJECT_NAME__` if the existing file still has the token. The CKAN list is
+pre-rendered server-side, so the template's client-side `useMemo` filter is replaced — if
+you want live text filtering over the CKAN results, keep a client-side filter over the
+`datasets` prop (same pattern the static `search.tsx` uses) or wire it to
+`package_search?q=` later. Leave `pages/index.tsx` as-is (it's the static search landing);
+only swap the catalog's data source. Tell the user what you changed.
 
-### 8. Generate the dynamic dataset page
+### 8. Generate the CKAN-backed showcase at `/@<namespace>/<slug>`
 
-Create `PORTAL_DIR/pages/datasets/[slug].tsx` (make the `pages/datasets/` directory if
-needed). It pre-renders one page per dataset via `getStaticPaths` and fetches full details
-with `package_show` in `getStaticProps`. Tabular resources (CSV/TSV) preview through the
-template's local `Table` component, which fetches the resource URL client-side.
+Overwrite `PORTAL_DIR/pages/[owner]/[slug].tsx` (the template's showcase route). It
+pre-renders one page per dataset via `getStaticPaths` and fetches full details with
+`package_show` in `getStaticProps`. The `owner` segment carries the `@` prefix so the URL
+stays `/@<namespace>/<slug>` (namespace = CKAN org name). Tabular resources (CSV/TSV)
+preview through the template's local `Table` component, which fetches the resource URL
+client-side.
 
 ```tsx
 import Head from 'next/head'
@@ -230,7 +249,7 @@ import { Table } from '../../components/Table'
 import { ckan, ORG_FILTER, GROUP_FILTER, MAX_DATASETS } from '../../lib/ckan'
 
 type ResourceView = { id: string; name: string; format: string; url: string; isTabular: boolean }
-type DatasetView = { slug: string; title: string; notes: string; org: string; resources: ResourceView[] }
+type DatasetView = { slug: string; namespace: string; title: string; notes: string; org: string; resources: ResourceView[] }
 
 const TABULAR = ['csv', 'tsv']
 
@@ -243,7 +262,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
     groups: GROUP_FILTER,
   })
   return {
-    paths: datasets.map((d) => ({ params: { slug: d.name } })),
+    // owner carries the leading `@`; slug is the CKAN package name. namespace = org name.
+    paths: datasets.map((d) => ({
+      params: { owner: '@' + (d.organization?.name || 'dataset'), slug: d.name },
+    })),
     // false: only datasets present at build time are served. Rebuild to pick up new ones.
     // Switch to 'blocking' if you deploy to a Node server and want new datasets on demand.
     fallback: false,
@@ -251,11 +273,13 @@ export const getStaticPaths: GetStaticPaths = async () => {
 }
 
 export const getStaticProps: GetStaticProps<{ dataset: DatasetView }> = async ({ params }) => {
+  const namespace = String(params?.owner ?? '').replace(/^@/, '')
   const slug = String(params?.slug)
   try {
     const d = await ckan.getDatasetDetails(slug)
     const dataset: DatasetView = {
       slug: d.name,
+      namespace,
       title: d.title || d.name,
       notes: d.notes || '',
       org: d.organization?.title || d.organization?.name || '',
@@ -283,6 +307,8 @@ export default function DatasetPage({ dataset }: { dataset: DatasetView }) {
       <main className="max-w-5xl mx-auto px-4 py-8">
         <nav className="mb-6 text-sm text-gray-500">
           <Link href="/" className="hover:text-gray-700">Home</Link>
+          <span className="mx-2">/</span>
+          <Link href="/search" className="hover:text-gray-700">Datasets</Link>
           <span className="mx-2">/</span>
           <span>{dataset.title}</span>
         </nav>
@@ -323,9 +349,11 @@ export default function DatasetPage({ dataset }: { dataset: DatasetView }) {
 }
 ```
 
-> If the portal already has a static `pages/datasets/[slug].tsx` (from the
-> `portaljs-catalog` template or `/add-dataset`), this overwrites it — CKAN becomes the
-> single source of truth. Tell the user the static dataset route was replaced.
+> This overwrites the static showcase route `pages/[owner]/[slug].tsx` so CKAN becomes the
+> single source of truth (the static `datasets.json` / `lib/datasets.ts` path is no longer
+> read). Tell the user the static dataset route was replaced. The `/add-chart` and
+> `/add-map` skills target the static showcase's Views section, so they don't apply to the
+> CKAN-backed route as-is.
 
 ### 9. Verify the build
 
@@ -350,8 +378,9 @@ not report success while the build is failing. Common cause: missing tsconfig `p
 ```
 ✓ Connected to CKAN: CKAN_URL
   - Client:    lib/ckan.ts (DMS overridable via env var)
-  - Home:      pages/index.tsx → lists datasets from package_search
-  - Dataset:   pages/datasets/[slug].tsx → package_show, CSV/TSV preview via <Table>
+  - Home:      pages/index.tsx → unchanged search landing (search box → /search)
+  - Catalog:   pages/search.tsx → lists datasets from package_search, links to /@<ns>/<slug>
+  - Showcase:  pages/[owner]/[slug].tsx → package_show, CSV/TSV preview via <Table>
   - Filters:   orgs=[...]  groups=[...]   (edit lib/ckan.ts to change)
   - Build:     N static dataset pages generated (catalog has M)
 
@@ -370,8 +399,9 @@ Next: run `npm run dev` and visit http://localhost:3000, or run /deploy to publi
 - **DMS env var.** `lib/ckan.ts` reads `process.env.DMS` first, falling back to the URL you
   provided. Set `DMS` in the deploy environment to point at a different CKAN instance without
   editing code.
-- **Slugs are CKAN package `name`s** — already lowercase and URL-safe and unique, so they map
-  cleanly to a single `[slug]` route segment.
+- **Slugs are CKAN package `name`s** — already lowercase, URL-safe, and unique. The CKAN
+  organization name becomes the `@<namespace>` segment, giving the template's
+  `/@<namespace>/<slug>` URLs. Datasets with no org fall back to the `@dataset` namespace.
 - **CORS for resource previews.** The `<Table>` preview fetches resource URLs from the
   browser. If a CKAN resource host blocks cross-origin requests, the table shows a load
   error while the Download link still works. Datastore-backed resources are the most reliable.

--- a/.claude/commands/new-portal.md
+++ b/.claude/commands/new-portal.md
@@ -1,58 +1,115 @@
 ---
-description: Scaffold a new PortalJS data portal from a brief. Copies the canonical template from examples/portaljs-template and substitutes project tokens.
+description: Scaffold a new PortalJS data portal from a brief. Copies the canonical template from examples/portaljs-catalog and substitutes project tokens.
 allowed-tools: Read, Write, Edit, Bash
 ---
 
 # /new-portal
 
-Scaffold a production-ready PortalJS data portal from a client brief. Copies `examples/portaljs-template`, substitutes placeholder tokens, installs dependencies, and verifies the build.
+Scaffold a production-ready PortalJS data portal. The skill is **interactive**: if the
+brief is thin, it interviews the user in three short rounds (mapped to the template's
+three surfaces — Home, Catalog, Showcase), echoes a brief back for confirmation, then
+copies `examples/portaljs-catalog`, substitutes placeholder tokens, sets the namespace
+mode, seeds any datasets, installs dependencies, and verifies the build.
 
-## Required input
+## The template you are scaffolding
 
-The brief must include at minimum:
-- A **project name** (used for the page title)
-- At least **one dataset reference** is optional at scaffold time — add later with `/add-dataset`
+`examples/portaljs-catalog` is the canonical template. It has **three surfaces**:
 
-If no project name is found:
-```
-ERROR: [new-portal] MISSING_INPUT No project name found in brief — provide a name and retry.
-```
+| Surface | Route | File | What it is |
+|---|---|---|---|
+| Home | `/` | `pages/index.tsx` | Search-first landing: hero + search box + suggested-query chips (`__PROJECT_NAME__` / `__DESCRIPTION__` tokens) |
+| Catalog / search | `/search` | `pages/search.tsx` | Client-side full-text list over `datasets.json` |
+| Dataset showcase | `/@<namespace>/<slug>` | `pages/[owner]/[slug].tsx` | One dataset: metadata, `Table` data preview, Download & API, and a Views placeholder for charts/maps |
+
+The catalog is driven by `datasets.json` (the single source of truth) — each entry is
+`{ slug, name, description, file, format, namespace }`. `lib/datasets.ts` exposes
+`getDatasets()`, `getDataset(slug)`, `getDatasetByNamespace(ns, slug)`, `datasetHref(d)`
+→ `/@${namespace}/${slug}`, and a `NAMESPACE_TYPE: 'theme' | 'owner'` constant.
+
+A portal uses **exactly one** namespace mode:
+- **`'theme'`** — a single-publisher portal whose datasets are grouped by subject
+  (e.g. `@reference/country-codes`). The showcase labels the namespace "Theme".
+- **`'owner'`** — a multi-publisher portal whose datasets are grouped by who published
+  them (e.g. `@worldbank/country-codes`). The showcase labels the namespace "Owner".
+
+Search is a **static client-side list** for now. A live backend (e.g. CKAN, via
+`/connect-ckan`) can replace `datasets.json` later without changing the URL structure.
+
+## Required input — interview, don't error
+
+You need a **project name** and **one-line description**. Datasets are optional at
+scaffold time. **Never dead-end with a missing-input error.** If `$ARGUMENTS` is empty or
+thin, run the structured interview in Step 1 to gather what's missing. The user can say
+**"use defaults"** at any point to skip a round and accept the defaults below.
 
 ## Steps
 
-### 1. Parse the brief from `$ARGUMENTS`
+### 1. Interview the user (skip rounds already answered by `$ARGUMENTS`)
 
-Extract:
-- `PROJECT_NAME` — e.g. `"Auckland Council Open Data Portal"`
-- `PROJECT_SLUG` — lowercase, hyphenated, no special chars (e.g. `auckland-council-open-data`)
-- `DESCRIPTION` — one sentence describing the portal (default: `"An open data portal."`)
-- `DATASETS` — list of file paths or URLs mentioned in the brief (can be empty)
+Parse `$ARGUMENTS` first and pre-fill anything it already specifies. Then ask only for
+what's still missing, **one focused round at a time** (wait for the answer before the next
+round). Each round maps to a template surface. Tell the user they can reply "use defaults"
+to take the defaults.
 
-If `$ARGUMENTS` is empty, ask:
+**Round 1 — Home / basics:**
 ```
-To scaffold a portal I need:
-1. Project name (e.g. "Auckland Open Data Portal")
-2. Description (optional)
-3. Any datasets to add? (file paths or URLs — you can also add them later with /add-dataset)
+Round 1 of 3 — the home page.
+1. What's the portal called? (e.g. "Auckland Open Data Portal")
+2. One-line description for the hero? (default: "An open data portal.")
+3. Who is it for / what's it about? (helps pick suggested-search chips)
 ```
 
-### 2. Resolve the template source
+**Round 2 — Catalog & discovery:**
+```
+Round 2 of 3 — the catalog (the /search list).
+1. Which datasets should it start with? Give file paths or URLs, or "none yet".
+2. Roughly how many datasets total — a handful, dozens, hundreds?
+3. Single publisher or multiple?
+   - single  → datasets grouped by SUBJECT (namespace mode "theme")
+   - multiple → datasets grouped by PUBLISHER (namespace mode "owner")
+   Then: what namespace value(s)? (e.g. "reference", or "worldbank, eurostat")
+```
+Note for the user when relevant: search is a static client-side list over
+`datasets.json` for now; a live backend (CKAN) can be wired in later with
+`/connect-ckan` without changing URLs.
+
+**Round 3 — Showcase / views:**
+```
+Round 3 of 3 — each dataset's showcase page (/@<namespace>/<slug>).
+Every showcase already shows metadata + a data preview + a Download & API section.
+For the dataset(s) above, do any need an extra view?
+  - a chart (line/bar/area/pie/scatter) → added later with /add-chart
+  - a map (GeoJSON on Leaflet)          → added later with /add-map
+(Press Enter / "use defaults" for metadata + preview + download only.)
+```
+
+**Defaults if a round is skipped:** description `"An open data portal."`; no datasets;
+`NAMESPACE_TYPE = 'theme'` with namespace value `reference`; no extra views.
+
+### 2. Confirm the brief before building
+
+Echo a short brief back and wait for a yes:
+```
+Here's the plan — say "go" to build, or correct anything:
+  • Name:        PROJECT_NAME  (slug: PROJECT_SLUG)
+  • Description: DESCRIPTION
+  • Namespace:   NAMESPACE_TYPE — value(s): NS_VALUES
+  • Datasets:    <list, or "none — add later with /add-dataset">
+  • Views to add after scaffold: <charts/maps per dataset, or "none">
+```
+
+Derive `PROJECT_SLUG` from `PROJECT_NAME` (lowercase, hyphenated, no special chars, e.g.
+`auckland-open-data`).
+
+### 3. Resolve the template source
 
 This skill works **both inside a clone of the portaljs repo and from any other project**.
 It prefers a local checkout (fast, offline, matches your working tree) and otherwise
-fetches the template remotely from GitHub.
-
-First pick the **variant**. Default is `examples/portaljs-template`. If the brief
-describes a portal with **many datasets** (dozens or more), or the user asks for a
-manifest-driven catalog, use the dynamic-routes variant `examples/portaljs-catalog`
-instead. This variant renders all datasets through one `pages/datasets/[slug].tsx` route
-from a `datasets.json` manifest, so adding a dataset is a JSON entry plus a data file — no
-new page. Both variants use the same tokens and the same `npm install` / build steps below.
+fetches the template remotely from GitHub. The default — and currently only — variant is
+`examples/portaljs-catalog`.
 
 ```bash
-# Pick one — default template, or the catalog variant for many datasets:
-TEMPLATE_VARIANT="examples/portaljs-template"
-# TEMPLATE_VARIANT="examples/portaljs-catalog"
+TEMPLATE_VARIANT="examples/portaljs-catalog"
 
 # Prefer a local checkout; fall back to remote fetch from GitHub.
 if GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && [ -d "$GIT_ROOT/$TEMPLATE_VARIANT" ]; then
@@ -65,20 +122,20 @@ else
 fi
 ```
 
-### 3. Materialize the template
+### 4. Materialize the template
 
-First, check the destination does not already exist:
+First, check the destination does not already exist. If `./$PROJECT_SLUG` is non-empty,
+**don't error out blindly — ask** the user for a different name or whether to remove the
+existing directory, then proceed with their answer:
+
 ```bash
 if [ -d "./$PROJECT_SLUG" ] && [ "$(ls -A "./$PROJECT_SLUG" 2>/dev/null)" ]; then
-  echo "ERROR: [new-portal] DIR_EXISTS ./$PROJECT_SLUG already exists — choose a different name or remove the existing directory."
-  exit 1
+  echo "DIR_EXISTS: ./$PROJECT_SLUG already exists and is non-empty."
 fi
 ```
 
-If the directory is non-empty, stop and report:
-```
-ERROR: [new-portal] DIR_EXISTS ./$PROJECT_SLUG already exists — choose a different name or remove the existing directory.
-```
+If it exists, ask: *"./PROJECT_SLUG already exists. Use a different name, or remove it and
+continue?"* and act on the reply.
 
 Then materialize, depending on the resolved mode:
 
@@ -93,17 +150,12 @@ else
 fi
 ```
 
-If the remote fetch fails (bad ref, network, or degit unavailable):
-```
-ERROR: [new-portal] FETCH_FAILED Could not fetch datopian/portaljs/$TEMPLATE_VARIANT#$PORTALJS_TEMPLATE_REF — check network access and that the ref exists, then retry. (Requires Node.js >=18 so `npx degit` is available.)
-```
+If the remote fetch fails (bad ref, network, or degit unavailable), tell the user plainly
+and ask how to proceed (retry / different ref / check network) — requires Node.js >=18 so
+`npx degit` is available. If running locally and the variant directory is missing, tell
+the user the local checkout is out of date and offer to fetch remotely instead.
 
-If running locally and the variant directory is missing:
-```
-ERROR: [new-portal] TEMPLATE_NOT_FOUND $TEMPLATE_VARIANT not found in the local checkout — update the repo or unset the local checkout to fetch remotely.
-```
-
-### 4. Substitute placeholder tokens
+### 5. Substitute placeholder tokens
 
 Replace all occurrences of the placeholder tokens in every file under `./$PROJECT_SLUG/`:
 
@@ -129,7 +181,48 @@ find "./$PROJECT_SLUG" -type f \( -name "*.tsx" -o -name "*.ts" -o -name "*.json
       s/__DESCRIPTION__/$DESC_ESC/g"
 ```
 
-### 5. Install dependencies
+Optionally tailor the `SUGGESTED_QUERIES` array near the top of `pages/index.tsx` to the
+portal's topics (from Round 1) — these are the suggested-search chips under the hero.
+
+### 6. Set the namespace mode
+
+Edit `./$PROJECT_SLUG/lib/datasets.ts` and set `NAMESPACE_TYPE` from the interview:
+`'theme'` for a single publisher (datasets grouped by subject) or `'owner'` for multiple
+publishers (datasets grouped by who published them). The default in the template is
+`'theme'`.
+
+```bash
+# Set to 'owner' only if the interview chose a multi-publisher portal.
+perl -pi -e "s/export const NAMESPACE_TYPE: 'theme' \\| 'owner' = '[a-z]+'/export const NAMESPACE_TYPE: 'theme' | 'owner' = 'owner'/" "./$PROJECT_SLUG/lib/datasets.ts"
+```
+
+### 7. Seed datasets captured in the interview
+
+The template ships with three sample entries in `datasets.json` (under namespace
+`reference`). If the user named real datasets in Round 2, **replace the samples** with
+their data; if they said "none yet", **clear** the manifest to `[]` so the `/search` page
+shows its empty state.
+
+For each captured dataset, run the `/add-dataset` flow (preferred — it handles
+fetch/copy, format detection, and manifest append), or append directly: drop the file in
+`./$PROJECT_SLUG/public/data/` and add an entry to `datasets.json` shaped like:
+
+```json
+{
+  "slug": "<url-safe-slug>",
+  "namespace": "<the NS value from Round 2>",
+  "name": "<Human Name>",
+  "description": "<one line>",
+  "file": "<file-in-public-data>",
+  "format": "csv"
+}
+```
+
+Use the namespace value(s) from Round 2 (the portal's `NAMESPACE_TYPE` mode). No
+per-dataset page is needed — `pages/[owner]/[slug].tsx` renders every entry at
+`/@<namespace>/<slug>` automatically.
+
+### 8. Install dependencies
 
 ```bash
 cd "./$PROJECT_SLUG" && npm install
@@ -137,12 +230,10 @@ cd "./$PROJECT_SLUG" && npm install
 
 Tell the user first: `Installing dependencies (2–5 min on cold cache)...`
 
-If `npm install` fails:
-```
-ERROR: [new-portal] INSTALL_FAILED npm install failed — check Node.js >=18 and network access, then retry.
-```
+If `npm install` fails, report the error plainly and ask the user to check Node.js >=18
+and network access before retrying.
 
-### 6. Verify scaffold-ready
+### 9. Verify scaffold-ready
 
 Capture build output and exit code separately so a failure is never silently missed:
 
@@ -153,23 +244,37 @@ BUILD_EXIT=$?
 tail -20 /tmp/next-build.log
 ```
 
-If `BUILD_EXIT` is non-zero, print the full log and fix the error before reporting success. Do not report `✓ Portal scaffolded` while the build is still failing.
+If `BUILD_EXIT` is non-zero, print the full log and fix the error before reporting
+success. Do not report success while the build is still failing.
 
-### 7. Report success
+### 10. Report success
 
 ```
-✓ Portal scaffolded at ./$PROJECT_SLUG
-✓ Run: cd $PROJECT_SLUG && npm run dev  →  http://localhost:3000
-```
-
-If DATASETS were listed in the brief:
-```
-Datasets to add — run /add-dataset for each:
-  - DATASET_1
-  - DATASET_2
+✓ Portal scaffolded at ./PROJECT_SLUG
+  - Home:     /                       (pages/index.tsx — search + chips)
+  - Catalog:  /search                 (pages/search.tsx — filters datasets.json)
+  - Showcase: /@<namespace>/<slug>    (pages/[owner]/[slug].tsx)
+  - Namespace mode: NAMESPACE_TYPE
+✓ Run: cd PROJECT_SLUG && npm run dev  →  http://localhost:3000
 ```
 
-Otherwise:
+If datasets still need adding (named in the interview but not yet seeded, or "none yet"):
 ```
-Next: run /add-dataset to load your client's data into the portal.
+Next steps:
+  - /add-dataset       load a dataset (appends to datasets.json, renders at /@<ns>/<slug>)
+  - /add-chart         add a chart to a dataset's showcase Views section
+  - /add-map           add a Leaflet map to a dataset's showcase Views section
+  - /connect-ckan      swap the static catalog for a live CKAN backend
 ```
+
+## Example
+
+```
+/new-portal Auckland Open Data Portal — datasets published by several council
+departments (multiple publishers). Start with ./data/parks.csv and ./data/budget.csv.
+```
+From this the skill infers name + description, picks `NAMESPACE_TYPE = 'owner'` (multiple
+publishers), asks for the namespace values (e.g. `parks-dept`, `finance`), confirms the
+brief, scaffolds `examples/portaljs-catalog`, and seeds the two datasets so they render at
+`/@parks-dept/parks` and `/@finance/budget`. With no arguments at all, the skill simply
+runs the three-round interview first.


### PR DESCRIPTION
Implements **A** of the skills redesign: the skills now **interview** instead of erroring on missing input, and all five align with the restructured catalog template from #1536 (`/search` + `/@<namespace>/<slug>`).

## new-portal (the main change)
- **Default template → `examples/portaljs-catalog`** (the 3-surface one).
- Removes the `MISSING_INPUT` error. With no/thin input it runs a **3-round interview** mapped to the concepts:
  1. **Home / basics** — name, description, audience
  2. **Catalog & discovery** — datasets + count; **single vs multiple publishers → `NAMESPACE_TYPE` (theme/owner)** + namespace; static search now, CKAN later
  3. **Showcase / views** — per-dataset chart/map needs
  Then **echoes a brief for confirmation**; "use defaults" skips any round.
- Scaffolds the catalog template, substitutes tokens, sets `NAMESPACE_TYPE`.

## Other skills
- **add-dataset** — manifest model (append to `datasets.json` incl. `namespace`, file to `/public/data`, auto-renders at `/@<namespace>/<slug>`). Asks for the source if missing.
- **add-chart / add-map** — render a view into the showcase **Views** section of `pages/[owner]/[slug].tsx`, gated on `(namespace, slug)`. Ask which dataset if unspecified.
- **connect-ckan** — feeds the `/search` catalog + `/@<namespace>/<slug>` showcases from CKAN. Asks for URL/org if missing.

**Global:** ask-don't-error everywhere. Verified: no `MISSING_INPUT`, no `portaljs-template` default, no real `pages/datasets/[slug].tsx` references remain.

## Reviewer note
`connect-ckan` generates a server-rendered `/search` (CKAN-backed), which drops the static template's client-side text filter — flagged inline; could keep a client filter or wire `package_search?q=`.

Next: **C** — `/docs/core-concepts` + `CLAUDE.md` teach Home/Catalog/Showcase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command guides for adding charts, datasets, and maps to improve interactive workflows and error handling.
  * Simplified dataset creation process—no longer requires generating individual page files.
  * Enhanced CKAN connection documentation with improved validation and namespace support.
  * Improved new portal setup with clearer scaffolding steps and better build verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->