### PR TITLE
docs: teach the three core concepts (Home / Catalog / Showcase) + align routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,24 @@
 
 PortalJS is a Next.js framework for building data portals and catalogs. This file teaches AI assistants the conventions, patterns, and idioms used across this repo.
 
+## Core concepts — three surfaces
+
+Every data portal is built from three surfaces. The template and routes map directly onto them; reason in these terms:
+
+1. **Home** (`/`, `pages/index.tsx`) — what the portal is + a search box that routes to the catalog.
+2. **Catalog** (`/search`, `pages/search.tsx`) — find/browse datasets. Static = full-text filter over `datasets.json`; scales to a search backend (CKAN/Solr) via `/connect-ckan`.
+3. **Showcase** (`/@<namespace>/<slug>`, `pages/[owner]/[slug].tsx`) — one dataset: metadata, a `Table` preview, download/API, and a Views slot for charts/maps.
+
+Datasets are `@`-namespaced so they never collide with content pages. See `docs/core-concepts`.
+
 ## Repo structure
 
 ```
 packages/
-  components/   — data viz React components (@portaljs/components)
-  core/         — layout/UI components (@portaljs/core)
-  ckan/         — CKAN backend integration (@portaljs/ckan)
-  remark-*/     — remark plugins for markdown processing
-examples/       — reference implementations (read these before building)
+  core/                — layout/UI components (@portaljs/core)
+  ckan/                — CKAN catalog UI + React components (@portaljs/ckan)
+  ckan-api-client-js/  — pure CKAN API client (@portaljs/ckan-api-client-js)
+examples/              — reference implementations (read these before building)
 .claude/
   commands/     — Claude Code slash commands (OSS skills)
   datopian/     — Datopian-internal skills (require API keys)
@@ -60,10 +69,10 @@ Use `datastoreConfig` prop — requires a running CKAN backend.
 
 ## Page structure
 
-Standard data portal page:
+Datasets themselves are manifest-driven and render via the showcase route (see Routing). A standalone content page looks like:
 
 ```tsx
-// pages/datasets/[slug].tsx
+// pages/about-the-data.tsx — datasets render via pages/[owner]/[slug].tsx from datasets.json
 import { Table } from '../../components/Table'
 import Head from 'next/head'
 
@@ -99,11 +108,14 @@ export default function App({ Component, pageProps }: AppProps) {
 
 ## Routing conventions
 
-- `/` — catalog/home (list of datasets)
-- `/datasets/[slug]` — individual dataset page
+The three surfaces (see Core concepts):
+
+- `/` — **home** (`pages/index.tsx`): hero + search box → `/search`
+- `/search` — **catalog** (`pages/search.tsx`): full-text list over `datasets.json`
+- `/@<namespace>/<slug>` — **showcase** (`pages/[owner]/[slug].tsx`): one dataset, manifest-driven
 - `/api/` — server-side API routes (avoid for simple portals; use static data in `/public/`)
 
-Dataset slug: lowercase, hyphenated. Derived from filename: `country-codes.csv` → `/datasets/country-codes`.
+Datasets are `@`-namespaced so they never collide with content pages. Pick one mode per portal — `theme` (single publisher, group by subject) or `owner` (multi-publisher, group by who published) — set via `NAMESPACE_TYPE` in `lib/datasets.ts`. Slug: lowercase, hyphenated, from the filename: `country-codes.csv` → `/@reference/country-codes`.
 
 ## Styling
 
@@ -162,7 +174,7 @@ Simple CSV portals need no environment variables.
 
 ## Key components — quick reference
 
-All components live in `components/` inside the portal project (copied from `examples/portaljs-template/components/`).
+All components live in `components/` inside the portal project (copied from `examples/portaljs-catalog/components/`).
 
 ### `<Table />` — `components/Table.tsx`
 ```tsx
@@ -203,8 +215,9 @@ See `.claude/commands/` for available slash commands:
 - `/add-map` — render a GeoJSON dataset on an interactive Leaflet map
 - `/deploy` — one-shot deploy to Vercel or static hosting
 - `/connect-ckan` — wire a portal to a CKAN backend over its API (decoupled / any backend)
+- `/check-data-quality` — audit a dataset for quality issues (schema, nulls, types)
 
-These skills run from any project, not just a clone of this repo — see
+The skills interview you for missing input (rounds of questions) rather than erroring, and build around the three surfaces. These skills run from any project, not just a clone of this repo — see
 [`.claude/INSTALL.md`](.claude/INSTALL.md) for the three install paths (run-from-clone,
 personal `~/.claude/commands/`, or Claude Code plugin).
 

--- a/site/content/docs/core-concepts.md
+++ b/site/content/docs/core-concepts.md
@@ -1,74 +1,118 @@
 ---
-metatitle: PortalJS Core Concepts – Template, Skills, Plain Code, Decoupled
-metadescription: The four ideas behind PortalJS — a lightweight template plus agentic skills, plain editable code with no lock-in, decoupled from any backend, and bring-your-own-stack.
+metatitle: PortalJS Core Concepts – Home, Catalog, and Dataset Showcase
+metadescription: Every data portal is built from three surfaces — a home/landing page, a search catalog, and a per-dataset showcase. Learn what each does, how it scales, and how PortalJS builds them.
 title: Core concepts
-description: The four ideas that shape PortalJS — lightweight template + skills, plain editable code, decoupled by default, and bring your own stack.
+description: Every data portal is built from three surfaces — Home, Catalog, and Showcase. Understand these and the template, routes, and skills all fall into place.
 ---
 
-PortalJS rests on four ideas. Understand these and the skills, the template, and
-the decisions behind them all make sense.
+Almost every data portal — however simple or sophisticated — is built from **three
+surfaces**. Get these straight and the template layout, the URL structure, and the
+skills all make sense, because each maps directly onto one of them.
 
-## 1. A lightweight template + agentic skills
+1. **Home** — what this portal is, and a way in.
+2. **Catalog** — find and discover datasets.
+3. **Showcase** — explore one dataset in full.
 
-For years, building a data portal meant wiring up a heavy component library,
-fighting bundle sizes, and writing boilerplate for every dataset page and catalog
-view. PortalJS replaces that with two smaller pieces:
+Everything else is an elaboration of these three.
 
-- **A lightweight, customizable template** — plain Next.js, Tailwind, and a few
-  small React components (`Table`, charts, maps added only when you need them). No
-  monolithic, non-tree-shakeable bundle.
-- **A set of agentic skills** — `/new-portal`, `/add-dataset`, `/add-chart`,
-  `/add-map`, `/connect-ckan`, `/deploy` — that do the repetitive assembly.
+## 1. Home — the landing page
 
-The work moves from _writing boilerplate_ to _describing intent_. The framework
-stays small and easy to own; the agent does the assembly.
+The front door. It tells a first-time visitor **what this portal is** (the project,
+who runs it, what kind of data lives here) and gives them an immediate way in.
 
-## 2. Plain, editable code — no lock-in
+The most important element is usually the **search box in the hero** — the primary
+call to action is "start searching," not "read about us." A good home page also
+offers a few **suggested queries** (example searches based on the data that's
+actually published) so visitors who don't know what to type still get moving.
 
-Every skill produces **plain, readable code you can clone, fork, and edit by
-hand**. There is no magic runtime interpreting a config file at request time, and
-nothing is feature-gated behind a hosted product.
+- **Basic:** a title, a sentence of description, and a search input that sends
+  people to the catalog.
+- **Scales to:** featured/most-popular datasets, themes, recent additions, stats.
 
-This is what _AI-native, not AI-only_ means: the skills are the fast path, but the
-output is an ordinary Next.js project. You can scaffold with skills today and hand
-the repo to a developer who's never heard of them — see [Manual setup](/docs/manual-setup).
+**In PortalJS:** `pages/index.tsx` at `/` — a search input whose submit routes to
+`/search`, plus suggested-query chips. Built by **`/new-portal`**.
 
-## 3. Decoupled by default
+## 2. Catalog — search & discovery
 
-The frontend is **independent from the backend** and talks to it over an API. The
-same portal frontend can sit in front of:
+Where users **find what they're looking for**. This is the heart of a portal: a
+searchable, browsable index of every dataset.
 
-- **CKAN**, **DKAN**, **OpenMetadata**, **Microsoft Purview**, **DataHub**
-- **GitHub**-backed and **Frictionless** datasets
-- plain **JSON / static files** (the default — no backend at all)
-- a **custom backend** you already run
+How much machinery sits behind it is the main thing that separates a simple portal
+from a sophisticated one:
 
-Start with static CSVs in `/public/data/`, then point the portal at a real catalog
-later with [`/connect-ckan`](/ckan) — without rewriting the frontend.
+- **Basic:** a plain list you can filter client-side. For a statically built
+  portal this is an **index written to a flat file** (e.g. `datasets.json`) loaded
+  into the browser on page load — no server required.
+- **Scales to:** a real **search engine** — full-text search, **faceted** filtering
+  (by theme, format, organization…), pagination, ranking. CKAN does this with
+  **Solr**; OpenMetadata with **Elasticsearch**. PortalJS stays decoupled: it
+  renders results from whichever index you point it at.
 
-## 4. Bring your own stack
+**In PortalJS:** `pages/search.tsx` at `/search` — client-side full-text search over
+the static `datasets.json` index, structured so a backend (e.g. CKAN) can replace
+the index later via **`/connect-ckan`** without changing the frontend.
 
-PortalJS ships a sensible default template, but never forces a frontend toolchain
-or design system on a team that already has one. The components are small and
-swappable; the styling is plain Tailwind. Adopt the whole template, or lift the
-skills and ideas into an existing app.
+## 3. Showcase — the dataset page
 
-## How it fits together
+Where a user **explores a single dataset in full**. Once they've found something in
+the catalog, this is where they decide whether it's what they need and how to use
+it. A good showcase covers:
 
-```
-You describe intent  ──►  Agentic skill  ──►  Plain editable code
-   "add this CSV"          /add-dataset        pages/datasets/*.tsx
-                                                public/data/*.csv
-```
+- **Metadata** — every attribute: title, description, license, source, fields, dates.
+- **Understanding the data** — a **preview** of the actual rows so people see what
+  they're getting.
+- **How to use it** — **download** the file vs **API/programmatic** access.
+- **Views** — visualizations: tables, **charts**, **maps**, so the data is legible
+  at a glance.
 
-The skills are first-class citizens of the repo: documented, tested end-to-end,
-and composable. Anyone can author one — see the
-[authoring guide](https://github.com/datopian/portaljs/blob/main/.claude/AUTHORING.md).
+**In PortalJS:** `pages/[owner]/[slug].tsx`, served at **`/@<namespace>/<slug>`** —
+metadata block, a `Table` data preview, a Download & API section, and a **Views**
+slot. Built incrementally: **`/add-dataset`** creates the dataset, **`/add-chart`**
+and **`/add-map`** add views.
+
+### Why dataset URLs start with `@`
+
+Datasets live under an `@`-prefixed namespace — `/@<owner-or-theme>/<dataset>` —
+which separates them from ordinary content/static pages (which never start with
+`@`), so the two can't collide. Pick **one** namespace mode per portal:
+
+- **`theme`** — a single-publisher portal, grouping datasets by subject
+  (`/@transport/road-deaths`).
+- **`owner`** — a multi-publisher portal, grouping by who published it
+  (`/@auckland-council/road-deaths`).
+
+Using exactly one keeps every `(@namespace, slug)` pair unique.
+
+## How the three map to skills
+
+| Surface | Route | Skill(s) that build it |
+|---------|-------|------------------------|
+| Home | `/` | `/new-portal` |
+| Catalog | `/search` | `/new-portal` (static) · `/connect-ckan` (backend) |
+| Showcase | `/@<namespace>/<slug>` | `/add-dataset`, then `/add-chart` · `/add-map` |
+
+Start with all three as static surfaces, then grow each one independently — a richer
+home, a search backend behind the catalog, more views on each showcase.
+
+## The principles underneath
+
+These three surfaces are delivered the PortalJS way:
+
+- **Lightweight template + agentic skills.** A small Next.js + Tailwind template
+  plus skills that do the assembly — you describe intent, the skill writes the code.
+- **Plain, editable code — no lock-in.** Every skill emits an ordinary Next.js
+  project you can fork and hand to any developer. No magic runtime. See
+  [Manual setup](/docs/manual-setup).
+- **Decoupled by default.** The frontend talks to the backend over an API — CKAN,
+  DKAN, OpenMetadata, Purview, DataHub, GitHub, Frictionless, plain JSON, or custom.
+  Start static, point at a real catalog later with [`/connect-ckan`](/ckan).
+- **Bring your own stack.** Adopt the whole template, or lift the skills and the
+  three-surface model into an app you already have.
 
 ## Where to go next
 
-- **[Quickstart](/docs/quickstart)** — put these concepts to work with the skills.
-- **[Manual setup](/docs/manual-setup)** — or build by hand.
+- **[Quickstart](/docs/quickstart)** — build all three surfaces with the skills.
+- **[Manual setup](/docs/manual-setup)** — or by hand.
 - **[Open-source framework docs](/opensource)** — the classic framework reference.
 
 <DocsPagination prev="/docs/manual-setup" />

--- a/site/content/docs/guides/add-tabular-data.md
+++ b/site/content/docs/guides/add-tabular-data.md
@@ -5,8 +5,8 @@ title: Add tabular data
 description: Add a CSV, TSV, or JSON dataset and render it as a sortable table — with /add-dataset, or by hand.
 ---
 
-**Goal:** add a CSV, TSV, or JSON file to your portal and render it as a table on its
-own dataset page, linked from the home page catalog.
+**Goal:** add a CSV, TSV, or JSON file to your portal and render it as a table in its
+dataset showcase, discoverable from the `/search` catalog.
 
 > [!info] Before you start
 > You need a portal scaffolded with [`/new-portal`](/docs/skills/new-portal). Tabular
@@ -25,9 +25,10 @@ Point [`/add-dataset`](/docs/skills/add-dataset) at a local file or a public URL
 /add-dataset https://example.com/air-quality.csv — Air quality monitoring
 ```
 
-It copies the data into `/public/data/`, generates a dataset page at
-`pages/datasets/<slug>.tsx` with a `<Table />`, and registers the dataset on the home
-page catalog. Run `npm run dev` and visit `/datasets/<slug>` to check it.
+It copies the data into `/public/data/` and appends an entry to `datasets.json`
+(including its `namespace`). The dataset then renders at `/@<namespace>/<slug>` through
+the existing `pages/[owner]/[slug].tsx` showcase — no new page file. Run `npm run dev`
+and visit `/@<namespace>/<slug>` to check it.
 
 ## The by-hand path
 
@@ -37,36 +38,29 @@ Drop the file into `/public/data/`:
 cp ~/Downloads/population.csv public/data/population.csv
 ```
 
-Create `pages/datasets/population.tsx`:
+Then append an entry to `datasets.json`:
 
-```tsx
-import { Table } from '../../components/Table';
-import Head from 'next/head';
-
-export default function PopulationDataset() {
-  return (
-    <>
-      <Head><title>Population by area</title></Head>
-      <main className="max-w-6xl mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold mb-6">Population by area</h1>
-        <Table url="/data/population.csv" fullWidth />
-      </main>
-    </>
-  );
+```json
+{
+  "slug": "population",
+  "name": "Population by area",
+  "description": "Resident population by area.",
+  "file": "population.csv",
+  "format": "csv",
+  "namespace": "reference"
 }
 ```
 
-The `Table` component (in `components/Table.tsx`) fetches the file in the browser with
-`papaparse` and renders it with `@tanstack/react-table` — no server code, and it works
-under static export. For a **JSON array**, import the file and pass it as `data` with
-`cols` instead of a `url`; set `"resolveJsonModule": true` in `tsconfig.json` first.
+That's all — the dataset now renders at **`/@reference/population`** via the existing
+`pages/[owner]/[slug].tsx` showcase, and appears in the `/search` catalog. The showcase
+previews the file with the `Table` component (in `components/Table.tsx`), which fetches
+it in the browser with `papaparse` and renders it with `@tanstack/react-table` — no
+server code, and it works under static export.
 
-Finally, add a link to the new page from your home page catalog (`pages/index.tsx`).
-
-> [!note] Many datasets?
-> If you'll have dozens of datasets, use the
-> [catalog template](/docs/templates) — one dynamic `[slug].tsx` route driven by a
-> `datasets.json` manifest, so adding a dataset is a JSON entry plus a data file.
+Every entry carries a `namespace`. A portal uses **one** namespace mode — `theme`
+(group by subject) or `owner` (group by publisher) — set via `NAMESPACE_TYPE` in
+`lib/datasets.ts`. See [Core concepts](/docs/core-concepts) for why dataset URLs start
+with `@`.
 
 ## Notes
 

--- a/site/content/docs/guides/connect-a-ckan-backend.md
+++ b/site/content/docs/guides/connect-a-ckan-backend.md
@@ -28,8 +28,8 @@ Optionally restrict the catalog to one or more organizations or groups:
 
 [`/connect-ckan`](/docs/skills/connect-ckan) verifies the CKAN API is reachable,
 installs `@portaljs/ckan`, generates a `lib/ckan.ts` client module, and rewrites the
-home page and dataset route to fetch from CKAN. It runs a full `next build` and
-reports how many dataset pages were generated.
+catalog (`/search`) and the dataset showcase route to fetch from CKAN. It runs a full
+`next build` and reports how many dataset pages were generated.
 
 ## How it works — the decoupled model
 
@@ -44,9 +44,10 @@ It writes plain, editable code:
 - `lib/ckan.ts` — a shared `CKAN` client. The base URL defaults to what you passed and
   is overridable at deploy time via the `DMS` env var; org/group filters and a
   build-time `MAX_DATASETS` cap live here as plain constants.
-- `pages/index.tsx` — a catalog home that lists datasets from `package_search`.
-- `pages/datasets/[slug].tsx` — one statically generated page per dataset, with
-  CSV/TSV resources previewed through the template's local `<Table />`.
+- `pages/search.tsx` — the catalog at `/search`, listing datasets from `package_search`.
+- `pages/[owner]/[slug].tsx` — the dataset showcase at `/@<namespace>/<slug>`, one
+  statically generated page per dataset, with CSV/TSV resources previewed through the
+  template's local `<Table />`.
 
 > [!note] Keep CKAN calls server-side
 > Reference `ckan`, `DMS`, and the filters **only** inside
@@ -67,9 +68,9 @@ import { CKAN } from '@portaljs/ckan';
 export const ckan = new CKAN((process.env.DMS || 'https://demo.dev.datopian.com').replace(/\/+$/, ''));
 ```
 
-Then call `ckan.packageSearch(...)` from `getStaticProps` on the home page and
-`ckan.getDatasetDetails(slug)` from a dynamic `pages/datasets/[slug].tsx`, passing the
-results as props.
+Then call `ckan.packageSearch(...)` from `getStaticProps` on the catalog
+(`pages/search.tsx`) and `ckan.getDatasetDetails(slug)` from the dynamic showcase route
+`pages/[owner]/[slug].tsx`, passing the results as props.
 
 > [!note] TypeScript types for @portaljs/ckan
 > Under the template's `moduleResolution: "bundler"`, add a `paths` entry in

--- a/site/content/docs/guides/render-a-map.md
+++ b/site/content/docs/guides/render-a-map.md
@@ -6,7 +6,7 @@ description: Put a GeoJSON dataset on an interactive map — with /add-map, or b
 ---
 
 **Goal:** render a GeoJSON dataset (points, lines, or polygons) on an interactive map
-on its own page, linked from the home page catalog.
+as a view in the dataset's showcase.
 
 > [!info] Before you start
 > You need a portal scaffolded with [`/new-portal`](/docs/skills/new-portal). The
@@ -22,14 +22,13 @@ Point [`/add-map`](/docs/skills/add-map) at a local file or a public URL:
 ```
 
 It validates the GeoJSON, copies it into `/public/data/`, installs
-`react-leaflet`/`leaflet` (once), generates a reusable client-only `Map` component,
-creates a map page under `pages/datasets/`, and registers it on the home page. It
-runs a full `next build` before reporting success.
+`react-leaflet`/`leaflet` (once), generates a reusable client-only `Map` component, and
+adds the map as a view in the dataset's showcase (`pages/[owner]/[slug].tsx`, in the
+Views section). It runs a full `next build` before reporting success.
 
 > [!note] Map and table of the same file
 > `/add-dataset` renders GeoJSON as a properties table; `/add-map` renders it on a
-> map. Run both on the same file to offer both views — `/add-map` adds a `-map` suffix
-> to keep the routes distinct.
+> map. Run both on the same dataset to offer both views in the same showcase.
 
 ## The by-hand path
 
@@ -49,17 +48,18 @@ wrapper that loads it with `dynamic(() => import('./MapView'), { ssr: false })`.
 the prop type is imported across the boundary, so Leaflet never reaches the server
 bundle.
 
-The map page passes the GeoJSON as a `url` so the component fetches it client-side
-(the file is served statically from `/public/data/`), which sidesteps `.geojson`
-import quirks:
+Render the `Map` as a view in the dataset's showcase (`pages/[owner]/[slug].tsx`),
+passing the GeoJSON as a `url` so the component fetches it client-side (the file is
+served statically from `/public/data/`), which sidesteps `.geojson` import quirks:
 
 ```tsx
 import Map from '../../components/Map';
-// …
+// …in the showcase's Views section:
 <Map url="/data/regions.geojson" />
 ```
 
-Then add a link from your home page catalog (`pages/index.tsx`).
+The dataset itself is registered in `datasets.json`, so it already appears in the
+`/search` catalog — no home-page link to add.
 
 ## Notes
 

--- a/site/content/docs/manual-setup.md
+++ b/site/content/docs/manual-setup.md
@@ -16,67 +16,68 @@ the same project by hand. This page shows how.
 
 ## 1. Get the template
 
-Grab the canonical lightweight template with [degit](https://github.com/Rich-Harris/degit)
+Grab the canonical catalog template with [degit](https://github.com/Rich-Harris/degit)
 (no git history, just the files):
 
 ```bash
-npx degit datopian/portaljs/examples/portaljs-template my-portal
+npx degit datopian/portaljs/examples/portaljs-catalog my-portal
 cd my-portal
 npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000). You now have a running portal
-with a sample dataset.
+Open [http://localhost:3000](http://localhost:3000). You now have a running portal —
+a home page (`/`), a search catalog at `/search`, and per-dataset showcase pages — with
+a few sample datasets.
 
-> [!note] Many datasets?
-> For a catalog with dozens of datasets, use the dynamic-routes variant
-> `examples/portaljs-catalog` instead — it renders every dataset through one
-> `pages/datasets/[slug].tsx` route from a `datasets.json` manifest, so adding a
-> dataset is a JSON entry plus a data file.
+> [!note] Just a landing page?
+> If you only want a single home page with no catalog or dataset pages, use the
+> minimal variant `examples/portaljs-template` instead and build up from there. See
+> [Templates](/docs/templates).
 
 ## 2. Add a dataset
 
-Drop your file into `/public/data/`:
+Datasets are driven by a `datasets.json` manifest — there's no per-dataset page file
+to write. Drop your file into `/public/data/`:
 
 ```bash
 cp ~/Downloads/population.csv public/data/population.csv
 ```
 
-Create a dataset page at `pages/datasets/population.tsx`:
+Then append an entry to `datasets.json`:
 
-```tsx
-import { Table } from '../../components/Table';
-import Head from 'next/head';
-
-export default function PopulationDataset() {
-  return (
-    <>
-      <Head>
-        <title>Population by area</title>
-      </Head>
-      <main className="max-w-5xl mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold mb-6">Population by area</h1>
-        <Table url="/data/population.csv" />
-      </main>
-    </>
-  );
+```json
+{
+  "slug": "population",
+  "name": "Population by area",
+  "description": "Resident population by area.",
+  "file": "population.csv",
+  "format": "csv",
+  "namespace": "reference"
 }
 ```
 
-The `Table` component (in `components/Table.tsx`) fetches the CSV in the browser
-with `papaparse` and renders it with `@tanstack/react-table`. No server code
-needed — Next.js serves `/public/` statically.
+That's it — the dataset now renders at **`/@reference/population`** through the
+existing `pages/[owner]/[slug].tsx` showcase route, and shows up in the `/search`
+catalog. The showcase previews the file with the `Table` component (in
+`components/Table.tsx`), which fetches the CSV in the browser with `papaparse` and
+renders it with `@tanstack/react-table` — no server code needed, since Next.js serves
+`/public/` statically.
 
-Then add a link to the new page from your home page catalog (`pages/index.tsx`).
+Every dataset carries a `namespace`. A portal uses **one** namespace mode —
+`theme` (group by subject) or `owner` (group by publisher) — set via `NAMESPACE_TYPE`
+in `lib/datasets.ts`. It only changes the showcase's metadata label; the URL is always
+`/@<namespace>/<slug>`. See [Core concepts](/docs/core-concepts) for why dataset URLs
+start with `@`.
 
 ## 3. Add charts, maps, and backends
 
 Everything the skills do, you can do by hand:
 
-- **Charts** — `npm install recharts` and add a chart component to the dataset
-  page.
-- **Maps** — `npm install react-leaflet leaflet` and render a GeoJSON file.
+- **Charts** — `npm install recharts` and add a chart as a view in the dataset's
+  showcase (`pages/[owner]/[slug].tsx`).
+- **Maps** — `npm install react-leaflet leaflet` and render a GeoJSON file as a view
+  in the showcase.
 - **CKAN** — `npm install @portaljs/ckan` and pass a `datastoreConfig` to `Table`,
   or build a catalog against the CKAN API. See [CKAN integration](/ckan).
 

--- a/site/content/docs/skills/add-chart.md
+++ b/site/content/docs/skills/add-chart.md
@@ -1,26 +1,27 @@
 ---
 metatitle: /add-chart – Add a Line, Bar, Area, Pie, or Scatter Chart to PortalJS
-metadescription: The /add-chart skill installs recharts, writes a reusable Chart component, and embeds a visualization into a dataset page — reading the same data the table already uses.
+metadescription: The /add-chart skill installs recharts, writes a reusable Chart component, and adds a chart view to a dataset's showcase — reading the same data the table already uses.
 title: /add-chart
-description: Add a line, bar, area, pie, or scatter chart to a dataset page, reading the same data the table already uses.
+description: Add a line, bar, area, pie, or scatter chart as a view on a dataset's showcase, reading the same data the table already uses.
 ---
 
-`/add-chart` adds a visualization to an existing dataset page. It installs
+`/add-chart` adds a chart view to an existing dataset's showcase. It installs
 `recharts`, writes a reusable client-side `Chart` component into the portal's
-`components/`, and embeds a `<Chart />` into the target page next to its `<Table />`.
-The chart reads the same `/public/data/*` file the table already uses — no data is
-duplicated.
+`components/`, and adds a `<Chart />` into the **Views** section of the showcase
+route (`pages/[owner]/[slug].tsx`), keyed to the chosen `(namespace, slug)`. The
+chart reads the same `/public/data/*` file the dataset's table already uses — no
+data is duplicated.
 
 ## When to use it
 
-Run it after [`/add-dataset`](/docs/skills/add-dataset) has created the dataset
-page you want to chart.
+Run it after [`/add-dataset`](/docs/skills/add-dataset) has added the dataset
+you want to chart.
 
 ## Inputs
 
 | Input | Required | Notes |
 | ----- | -------- | ----- |
-| Dataset | Yes | The dataset slug or page path (e.g. `country-codes`). The page must already exist. |
+| Dataset | Yes | The dataset slug (e.g. `country-codes`). The dataset must already exist in `datasets.json`. |
 | X axis column | Yes | The column for the category / X axis (e.g. `year`). |
 | Y axis column(s) | Yes | One or more numeric columns to plot (e.g. `population` or `imports,exports`). |
 | Chart type | No | `line` (default), `bar`, `area`, `pie`, or `scatter`. |
@@ -50,8 +51,10 @@ In natural language:
   `@portaljs/components` bundle).
 - A reusable `components/Chart.tsx` (written once; an existing customized component
   is never overwritten).
-- A `<Chart />` block inserted into the dataset page above the `<Table />`, so the
-  visual summary leads and the raw table follows.
+- A `<Chart />` view added to the **Views** section of the showcase route
+  (`pages/[owner]/[slug].tsx`), rendered only for the chosen dataset's
+  `(namespace, slug)`. No separate page is created and nothing is registered on the
+  home page.
 
 It type-checks the project (`tsc --noEmit`) before reporting success. When it
 finishes:
@@ -59,7 +62,7 @@ finishes:
 ```
 ✓ Chart added to country-codes
   - Component: components/Chart.tsx (recharts)
-  - Page: pages/datasets/country-codes.tsx — <Chart type="line" x="year" y="population">
+  - View: pages/[owner]/[slug].tsx — <Chart type="line" x="year" y="population"> for @reference/country-codes
   - Dependency: recharts@^2.12.0 added to package.json
 ```
 

--- a/site/content/docs/skills/add-dataset.md
+++ b/site/content/docs/skills/add-dataset.md
@@ -1,13 +1,15 @@
 ---
 metatitle: /add-dataset – Add a CSV, TSV, JSON, or GeoJSON Dataset to PortalJS
-metadescription: The /add-dataset skill copies your data into the portal, generates a dataset page with a Table, and registers it on the home page catalog — all as plain, editable code.
+metadescription: The /add-dataset skill copies your data into the portal and appends an entry to datasets.json, so the dataset's showcase renders automatically at /@<namespace>/<slug> — all as plain, editable code.
 title: /add-dataset
-description: Add a CSV, TSV, JSON, or GeoJSON dataset — copies the data in, generates a dataset page, and registers it on the home page.
+description: Add a CSV, TSV, JSON, or GeoJSON dataset — copies the data in and appends a datasets.json entry, so its showcase renders automatically.
 ---
 
 `/add-dataset` adds a dataset to an existing PortalJS portal. It copies the data
-into `/public/data/`, generates a dataset page that renders the data as a table,
-and registers the dataset on the home page catalog.
+into `/public/data/` and appends an entry to the `datasets.json` manifest. The
+showcase page then renders automatically at `/@<namespace>/<slug>` and the dataset
+appears in the `/search` catalog — both are driven by the manifest, so no new page
+file is created.
 
 ## When to use it
 
@@ -22,7 +24,8 @@ publish. For geographic data you'd rather show on a map, use
 | Source | Yes | A local file path (`./data/file.csv`) or a public URL. |
 | Portal directory | No | Path to the portal project. Defaults to the current directory. |
 | Dataset name | No | Human-readable name. Defaults to the filename. |
-| Description | No | Optional one-line description shown on the page. |
+| Description | No | Optional one-line description shown on the showcase. |
+| Namespace | No | The `@`-prefixed namespace the dataset lives under (theme or owner). Defaults to a sensible value for the portal. |
 
 **Supported formats:** CSV, TSV, JSON (array), and GeoJSON. Anything else is
 rejected with a clear message to convert it first.
@@ -47,28 +50,27 @@ From a public URL:
 
 ## What it produces
 
-- The data file copied to `public/data/<slug>.<ext>`.
-- A dataset page at `pages/datasets/<slug>.tsx` — plain React that renders the data
-  through the template's `Table` component (one file per dataset, so no dynamic
-  routing is required).
-- A new entry in the `datasets` array on the home page (`pages/index.tsx`) so the
-  dataset appears in the catalog. Existing entries are preserved.
+- The data file copied to `public/data/<file>`.
+- A new entry appended to the `datasets.json` manifest: `{ slug, name, description,
+  file, format, namespace }`. Existing entries are preserved.
 
-If the home page has been heavily customized and the catalog array can't be found,
-the skill still creates the page and tells you to link it manually.
+No page file is created. The template's showcase route (`pages/[owner]/[slug].tsx`)
+renders every manifest entry automatically at `/@<namespace>/<slug>`, with a `Table`
+preview for tabular data, and the `/search` catalog picks it up from the same
+manifest.
 
 When it finishes:
 
 ```
 ✓ Dataset added: Air quality monitoring
   - Data file: public/data/air-quality.csv
-  - Page: pages/datasets/air-quality.tsx → http://localhost:3000/datasets/air-quality
-  - Home page: updated
+  - Manifest: datasets.json (entry appended)
+  - Showcase: http://localhost:3000/@environment/air-quality
 ```
 
 ## Where to go next
 
-- **[`/add-chart`](/docs/skills/add-chart)** — add a chart to the dataset page.
+- **[`/add-chart`](/docs/skills/add-chart)** — add a chart to the dataset's showcase.
 - **[`/add-map`](/docs/skills/add-map)** — show geographic data on a map.
 
 <DocsPagination prev="/docs/skills/new-portal" next="/docs/skills/add-chart" />

--- a/site/content/docs/skills/add-map.md
+++ b/site/content/docs/skills/add-map.md
@@ -1,21 +1,22 @@
 ---
 metatitle: /add-map – Render a GeoJSON Dataset on an Interactive Map in PortalJS
-metadescription: The /add-map skill installs react-leaflet, generates a reusable Map component, creates a map page, and registers it on the home page — rendering GeoJSON on an interactive Leaflet map.
+metadescription: The /add-map skill installs react-leaflet, generates a reusable Map component, and adds a map view to a dataset's showcase — rendering GeoJSON on an interactive Leaflet map.
 title: /add-map
-description: Render a GeoJSON dataset on an interactive Leaflet map and register it on the home page catalog.
+description: Render a GeoJSON dataset on an interactive Leaflet map as a view on its showcase.
 ---
 
-`/add-map` adds an interactive map of a GeoJSON dataset to an existing PortalJS
+`/add-map` adds an interactive map view of a GeoJSON dataset to an existing PortalJS
 portal. It copies the GeoJSON into `/public/data/`, installs `react-leaflet` /
-`leaflet` (once), generates a reusable `Map` component, creates a map page, and
-registers it on the home page catalog.
+`leaflet` (once), generates a reusable `Map` component, and adds a map view into the
+**Views** section of the dataset's showcase (`pages/[owner]/[slug].tsx`).
 
 ## When to use it
 
 Use it when your data is geographic (points, lines, polygons) and you want a map
-rather than the properties table that [`/add-dataset`](/docs/skills/add-dataset)
-produces for GeoJSON. You can run both on the same file to offer both views — the
-map page gets a `-map` suffix so the routes don't collide.
+view of it. If the GeoJSON isn't yet in the portal, add it first with
+[`/add-dataset`](/docs/skills/add-dataset); the map is added as a view alongside the
+dataset's other views, so a single showcase can offer both a properties table and a
+map.
 
 ## Inputs
 
@@ -46,12 +47,15 @@ From a public URL with a name:
 
 - The GeoJSON copied to `public/data/<slug>.geojson`.
 - `react-leaflet` and `leaflet` added to `package.json` (installed once).
+- The GeoJSON copied to `public/data/<file>` and, if not already present, a
+  `datasets.json` entry appended for it (so the showcase route renders it).
 - A reusable `components/Map.tsx` plus `components/MapView.tsx` — split so Leaflet
   is loaded with `dynamic(..., { ssr: false })` and never reaches the server
   bundle. Every feature's `properties` become a click popup automatically.
-- A map page at `pages/datasets/<slug>.tsx` that fetches the GeoJSON client-side.
-- A new entry on the home page catalog (`pages/index.tsx`), preserving existing
-  entries.
+- A `<Map />` view added to the **Views** section of the showcase route
+  (`pages/[owner]/[slug].tsx`), rendered for the chosen dataset's `(namespace, slug)`
+  and fetching the GeoJSON client-side. No separate page is created and nothing is
+  registered on the home page.
 
 It runs the build before reporting success. When it finishes:
 
@@ -59,8 +63,8 @@ It runs the build before reporting success. When it finishes:
 ✓ Map added: Auckland suburbs
   - Data file: public/data/auckland-suburbs.geojson
   - Component: components/Map.tsx (+ MapView.tsx)
-  - Page: pages/datasets/auckland-suburbs.tsx → http://localhost:3000/datasets/auckland-suburbs
-  - Home page: updated
+  - View: pages/[owner]/[slug].tsx — <Map> for @auckland-council/auckland-suburbs
+  - Showcase: http://localhost:3000/@auckland-council/auckland-suburbs
 ```
 
 ## Where to go next

--- a/site/content/docs/skills/connect-ckan.md
+++ b/site/content/docs/skills/connect-ckan.md
@@ -1,15 +1,16 @@
 ---
 metatitle: /connect-ckan – Wire a PortalJS Portal to a CKAN Backend over its API
-metadescription: The /connect-ckan skill installs @portaljs/ckan, generates a CKAN-backed catalog home and dynamic dataset pages as plain editable code, and verifies the build — the decoupled, any-backend path.
+metadescription: The /connect-ckan skill installs @portaljs/ckan, feeds the catalog at /search and dataset showcases at /@<namespace>/<slug> from CKAN as plain editable code, and verifies the build — the decoupled, any-backend path.
 title: /connect-ckan
 description: Wire a portal to a CKAN backend over its API instead of static files — the decoupled, any-backend path.
 ---
 
 `/connect-ckan` connects an existing PortalJS portal to a live [CKAN](/ckan)
-backend. The portal stops reading static files from `/public/data/` and instead
-lists and renders datasets straight from a CKAN instance's REST API
-(`package_search` / `package_show`) using the `@portaljs/ckan` client. The output
-is plain, editable Next.js code — no opaque framework wiring.
+backend. The portal stops reading the static `datasets.json` manifest and
+`/public/data/` files, and instead feeds both surfaces — the catalog at `/search`
+and the dataset showcases at `/@<namespace>/<slug>` — straight from a CKAN
+instance's REST API (`package_search` / `package_show`) using the `@portaljs/ckan`
+client. The output is plain, editable Next.js code — no opaque framework wiring.
 
 ## When to use it
 
@@ -50,18 +51,18 @@ Restricted to specific organizations:
 - `lib/ckan.ts` — a small, editable client module. The CKAN URL is the default,
   overridable at deploy time via the `DMS` env var; org/group filters and a
   build-time page cap (`MAX_DATASETS`) are plain constants you can edit.
-- `pages/index.tsx` rewritten to list datasets from `package_search`.
-- `pages/datasets/[slug].tsx` — a dynamic route that pre-renders one page per
-  dataset via `package_show`, previewing CSV/TSV resources through the template's
-  `Table`.
+- `pages/search.tsx` rewritten so the catalog lists datasets from `package_search`.
+- `pages/[owner]/[slug].tsx` — the showcase route, repointed to pre-render one
+  showcase per dataset at `/@<namespace>/<slug>` via `package_show`, previewing
+  CSV/TSV resources through the template's `Table`.
 
 It verifies the build before reporting success. When it finishes:
 
 ```
 ✓ Connected to CKAN: https://demo.dev.datopian.com
   - Client:    lib/ckan.ts (DMS overridable via env var)
-  - Home:      pages/index.tsx → lists datasets from package_search
-  - Dataset:   pages/datasets/[slug].tsx → package_show, CSV/TSV preview via <Table>
+  - Catalog:   pages/search.tsx → lists datasets from package_search
+  - Showcase:  pages/[owner]/[slug].tsx → package_show at /@<namespace>/<slug>, CSV/TSV preview via <Table>
 ```
 
 > The default is static generation (data fixed at build time — rebuild to pick up

--- a/site/content/docs/templates.md
+++ b/site/content/docs/templates.md
@@ -1,65 +1,73 @@
 ---
-metatitle: PortalJS Templates – Default Template vs Catalog Variant
-metadescription: PortalJS ships two starting points — the default template (one page file per dataset) and the catalog variant (one dynamic route driven by a datasets.json manifest). When to use which.
+metatitle: PortalJS Templates – Default Catalog vs Minimal Single-Page
+metadescription: PortalJS ships two starting points — the default catalog (a datasets.json manifest with a search page and dataset showcase) and a minimal single-page variant. When to use which.
 title: Templates
-description: The default template vs the catalog variant — one page per dataset, or one dynamic route driven by a manifest. When to use which.
+description: The default catalog vs the minimal single-page variant — a manifest-driven catalog with showcase pages, or one home page. When to use which.
 ---
 
 PortalJS ships two starting points. Both are real Next.js projects with the same
 lightweight `components/Table.tsx`, Tailwind setup, and Next 14 config — they differ
-only in how dataset pages are routed. [`/new-portal`](/docs/skills/new-portal) picks
-the right one for your brief; you can also clone either by hand.
+in whether they include the catalog and per-dataset showcase pages.
+[`/new-portal`](/docs/skills/new-portal) picks the right one for your brief; you can
+also clone either by hand. For the surfaces these build — Home, Catalog, Showcase —
+see [Core concepts](/docs/core-concepts).
 
 ## The two templates
 
-| | `portaljs-template` (default) | `portaljs-catalog` |
+| | `portaljs-catalog` (default) | `portaljs-template` |
 | --- | --- | --- |
-| Dataset pages | one `.tsx` file per dataset | one dynamic `[slug].tsx` for all |
-| Registration | hardcoded array in `index.tsx` | `datasets.json` manifest |
-| Adding a dataset | new page file + array entry | one JSON entry + a data file |
-| Best for | a handful of datasets | dozens to hundreds |
+| Pages | home + `/search` catalog + dataset showcase | home only |
+| Dataset pages | one dynamic `[owner]/[slug].tsx` for all | none |
+| Registration | `datasets.json` manifest | n/a |
+| Adding a dataset | one JSON entry + a data file | edit the home page directly |
+| Best for | any portal with a catalog of datasets | a single landing page |
 
-## Default template — one page per dataset
+## Default catalog — manifest-driven
 
-[`examples/portaljs-template`](https://github.com/datopian/portaljs/tree/main/examples/portaljs-template)
-is the canonical template. Each dataset is its own `pages/datasets/<slug>.tsx` file,
-registered in a `datasets` array on the home page. This is the simplest mental model —
-one file, one page — and it has no `getStaticPaths`, so it static-exports without
-fuss. [`/add-dataset`](/docs/skills/add-dataset) writes one file per dataset against
-this template.
+[`examples/portaljs-catalog`](https://github.com/datopian/portaljs/tree/main/examples/portaljs-catalog)
+is the canonical template. Datasets are listed in a single `datasets.json` manifest;
+every entry is rendered by one dynamic `pages/[owner]/[slug].tsx` showcase route,
+served at **`/@<namespace>/<slug>`**. It ships three surfaces: a home page (`/`), a
+client-side search **catalog** at `/search`, and the per-dataset **showcase**. Adding a
+dataset is one JSON entry plus a data file — no new page:
+
+```json
+{ "slug": "my-data", "name": "My Data", "description": "…", "file": "my-data.csv", "format": "csv", "namespace": "reference" }
+```
+
+Each entry carries a `namespace`. A portal uses **one** namespace mode for all
+datasets — `theme` (group by subject) or `owner` (group by publisher) — set via
+`NAMESPACE_TYPE` in `lib/datasets.ts`. It only changes the showcase's metadata label;
+the URL is always `/@<namespace>/<slug>`. See [Core concepts](/docs/core-concepts) for
+the rationale. [`/add-dataset`](/docs/skills/add-dataset) appends a manifest entry
+against this template.
 
 Clone it by hand with [degit](https://github.com/Rich-Harris/degit):
+
+```bash
+npx degit datopian/portaljs/examples/portaljs-catalog my-portal
+```
+
+## Minimal variant — single page
+
+[`examples/portaljs-template`](https://github.com/datopian/portaljs/tree/main/examples/portaljs-template)
+is a stripped-down starting point: just `pages/index.tsx`, `_app`, and `_document` —
+no catalog, no per-dataset pages. Use it when you want a single landing page and will
+add structure yourself, or as the smallest possible base to build on.
 
 ```bash
 npx degit datopian/portaljs/examples/portaljs-template my-portal
 ```
 
-## Catalog variant — one dynamic route
-
-[`examples/portaljs-catalog`](https://github.com/datopian/portaljs/tree/main/examples/portaljs-catalog)
-is for portals with **many datasets**. Instead of a file per dataset, the catalog is
-driven by a single `datasets.json` manifest and rendered by a dynamic
-`pages/datasets/[slug].tsx` route with `getStaticPaths`. Adding a dataset is one JSON
-entry plus a data file — no new page:
-
-```json
-{ "slug": "my-data", "name": "My Data", "description": "…", "file": "my-data.csv", "format": "csv" }
-```
-
-```bash
-npx degit datopian/portaljs/examples/portaljs-catalog my-catalog
-```
-
 ## Which should I use?
 
-- **A handful of datasets, or you want each page to be its own editable file** → the
-  **default template**.
-- **Dozens to hundreds of datasets, driven from a manifest** → the **catalog variant**.
-- **A live backend (CKAN, etc.)** → start from either, then run
-  [`/connect-ckan`](/docs/guides/connect-a-ckan-backend) — it replaces the dataset route
-  with one that fetches from the backend.
+- **Any portal with a catalog of datasets** → the **default catalog**.
+- **A single landing page you'll grow by hand** → the **minimal variant**.
+- **A live backend (CKAN, etc.)** → start from the catalog, then run
+  [`/connect-ckan`](/docs/guides/connect-a-ckan-backend) — it rewrites the showcase
+  route to fetch from the backend.
 
-Both static-export cleanly (the catalog pre-renders every manifest entry via
+The catalog static-exports cleanly (it pre-renders every manifest entry via
 `getStaticPaths` with `fallback: false`).
 
 ## Where to go next


### PR DESCRIPTION
Implements **C** of the redesign: the docs now teach the three surfaces every data portal is built from, and all route references match the restructured template from #1536 (`/search` + `/@<namespace>/<slug>`).

## core-concepts.md (the centerpiece)
Rewritten around the three surfaces:
1. **Home** (`/`) — what the portal is + a search box → catalog; suggested queries.
2. **Catalog** (`/search`) — find/browse; static full-text list over `datasets.json`, **scales to** a search backend (CKAN/Solr, OpenMetadata/Elasticsearch) via `/connect-ckan`.
3. **Showcase** (`/@<namespace>/<slug>`) — metadata, data preview, download/API, and **Views** (charts/maps).

Plus the **`@`-namespace rule** (one of `theme`/`owner` per portal) and a table mapping each surface → route → skill. Framework principles (lightweight template + skills, plain code, decoupled, BYO stack) kept as a secondary section.

## CLAUDE.md (AI dev guide)
- New **Core concepts** section up top so the assistant reasons in the three surfaces.
- Repo structure fixed: drops removed `components/` + `remark-*`, adds `ckan-api-client-js`.
- Routing → `/`, `/search`, `/@<namespace>/<slug>` + the `NAMESPACE_TYPE` theme/owner rule.
- Components path → `portaljs-catalog`; adds `/check-data-quality`; notes skills interview rather than error.

## Route-reference cleanup
`portaljs-catalog` is now documented as the **canonical/default** template (`portaljs-template` = minimal single-page). Replaced every `pages/datasets/[slug].tsx` / `/datasets/<slug>` reference with the manifest model + showcase route across **templates.md, manual-setup.md, guides/{connect-a-ckan-backend, render-a-map, add-tabular-data}.md, and skills/{add-dataset, add-chart, add-map, connect-ckan}.md**.

**Verified:** zero `datasets/[slug]` or `/datasets/` references remain anywhere in `site/content/docs` or `CLAUDE.md`.

Completes the redesign trio: B template (#1536) · A interactive skills (#1537) · **C docs (this)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured architecture documentation around three portal surfaces: Home, Catalog, and Showcase
  * Clarified routing patterns with centralized catalog search and showcase-based dataset rendering
  * Updated all guides and skills documentation to reflect manifest-driven dataset workflow
  * Revised template documentation highlighting catalog-first approach as the default starting point

<!-- end of auto-generated comment: release notes by coderabbit.ai -->