### PR TITLE
docs: roadmap + architecture decision framework (data-platform vision)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,105 @@
+# PortalJS Roadmap
+
+> Direction and sequencing for the PortalJS revamp. Living document — decisions here
+> are revisited as we learn. For the conceptual model behind the product, see
+> [Core concepts](site/content/docs/core-concepts.md); for the architecture decision
+> layer, see [the decision framework](site/content/docs/architecture/decision-framework.md).
+
+## What PortalJS is
+
+PortalJS is an **agentic skills framework that helps data teams build, develop, and
+ship data portals — and the data infrastructure underneath them.** It is not only a
+frontend layer. The skills do two jobs:
+
+- **Advise** — given *what you're building*, *what your data is*, and *what it's for*,
+  recommend an architecture (storage, compute, catalog, access, hosting).
+- **Build** — scaffold the chosen stack as plain, editable code with no lock-in.
+
+The product is organized into three layers:
+
+| Layer | What it does | Built from |
+|-------|--------------|-----------|
+| **Decision** | Advises on architecture from the team's needs | Advisory skills (e.g. `/architect`) |
+| **Build** | Scaffolds + wires the chosen stack | Generative skills + the contracts below |
+| **Presentation** | The portal users see | The three surfaces (Home / Catalog / Showcase) |
+
+## The four contracts
+
+Everything in the Build layer plugs into one of four file-declarative, pluggable
+contracts. Each has a static/none default and richer backend implementations, so
+simple stays simple.
+
+| Contract | Static default | Scales to | Drives |
+|----------|----------------|-----------|--------|
+| **Metadata profile** | Frictionless Tabular Data Package | extend → custom → multi-profile; DCAT interop | catalog facets, showcase metadata |
+| **Data provider** | git files (`datasets.json`) | git+LFS, lakehouse, CKAN, OpenMetadata | what feeds all three surfaces |
+| **Data query** | flat CSV fetch | DuckDB-Wasm → server/remote DuckDB | showcase preview + views |
+| **Auth / RBAC** | none (repo permissions) | CKAN / OIDC / OpenMetadata | visibility + edit across surfaces |
+
+The recurring axis through all four is **build-time (static) vs request-time
+(runtime)**. We stay **static-first**; runtime is an explicit opt-in mode, unlocked
+when a portal needs private data, live search, or write access — never a rewrite.
+
+## The storage + compute spectrum
+
+The data provider and data query contracts together span a spectrum the advisory
+layer reasons over — open/composable/cheap on the left, traditional/heavy on the right:
+
+| | Flat files | **Git-LFS + R2** | **Open lakehouse** | Warehouse / datastore |
+|---|---|---|---|---|
+| **Storage** | repo | R2 via giftless (Git LFS) | Parquet on R2 | Postgres / CKAN datastore / Snowflake |
+| **Catalog** | `datasets.json` | git + Frictionless | DuckLake (catalog in SQL) | warehouse-native |
+| **Compute** | papaparse | DuckDB-Wasm | DuckDB (Wasm or server) | warehouse SQL engine |
+| **Versioning** | git | git + LFS | git + table snapshots | none / CDC |
+| **Best for** | a few small files | large files, gitops workflow | analytics-grade, open, cheap | large internal/SQL, RBAC-native |
+
+**Opinionated modern default:** `git + giftless/R2 + Parquet + DuckLake + DuckDB` —
+open formats, object storage, bring-your-own-compute, no warehouse lock-in. The
+warehouse/CKAN column stays a fully supported choice for teams that need it. DuckDB is
+the through-line: it queries Parquet/CSV directly off object storage, client (Wasm) or
+server.
+
+### Where giftless fits
+
+[giftless](https://github.com/datopian/giftless) is Datopian's pluggable **Git LFS
+server**. It is the git tier's **ingest + versioning plane**: git versions metadata and
+LFS *pointers* (Frictionless packages, profiles, config) and giftless moves the actual
+bytes to blob storage. It keeps large data out of the repo, makes a `git push` / PR the
+way data enters and is versioned, and is the on-ramp to the lakehouse — the same R2
+bucket that holds LFS blobs holds the Parquet that DuckLake + DuckDB query.
+
+## Cloudflare-first (R2-portable)
+
+We champion Cloudflare as the default substrate, but keep storage S3-compatible so R2
+is never a hard lock-in.
+
+| Cloudflare | Role |
+|-----------|------|
+| **R2** | object storage — LFS blobs + Parquet (S3-compatible; swappable for S3/GCS/Azure) |
+| **Workers** | the opt-in **runtime** — SSR, auth/RBAC, server-side DuckDB, LFS endpoints |
+| **D1** | DuckLake catalog / metadata index |
+| **Pages** | static hosting for the build-time portal |
+
+The static-first → runtime fork is concretely **Pages → Workers**.
+
+## Sequencing
+
+1. **Advisory / decision layer** *(next — Phase 1)* — the needs→architecture framework
+   and an `/architect` interview skill. Defines *what* the build layer produces. See
+   [decision-framework.md](site/content/docs/architecture/decision-framework.md).
+2. **Data-provider contract** — the storage+compute+catalog seam every surface consumes;
+   refactor the static path onto it; design-in giftless/LFS+R2 (wire later); refactor
+   `/connect-ckan` onto it.
+3. **Metadata profile layer** ∥ **DuckDB data query** — parallel; both static-friendly,
+   high visible value.
+4. **DCAT interop** — export then import, layered on the profile layer (interop over a
+   Frictionless-native model, not the native model).
+5. **RBAC + runtime mode** — auth provider + visibility + Pages→Workers. Last; only
+   advanced/multi-team portals need it.
+
+## Shipped so far
+
+- Three-surface product model — Home `/`, Catalog `/search`, Showcase
+  `/@<namespace>/<slug>` (#1536).
+- Interactive skills — interview in rounds, never dead-end on missing input (#1537).
+- Docs teaching the three concepts + aligned routes (#1538).

--- a/site/content/docs/architecture/decision-framework.md
+++ b/site/content/docs/architecture/decision-framework.md
@@ -1,0 +1,96 @@
+---
+metatitle: PortalJS Architecture Decision Framework
+metadescription: How PortalJS skills recommend a data architecture — storage, compute, catalog, access, and hosting — from what you're building, what your data is, and what it's for.
+title: Architecture decision framework
+description: The advisory layer — how the skills turn three questions about your needs into a concrete, scaffoldable stack.
+---
+
+PortalJS doesn't just build a portal; it helps you **decide what to build**. This is
+the advisory layer: a small set of questions that map your needs onto a concrete
+architecture the build skills can then scaffold. It is opinionated by default and
+explicit about when to deviate.
+
+> Status: **design / Phase 1.** This document specifies the framework and the
+> `/architect` skill. It is the contract the build layer (data provider, data query,
+> metadata, RBAC) is designed against — see the [Roadmap](https://github.com/datopian/portaljs/blob/main/ROADMAP.md).
+
+## Three questions
+
+Every recommendation comes from three questions:
+
+1. **What are you building?** An open-data portal, an internal data catalog, a
+   project/research data site, a public-sector portal with harvesting obligations…
+2. **What is your data?** Size, shape (tabular / geospatial / documents), update
+   frequency, number of datasets, sensitivity.
+3. **What is it for?** Publishing/discovery, analytics/querying, redistribution,
+   compliance, machine-to-machine harvesting.
+
+## Decision axes
+
+The answers resolve into a handful of axes. Each pushes the recommendation along the
+[storage + compute spectrum](https://github.com/datopian/portaljs/blob/main/ROADMAP.md#the-storage--compute-spectrum).
+
+| Axis | Low → High | Pulls toward |
+|------|-----------|--------------|
+| **Data volume** | KBs → TBs | flat files → Git-LFS+R2 → lakehouse |
+| **Query needs** | "show me the rows" → "aggregate/join/filter" | flat preview → DuckDB → datastore |
+| **Update frequency** | rare, by-hand → continuous | git/gitops → pipeline/CDC |
+| **# of datasets** | a handful → hundreds+ | single-page → catalog → search backend |
+| **Access control** | fully public → role-based private | static → backend RBAC (runtime) |
+| **Openness/interop** | internal only → standards-compliant harvest | plain → DCAT profiles |
+| **Team & budget** | small/cheap/git-native → large/funded/SQL-native | git+R2+DuckDB → warehouse/CKAN |
+
+## The recommendation
+
+Each axis-set resolves into a stack across five slots:
+
+| Slot | Options (default in **bold**) |
+|------|-------------------------------|
+| **Storage** | repo files · **Git-LFS + R2** · Parquet on R2 · CKAN datastore / warehouse |
+| **Catalog** | `datasets.json` · git + Frictionless · **DuckLake** · backend-native |
+| **Compute** | papaparse · **DuckDB** (Wasm → server) · warehouse engine |
+| **Access** | **static (public)** · runtime + backend RBAC |
+| **Hosting** | **Cloudflare Pages** (static) · Cloudflare Workers (runtime) · any static host |
+| **Metadata** | **Frictionless** profile · extended · custom · multi-profile + DCAT |
+
+### Opinionated defaults
+
+When in doubt, PortalJS recommends the **open, cheap, composable** path:
+
+- **git + giftless/R2 + Parquet + DuckLake + DuckDB**, static on **Cloudflare Pages**,
+  Frictionless metadata.
+- Storage stays **S3-compatible**, so R2 is the default but never a lock-in.
+- DuckDB is the query engine everywhere — client-side (Wasm) until data size or
+  privacy forces a server (Cloudflare Workers).
+
+### When to deviate
+
+- **Role-based private data, multi-team governance** → a backend that owns RBAC
+  (**CKAN** or **OpenMetadata**) + the runtime mode. The portal surfaces it.
+- **Existing warehouse / SQL-native team** → keep the warehouse as the datastore; the
+  data-query contract has a datastore implementation.
+- **Tiny, static, a handful of CSVs** → don't reach for the lakehouse; flat files +
+  client-side preview is the whole stack.
+
+## The `/architect` skill (design)
+
+A new advisory skill that runs the framework as an interview and emits an
+**architecture brief**, then hands off to the build skills.
+
+**Interview (rounds, skippable with sensible defaults):**
+1. **Building** — what kind of portal, and who runs it.
+2. **Data** — volume, shape, update cadence, dataset count, sensitivity.
+3. **Use** — publish/discover, analytics, redistribution, compliance/harvest.
+4. **Constraints** — team size/skills, budget, cloud preference, existing backends.
+
+**Output — an architecture brief:** the five-slot recommendation above, the reasoning
+per axis, and the deviations chosen. Echoed for confirmation.
+
+**Handoff:** the brief parameterizes the build skills — `/new-portal` (surfaces +
+namespace mode), the storage/compute choice (Git-LFS+R2 / lakehouse / datastore), the
+metadata profile (`/define-schema`), and any backend wiring (`/connect-ckan`,
+`/connect-openmetadata`). The advisory layer decides; the build layer executes.
+
+> The framework is intentionally small. It should give a confident default in seconds
+> for the common case, and a defensible recommendation with trade-offs spelled out for
+> the hard ones — never a blank page.


### PR DESCRIPTION
Captures the expanded vision discussed for PortalJS and locks the longer-term direction.

## The shift
PortalJS is an **agentic skills framework for data teams to build, develop, and ship data portals — and the data infrastructure underneath**, not just a frontend. Skills both **advise** (recommend an architecture from your needs) and **build** (scaffold it as plain code).

## `ROADMAP.md` (repo root)
- **Three layers:** Decision (advisory skills) · Build (contracts + generative skills) · Presentation (the three surfaces).
- **Four pluggable contracts:** metadata profile · data provider · data query · auth/RBAC — each static-default, scaling to backends. Static-first; runtime is opt-in.
- **Storage + compute spectrum:** flat files → **Git-LFS + R2** → **open lakehouse (Parquet on R2 + DuckLake + DuckDB)** → warehouse/CKAN. Opinionated default = `git + giftless/R2 + Parquet + DuckLake + DuckDB`; warehouse/CKAN stays supported.
- **giftless** = the git tier's Git-LFS ingest/versioning plane (bytes → R2, git holds pointers); on-ramp to the lakehouse.
- **Cloudflare-first, R2-portable:** R2 (blobs+Parquet) · Workers (the opt-in runtime) · D1 (DuckLake catalog) · Pages (static). Pages→Workers = the static→runtime fork.
- **Sequencing:** advisory layer → provider contract (giftless designed-in) → metadata ∥ DuckDB → DCAT interop → RBAC/runtime.

## `docs/architecture/decision-framework.md` (Phase 1 anchor)
The advisory layer: three questions (what you're building / what your data is / what it's for) → decision axes → a five-slot stack recommendation (storage · catalog · compute · access · hosting · metadata) with opinionated defaults and explicit when-to-deviate. Specifies the **`/architect`** skill — an interview that emits an architecture brief and hands off to the build skills.

## Locked decisions
Cloudflare-first (R2-portable) · advisory framework first · giftless designed-in now / built later · DCAT as interop over a Frictionless-native model · static-first + opt-in runtime.

Planning/vision docs — no code. Open for direction review before we build Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a roadmap document outlining PortalJS's vision, architecture approach, and planned enhancements
  * Added an architecture decision framework guide to help users make informed technology choices for storage, compute, cataloging, and access control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->