### PR TITLE
feat(skills): /architect — the advisory layer (Phase 1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "portaljs",
   "version": "0.1.0",
-  "description": "Agentic skills for building PortalJS data portals — scaffold a portal, add datasets, charts, and maps, connect a CKAN backend, deploy, and audit data quality.",
+  "description": "Agentic skills for building PortalJS data portals — recommend an architecture, scaffold a portal, add datasets, charts, and maps, connect a CKAN backend, deploy, and audit data quality.",
   "author": {
     "name": "Datopian",
     "url": "https://www.datopian.com"
@@ -11,6 +11,7 @@
   "license": "MIT",
   "keywords": ["portaljs", "data-portal", "ckan", "nextjs", "data-catalog"],
   "commands": [
+    "./.claude/commands/architect.md",
     "./.claude/commands/new-portal.md",
     "./.claude/commands/add-dataset.md",
     "./.claude/commands/add-chart.md",

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -1,0 +1,187 @@
+---
+description: Recommend a data-portal architecture (storage, compute, catalog, access, hosting, metadata) from your needs, then hand off to the build skills. The advisory entry point.
+allowed-tools: Read, Write, Bash
+---
+
+# /architect
+
+The **advisory** skill. Before scaffolding anything, it works out *what* to build:
+given what you're building, what your data is, and what it's for, it recommends a
+concrete architecture and then hands off to the build skills (`/new-portal`,
+`/add-dataset`, `/connect-ckan`, …). It **decides**; it does not build.
+
+The skill is **interactive**: if the brief is thin it interviews you in short rounds,
+echoes an architecture brief for confirmation, and **never dead-ends on missing
+input** — every question has a sensible default; say **"use defaults"** to take them.
+
+See [the decision framework](../../site/content/docs/architecture/decision-framework.md)
+and [ROADMAP.md](../../ROADMAP.md) for the full model this skill encodes.
+
+## What it recommends — five slots
+
+Every recommendation fills five slots. The **bold** option is the default when nothing
+pulls you off it.
+
+| Slot | Options (default in **bold**) |
+|------|-------------------------------|
+| **Storage** | repo files · **Git-LFS + R2** · Parquet on R2 · CKAN datastore / warehouse |
+| **Catalog** | `datasets.json` · git + Frictionless · **DuckLake** · backend-native |
+| **Compute** | papaparse preview · **DuckDB** (Wasm → server) · warehouse engine |
+| **Access** | **static (public)** · runtime + backend RBAC |
+| **Hosting** | **Cloudflare Pages** (static) · Cloudflare Workers (runtime) · any static host |
+| **Metadata** | **Frictionless** profile · extended · custom · multi-profile + DCAT |
+
+Opinionated default stack: `git + giftless/R2 + Parquet + DuckLake + DuckDB`, static on
+Cloudflare Pages, Frictionless metadata. Storage stays **S3-compatible**, so R2 is the
+default but never a hard lock-in.
+
+## Steps
+
+### 1. Interview the user (skip rounds already answered by `$ARGUMENTS`)
+
+Parse `$ARGUMENTS` first and pre-fill anything it specifies. Then ask only for what's
+missing, **one round at a time** (wait for each answer). Tell the user they can reply
+"use defaults".
+
+**Round 1 — What are you building?**
+```
+Round 1 of 4 — the portal.
+1. What kind of portal? (open-data portal · internal data catalog · research/project
+   data site · public-sector portal with harvesting obligations · something else)
+2. Who runs it — one team/publisher, or several?
+```
+
+**Round 2 — What is your data?**
+```
+Round 2 of 4 — the data.
+1. Roughly how big? (KBs/MBs · GBs · TBs)
+2. What shape? (tabular CSV · geospatial/GeoJSON · documents · mixed)
+3. How often does it change? (rarely, by hand · regularly · continuously)
+4. How many datasets? (a handful · dozens · hundreds+)
+5. Any of it private / access-controlled? (no, all public · yes)
+```
+If the user points at actual files or a directory, inspect them to ground the answers
+instead of guessing — e.g. size and row counts:
+```bash
+# Replace PATHS with the files/dirs the user named.
+du -sh PATHS 2>/dev/null
+for f in PATHS; do [ -f "$f" ] && printf '%s: ' "$f" && { wc -l < "$f" 2>/dev/null || echo '?'; }; done
+```
+
+**Round 3 — What is it for?**
+```
+Round 3 of 4 — the purpose (pick any that apply).
+  - publishing & discovery (people find and download datasets)
+  - analytics / querying (filter, aggregate, join the data)
+  - redistribution / machine-to-machine harvesting (e.g. DCAT to data.europa.eu)
+  - compliance with a metadata standard (DCAT-AP, a national or domain profile)
+```
+
+**Round 4 — Constraints.**
+```
+Round 4 of 4 — constraints (all optional; Enter to skip).
+  - team size / SQL comfort?
+  - budget sensitivity?
+  - cloud preference? (default: Cloudflare — R2/Workers/Pages, S3-compatible)
+  - any existing backend to keep? (e.g. a CKAN or OpenMetadata instance)
+```
+
+**Defaults if a round is skipped:** open-data portal · single publisher · MBs of
+tabular CSV that changes rarely · a few-to-dozens of datasets · all public · publishing
+& discovery · Cloudflare, no existing backend.
+
+### 2. Derive the recommendation
+
+Fill the five slots by applying these rules (first match wins per slot; otherwise use
+the default):
+
+**Storage · Catalog · Compute** (by data volume + query needs):
+| Situation | Storage | Catalog | Compute |
+|-----------|---------|---------|---------|
+| Tiny — a few small CSVs, preview only | repo files | `datasets.json` | papaparse preview |
+| Large files, want versioning / gitops | **Git-LFS + R2** | git + Frictionless | DuckDB-Wasm |
+| Analytics-grade — aggregate/join/filter, or many/large datasets | **Parquet on R2** | **DuckLake** | **DuckDB** (Wasm→server) |
+| Existing warehouse, or SQL-native team needing a datastore | CKAN datastore / warehouse | backend-native | warehouse engine |
+
+**Access · Hosting:**
+- All public → **static**, hosted on **Cloudflare Pages**.
+- Any private / role-based → **runtime + backend RBAC** (CKAN or OpenMetadata owns
+  policy; PortalJS surfaces it), hosted on **Cloudflare Workers**. Flag this as the
+  larger build (the opt-in runtime mode).
+
+**Metadata:**
+- Default **Frictionless** profile.
+- Harvesting / standard compliance → add a **DCAT** export and the relevant profile
+  (DCAT-AP / national / domain). Multiple dataset types → multi-profile.
+
+**Namespace mode (for the `/new-portal` handoff):** single publisher → `theme`
+(group by subject); multiple publishers → `owner` (group by who published).
+
+When genuinely unsure, recommend the opinionated default and say so — never present a
+blank page.
+
+### 3. Echo the architecture brief for confirmation
+
+```
+Architecture brief — say "go" to proceed, or correct anything:
+
+  Building:  <kind>, <single/multi> publisher
+  Data:      <size>, <shape>, changes <cadence>, <count> datasets, <public/private>
+  For:       <purposes>
+
+  Recommended stack
+    • Storage:   <slot>      — <one-line why>
+    • Catalog:   <slot>      — <why>
+    • Compute:   <slot>      — <why>
+    • Access:    <slot>      — <why>
+    • Hosting:   <slot>      — <why>
+    • Metadata:  <slot>      — <why>
+    • Namespace: <theme|owner>
+
+  Deviations from the default: <list, or "none — this is the recommended default">
+  Designed-in but built later: <e.g. Git-LFS via giftless, DCAT export, runtime/RBAC>
+```
+
+### 4. Persist the brief
+
+On confirmation, write the brief to `./ARCHITECTURE.md` in the working directory (create
+or overwrite) so it documents the decision and parameterizes the build skills. Keep it to
+the five slots + reasoning + the deferred items.
+
+### 5. Hand off to the build skills
+
+Map the brief to concrete next commands and offer to run the first one:
+
+| Decision | Next skill |
+|----------|-----------|
+| Scaffold the portal (always) | `/new-portal` — pass the name, description, and the chosen **namespace mode** |
+| Load the datasets | `/add-dataset` (per dataset) |
+| Charts / maps on a showcase | `/add-chart` · `/add-map` |
+| Backend with RBAC / existing CKAN | `/connect-ckan` |
+| OpenMetadata backend | `/connect-openmetadata` *(planned)* |
+| Custom / extended / DCAT metadata | `/define-schema` *(planned)* |
+| Ship it | `/deploy` (Cloudflare Pages, or Workers for the runtime mode) |
+
+End by recommending the exact sequence, e.g.:
+```
+Next: 1) /new-portal "<name>" (namespace: <mode>)
+      2) /add-dataset for each source
+      3) /deploy to Cloudflare Pages
+```
+If the user says "go", proceed to run `/new-portal` with the inferred name, description,
+and namespace mode (skipping the questions `/architect` already answered). Skills marked
+*(planned)* aren't built yet — name them as the intended path and note they're upcoming.
+
+## Example
+
+```
+/architect We're a national statistics office. ~200 datasets, mostly large CSVs
+(some GBs), updated quarterly, all public, and we must publish DCAT-AP for the
+EU data portal.
+```
+From this the skill infers: multi-publisher open-data portal, analytics-grade volume,
+publishing + harvesting. It recommends **Parquet on R2 + DuckLake + DuckDB**, static on
+**Cloudflare Pages**, **Frictionless + DCAT-AP** metadata, `owner` namespace — flags the
+DCAT export and Git-LFS ingest as designed-in/built-later — writes `ARCHITECTURE.md`, and
+hands off to `/new-portal` (namespace `owner`) then `/add-dataset`. With no arguments, it
+runs the four-round interview first.

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -17,9 +17,9 @@ input** — every question has a sensible default; say **"use defaults"** to tak
 See [the decision framework](../../site/content/docs/architecture/decision-framework.md)
 and [ROADMAP.md](../../ROADMAP.md) for the full model this skill encodes.
 
-## What it recommends — five slots
+## What it recommends — six slots
 
-Every recommendation fills five slots. The **bold** option is the default when nothing
+Every recommendation fills six slots. The **bold** option is the default when nothing
 pulls you off it.
 
 | Slot | Options (default in **bold**) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,7 @@ Add `npm install react-leaflet leaflet @types/leaflet` and import directly. No m
 ## Skills
 
 See `.claude/commands/` for available slash commands:
+- `/architect` — recommend a data architecture (storage/compute/catalog/access/hosting/metadata) from your needs, then hand off to the build skills (the advisory entry point)
 - `/new-portal` — scaffold a new PortalJS data portal from a brief
 - `/add-dataset` — add a dataset (CSV/TSV/JSON/GeoJSON) to an existing portal
 - `/add-chart` — add a chart (line/bar/area/pie/scatter) to a dataset page via recharts

--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -22,6 +22,10 @@
       {
         "title": "Core concepts",
         "href": "/docs/core-concepts"
+      },
+      {
+        "title": "Architecture decision framework",
+        "href": "/docs/architecture/decision-framework"
       }
     ]
   },
@@ -31,6 +35,10 @@
       {
         "title": "Skills reference",
         "href": "/docs/skills"
+      },
+      {
+        "title": "/architect",
+        "href": "/docs/skills/architect"
       },
       {
         "title": "/new-portal",

--- a/site/content/docs/skills/architect.md
+++ b/site/content/docs/skills/architect.md
@@ -1,0 +1,60 @@
+---
+metatitle: /architect – Recommend a Data-Portal Architecture from Your Needs
+metadescription: The /architect skill interviews you about what you're building, what your data is, and what it's for, then recommends a concrete stack — storage, compute, catalog, access, hosting, metadata — and hands off to the build skills.
+title: /architect
+description: The advisory entry point — turns three questions about your needs into a concrete, scaffoldable architecture, then hands off to the build skills.
+---
+
+`/architect` is the **advisory** skill. Before you scaffold anything, it works out
+*what* to build: from what you're building, what your data is, and what it's for, it
+recommends a concrete architecture across six slots — storage, catalog, compute, access,
+hosting, and metadata — then hands off to the build skills like
+[`/new-portal`](/docs/skills/new-portal). It **decides**; it doesn't build.
+
+It's interactive: if your brief is thin it interviews you in short rounds, echoes an
+architecture brief back for confirmation, and never dead-ends on missing input — every
+question has a sensible default. See the
+[architecture decision framework](/docs/architecture/decision-framework) for the full
+model it encodes.
+
+## When to use it
+
+Run it **first**, when you're unsure how to set up a portal — especially the data
+infrastructure underneath it (files vs Git-LFS vs a lakehouse vs a warehouse; static vs
+runtime; which metadata standard). If you already know what you want, skip straight to
+[`/new-portal`](/docs/skills/new-portal).
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| What you're building | No | Kind of portal + one or many publishers. Asked if missing. |
+| Your data | No | Size, shape, update cadence, count, sensitivity. Point at files and it inspects them. |
+| What it's for | No | Publishing, analytics, redistribution/harvesting, compliance. |
+| Constraints | No | Team/budget, cloud preference (default Cloudflare), existing backend. |
+
+Nothing is required — with no input it runs the four-round interview.
+
+## What it produces
+
+- An **architecture brief** filling six slots, with one-line reasoning per slot and any
+  deviations from the opinionated default called out. The default stack is
+  `git + giftless/R2 + Parquet + DuckLake + DuckDB`, static on Cloudflare Pages, with
+  Frictionless metadata — kept S3-compatible so R2 is never a hard lock-in.
+- An `ARCHITECTURE.md` written to your project documenting the decision.
+- A **handoff**: the exact next commands (`/new-portal` with the inferred namespace mode,
+  `/add-dataset`, `/connect-ckan`, `/deploy`, …), and an offer to run the first one.
+
+## Example
+
+```
+/architect We're a national statistics office. ~200 datasets, mostly large CSVs
+(some GBs), updated quarterly, all public, and we must publish DCAT-AP for the EU
+data portal.
+```
+
+It infers a multi-publisher open-data portal with analytics-grade data and harvesting
+needs, and recommends **Parquet on R2 + DuckLake + DuckDB**, static on **Cloudflare
+Pages**, **Frictionless + DCAT-AP** metadata, and an `owner` namespace — flagging the
+DCAT export and Git-LFS ingest as designed-in but built later — then hands off to
+[`/new-portal`](/docs/skills/new-portal).

--- a/tests/skill-triggering/prompts/architect.txt
+++ b/tests/skill-triggering/prompts/architect.txt
@@ -1,0 +1,1 @@
+We're standing up a data portal for our agency and have a few hundred datasets, some of them pretty large. We're not sure whether to use a data warehouse, a lakehouse, or just plain files, and how to host it. Can you help us figure out the right setup before we start building?

--- a/tests/skill-triggering/run-all.sh
+++ b/tests/skill-triggering/run-all.sh
@@ -8,6 +8,7 @@ PROMPTS="$SCRIPT_DIR/prompts"
 
 # One entry per shipped skill (.claude/commands/*.md).
 SKILLS=(
+  architect
   new-portal
   add-dataset
   add-chart


### PR DESCRIPTION
Builds **Phase 1** of the roadmap (#1539): the **advisory layer**. `/architect` is the entry point that recommends a data-portal architecture from the user's needs, then hands off to the build skills. It **decides**; it doesn't build.

## The skill
`.claude/commands/architect.md` — interactive, encodes the [decision framework](https://github.com/datopian/portaljs/blob/main/site/content/docs/architecture/decision-framework.md):

- **4-round interview** (building · data · use · constraints), one round at a time, skips what `$ARGUMENTS` answers, inspects files the user names (`du`/`wc -l`) to ground the data questions, and **never dead-ends** — every question has a default ("use defaults").
- **Six-slot recommendation** (storage · catalog · compute · access · hosting · metadata) via first-match rules, with the opinionated default = `git + giftless/R2 + Parquet + DuckLake + DuckDB`, static on **Cloudflare Pages**, Frictionless metadata — kept **S3-compatible** so R2 is never a hard lock-in. Private data → runtime + backend RBAC on Workers.
- Echoes an **architecture brief** for confirmation, writes **`ARCHITECTURE.md`**, and **hands off**: the exact next commands (`/new-portal` with the inferred namespace mode, `/add-dataset`, `/connect-ckan`, `/deploy`), with `/define-schema` + `/connect-openmetadata` named as planned.

## Wiring
- Registered first in `.claude-plugin/plugin.json` (+ updated plugin description).
- **Skill-triggering test:** `prompts/architect.txt` (a naive 'help me decide the setup' prompt) + `architect` added to `run-all.sh`.
- `CLAUDE.md` skills list updated (advisory entry point).
- **Docs:** `docs/skills/architect.md`; also wired `/architect` **and** the previously-orphaned `decision-framework` page into `docs-sidebar.json`.

## Not in this PR (by design)
The build-layer skills the brief hands off to (`/define-schema`, `/connect-openmetadata`) and the storage+compute impls (Git-LFS/giftless, DuckLake/DuckDB) are later phases — `/architect` names them as the intended path. Per the locked decision, giftless is **designed-in now, built later**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/architect` skill: interactive advisory flow that interviews users, recommends a six-slot data-portal architecture, generates an architecture brief, persists confirmed designs, and proposes next build commands.

* **Documentation**
  * Added comprehensive docs and sidebar entry explaining when/how to use `/architect`, inputs/outputs, examples, and resulting architecture artifacts.

* **Tests**
  * Added prompt and integrated the `/architect` skill into automated skill-run tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->