### PR TITLE
feat(catalog): data-provider contract — decouple the surfaces from the source

### DIFF
--- a/examples/portaljs-catalog/lib/datasets.ts
+++ b/examples/portaljs-catalog/lib/datasets.ts
@@ -1,41 +1,19 @@
-import manifest from '../datasets.json'
+// Portal config + presentation helpers for datasets.
+//
+// The DATA itself is read through the provider seam in lib/providers (so a
+// backend can replace the static source without touching any page). This module
+// holds only the provider-independent bits: the Dataset shape, the namespace
+// mode, and the canonical URL helper.
 
-export type Dataset = {
-  slug: string
-  namespace: string
-  name: string
-  description?: string
-  file: string
-  format: 'csv' | 'tsv' | 'json' | 'geojson'
-}
+import type { Dataset } from './providers'
 
-// The manifest is the single source of truth for the catalog. Add datasets by
-// dropping the file in /public/data and appending an entry to datasets.json —
-// no new page file needed (pages/[owner]/[slug].tsx renders every entry).
-const datasets = manifest as Dataset[]
+export type { Dataset } from './providers'
 
 // A portal uses exactly ONE namespace mode. Set to 'theme' for a single-publisher
 // portal (datasets grouped by subject) or 'owner' for a multi-publisher portal
 // (datasets grouped by who published them). This only changes the showcase
 // metadata label ("Theme" vs "Owner") — the URL is always /@<namespace>/<slug>.
 export const NAMESPACE_TYPE: 'theme' | 'owner' = 'theme'
-
-export function getDatasets(): Dataset[] {
-  return datasets
-}
-
-export function getDataset(slug: string): Dataset | undefined {
-  return datasets.find((d) => d.slug === slug)
-}
-
-// Resolve a dataset by its (namespace, slug) pair, which is unique across the
-// manifest. Used by the showcase route to map /@<namespace>/<slug> back to data.
-export function getDatasetByNamespace(
-  namespace: string,
-  slug: string
-): Dataset | undefined {
-  return datasets.find((d) => d.namespace === namespace && d.slug === slug)
-}
 
 // Canonical URL for a dataset's showcase page. Datasets are namespaced under `@`
 // so they never collide with regular content/static pages (which never start

--- a/examples/portaljs-catalog/lib/providers/README.md
+++ b/examples/portaljs-catalog/lib/providers/README.md
@@ -1,0 +1,73 @@
+# Data providers
+
+The **data-provider contract** is the seam that keeps a PortalJS portal decoupled
+from where its data lives. The three surfaces — the home page, the `/search`
+catalog, and the `/@<namespace>/<slug>` showcase — read datasets **only** through a
+`DataProvider`. Swap the provider and the source of data changes without touching a
+single page.
+
+```
+   the three surfaces
+   Home /      Catalog /search      Showcase /@<ns>/<slug>
+      |              |                      |
+      +--------------+----------------------+
+                     |  import { provider }
+              +------v-------+
+              | DataProvider |   <- the contract (types.ts)
+              +------+-------+
+       +----------+--+-----------+--------------+
+       |          |              |              |
+  StaticProvider CKAN      OpenMetadata    git-LFS + R2    ...future
+  (datasets.json)(api)        (api)        (object store)
+```
+
+## The contract
+
+```ts
+interface DataProvider {
+  readonly name: string
+  readonly capabilities: ProviderCapabilities   // search · query · write · rbac
+  listDatasets(): Promise<Dataset[]>
+  getDataset(namespace: string, slug: string): Promise<Dataset | null>
+  search(query: DatasetQuery): Promise<Dataset[]>
+}
+```
+
+See [`types.ts`](./types.ts) for the full definitions and
+[`static-provider.ts`](./static-provider.ts) for the default implementation.
+
+## Capabilities map onto the storage + compute spectrum
+
+A provider declares what it can do; surfaces and skills branch on the flags rather
+than sniffing the provider type. (See `ROADMAP.md` for the spectrum.)
+
+| Flag | Off (static default) | On |
+|------|----------------------|----|
+| `search` | catalog filters client-side over `listDatasets()` | provider does server-side / faceted search |
+| `query` | flat-file preview only | structured queries (DuckDB / a datastore) |
+| `write` | datasets added via git (a PR) | create/update at runtime (e.g. CKAN API) |
+| `rbac` | fully public | backend owns access control (needs the runtime mode) |
+
+`search` / `write` / `rbac` being on generally implies the **opt-in runtime mode**
+(SSR / API routes) rather than a purely static build — private data and live writes
+can't live in a public static bundle.
+
+## Adding a provider
+
+1. Create `lib/providers/<name>-provider.ts` implementing `DataProvider`.
+2. Set its `capabilities` honestly — surfaces rely on them.
+3. Select it in [`index.ts`](./index.ts)'s `getProvider()`, usually behind an env var.
+
+### Backends on the roadmap
+
+- **CKAN** — `listDatasets`/`getDataset` map to `package_list`/`package_show`,
+  `search` to `package_search` (`capabilities.search = true`). Adds `rbac` and, via
+  the datastore, `query`. Wired by the `/connect-ckan` skill.
+- **OpenMetadata** — its REST API for catalog + governance metadata; owns its own
+  `rbac`.
+- **git-LFS + object store (R2)** — same model as `StaticProvider` (datasets.json +
+  Frictionless metadata in git) but the bytes live in object storage via Git LFS
+  (e.g. [giftless](https://github.com/datopian/giftless) → R2). The on-ramp to a
+  Parquet-on-R2 + DuckLake + DuckDB lakehouse, where `query` turns on.
+
+Keep object storage **S3-compatible** so R2 is the default but never a hard lock-in.

--- a/examples/portaljs-catalog/lib/providers/index.ts
+++ b/examples/portaljs-catalog/lib/providers/index.ts
@@ -1,0 +1,30 @@
+import { StaticProvider } from './static-provider'
+import type { DataProvider } from './types'
+
+export type {
+  DataProvider,
+  Dataset,
+  DatasetQuery,
+  ProviderCapabilities,
+} from './types'
+
+// Select the active data provider. The three surfaces consume the portal's data
+// ONLY through this, so swapping the source never touches a page.
+//
+// Today there is one provider — StaticProvider, the git/static default that reads
+// datasets.json. A backend provider (CKAN, OpenMetadata, or a git-LFS +
+// object-store source) implements the same DataProvider interface and is selected
+// here, typically driven by an env var, e.g.:
+//
+//   export function getProvider(): DataProvider {
+//     if (process.env.CKAN_URL) return new CkanProvider(process.env.CKAN_URL)
+//     return new StaticProvider()
+//   }
+//
+// See ./README.md for the contract and a guide to adding one.
+export function getProvider(): DataProvider {
+  return new StaticProvider()
+}
+
+// The singleton the pages import.
+export const provider: DataProvider = getProvider()

--- a/examples/portaljs-catalog/lib/providers/static-provider.ts
+++ b/examples/portaljs-catalog/lib/providers/static-provider.ts
@@ -1,0 +1,49 @@
+import manifest from '../../datasets.json'
+import type {
+  DataProvider,
+  Dataset,
+  DatasetQuery,
+  ProviderCapabilities,
+} from './types'
+
+// The default provider: a read-only, build-time source backed by datasets.json
+// (the git/static tier). The manifest is the single source of truth — add
+// datasets by dropping the file in /public/data and appending an entry, no page
+// file needed. A git-LFS + object-store (e.g. R2) source is the same model with
+// the bytes living outside the repo; it would implement this same interface.
+const datasets = manifest as Dataset[]
+
+export class StaticProvider implements DataProvider {
+  readonly name = 'static'
+
+  readonly capabilities: ProviderCapabilities = {
+    search: false, // the catalog page filters client-side over listDatasets()
+    query: false, // flat-file preview only (no DuckDB / datastore yet)
+    write: false, // datasets are added via git (a PR), not at runtime
+    rbac: false, // fully public
+  }
+
+  async listDatasets(): Promise<Dataset[]> {
+    return datasets
+  }
+
+  async getDataset(namespace: string, slug: string): Promise<Dataset | null> {
+    return (
+      datasets.find((d) => d.namespace === namespace && d.slug === slug) ?? null
+    )
+  }
+
+  async search({ q, namespace, format }: DatasetQuery): Promise<Dataset[]> {
+    const needle = q?.trim().toLowerCase()
+    return datasets.filter((d) => {
+      if (namespace && d.namespace !== namespace) return false
+      if (format && d.format !== format) return false
+      if (!needle) return true
+      return (
+        d.name.toLowerCase().includes(needle) ||
+        d.namespace.toLowerCase().includes(needle) ||
+        (d.description ?? '').toLowerCase().includes(needle)
+      )
+    })
+  }
+}

--- a/examples/portaljs-catalog/lib/providers/types.ts
+++ b/examples/portaljs-catalog/lib/providers/types.ts
@@ -1,0 +1,59 @@
+// The data-provider contract.
+//
+// The three surfaces (home, the /search catalog, and the /@<namespace>/<slug>
+// showcase) read the portal's data ONLY through a DataProvider. This is the seam
+// that keeps PortalJS decoupled: the static/git default and any backend (CKAN,
+// OpenMetadata, a git-LFS + object-store source) implement the same interface, so
+// swapping where data comes from never touches a page.
+
+export type Dataset = {
+  slug: string
+  namespace: string
+  name: string
+  description?: string
+  file: string
+  format: 'csv' | 'tsv' | 'json' | 'geojson'
+}
+
+// A discovery query against the catalog. The static provider filters in memory;
+// a backend provider translates these to its own search API (e.g. CKAN
+// package_search, faceted by namespace/format).
+export type DatasetQuery = {
+  q?: string
+  namespace?: string
+  format?: Dataset['format']
+}
+
+// What a provider can do beyond the read-only static baseline. Surfaces and skills
+// branch on these instead of sniffing the provider type — they map onto the
+// storage + compute spectrum in ROADMAP.md.
+export type ProviderCapabilities = {
+  // Server-side / full-text search. When false, the catalog page filters
+  // client-side over listDatasets() (the static default).
+  search: boolean
+  // Structured data queries beyond a flat-file preview (e.g. DuckDB or a
+  // datastore) — the data-query contract plugs in here.
+  query: boolean
+  // Create/update datasets at runtime (e.g. the CKAN API). Git-based portals
+  // "write" by opening a PR, not through this, so the static provider is false.
+  write: boolean
+  // The backend owns access control; the portal surfaces it. Requires the
+  // opt-in runtime mode (private data can't live in a public static bundle).
+  rbac: boolean
+}
+
+export interface DataProvider {
+  readonly name: string
+  readonly capabilities: ProviderCapabilities
+
+  // The full catalog. Used at build time by the catalog and showcase routes.
+  listDatasets(): Promise<Dataset[]>
+
+  // Resolve one dataset by its (namespace, slug) pair, which is unique across
+  // the catalog. Returns null when nothing matches.
+  getDataset(namespace: string, slug: string): Promise<Dataset | null>
+
+  // Discovery. The static provider implements this in memory; a backend
+  // delegates to its search service.
+  search(query: DatasetQuery): Promise<Dataset[]>
+}

--- a/examples/portaljs-catalog/pages/[owner]/[slug].tsx
+++ b/examples/portaljs-catalog/pages/[owner]/[slug].tsx
@@ -2,19 +2,16 @@ import Head from 'next/head'
 import Link from 'next/link'
 import type { GetStaticPaths, GetStaticProps } from 'next'
 import { Table } from '../../components/Table'
-import {
-  NAMESPACE_TYPE,
-  getDatasetByNamespace,
-  getDatasets,
-  type Dataset,
-} from '../../lib/datasets'
+import { NAMESPACE_TYPE, type Dataset } from '../../lib/datasets'
+import { provider } from '../../lib/providers'
 
 export const getStaticPaths: GetStaticPaths = async () => {
+  const datasets = await provider.listDatasets()
   return {
     // The `owner` segment carries the `@` prefix so the generated URL is
     // /@<namespace>/<slug> — namespacing datasets under `@` keeps them from
     // colliding with regular content/static pages (which never start with `@`).
-    paths: getDatasets().map((d) => ({
+    paths: datasets.map((d) => ({
       params: { owner: '@' + d.namespace, slug: d.slug },
     })),
     fallback: false,
@@ -25,7 +22,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // Strip the leading `@` from the owner segment to recover the namespace,
   // then resolve the dataset by its (namespace, slug) pair.
   const namespace = String(params?.owner ?? '').replace(/^@/, '')
-  const dataset = getDatasetByNamespace(namespace, String(params?.slug))
+  const dataset = await provider.getDataset(namespace, String(params?.slug))
   if (!dataset) return { notFound: true }
   return { props: { dataset } }
 }

--- a/examples/portaljs-catalog/pages/search.tsx
+++ b/examples/portaljs-catalog/pages/search.tsx
@@ -3,10 +3,11 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import DebouncedInput from '../components/ui/DebouncedInput'
-import { datasetHref, getDatasets, type Dataset } from '../lib/datasets'
+import { datasetHref, type Dataset } from '../lib/datasets'
+import { provider } from '../lib/providers'
 
 export async function getStaticProps() {
-  return { props: { datasets: getDatasets() } }
+  return { props: { datasets: await provider.listDatasets() } }
 }
 
 export default function Search({ datasets }: { datasets: Dataset[] }) {
@@ -21,9 +22,10 @@ export default function Search({ datasets }: { datasets: Dataset[] }) {
     setQuery(typeof q === 'string' ? q : '')
   }, [router.isReady, router.query.q])
 
-  // Client-side full-text filter over the manifest. This is the seam where a
-  // proper search backend or faceted search (by namespace, format, tags, …)
-  // would slot in later — swap this useMemo for a query to that service.
+  // Client-side full-text filter over the datasets the provider returned. A
+  // provider whose capabilities.search is true would instead call
+  // provider.search({ q, … }) server-side (full-text / faceted by namespace,
+  // format, tags) — the static provider filters here in the browser.
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
     if (!q) return datasets


### PR DESCRIPTION
Builds **Phase 2** of the roadmap (#1539): the **data-provider contract** — the seam everything else plugs through. The three surfaces now read datasets **only** through a `DataProvider`, so a backend can replace the static source without touching a page.

## What's added — `examples/portaljs-catalog/lib/providers/`
- **`types.ts`** — the contract: `listDatasets()` · `getDataset(ns, slug)` · `search(query)`, a `DatasetQuery`, and `ProviderCapabilities` (`search` · `query` · `write` · `rbac`) that map onto the storage+compute spectrum.
- **`static-provider.ts`** — `StaticProvider`, the git/static default over `datasets.json` (all capabilities false: client-side filter, flat-file preview, PR-based writes, public).
- **`index.ts`** — `getProvider()` selector + the `provider` singleton; documents how a CKAN / OpenMetadata / git-LFS+R2 provider is selected here (env-driven).
- **`README.md`** — the contract, the capabilities↔spectrum map, and a guide to adding a backend.

## Refactor (behavior unchanged)
- **`lib/datasets.ts`** slimmed to pure helpers (`Dataset` re-export, `NAMESPACE_TYPE`, `datasetHref`); data access moved to the provider.
- **`pages/search.tsx`** + **`pages/[owner]/[slug].tsx`** now `await provider.listDatasets()/getDataset()`. The catalog's client-side filter stays (and now documents that a `capabilities.search` provider would do it server-side).
- Verified: `next build` still prerenders all **7** pages (home, /search, the three `/@reference/*` showcases, 404).

## Designed-in, built later
CKAN / OpenMetadata / **git-LFS+R2 (via giftless)** providers are specified by the interface + capability flags + the README, not yet implemented — per the locked decision (giftless designed-in now, built later). Next phases — DuckDB data-query and the metadata profile — plug into this same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the dataset loading system to use a provider-based architecture, decoupling the portal from specific data storage implementations and enabling support for multiple backend sources in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->