### PR TITLE
feat(catalog): DuckDB-Wasm data-query layer (opt-in compute)

### DIFF
--- a/examples/portaljs-catalog/components/DataExplorer.tsx
+++ b/examples/portaljs-catalog/components/DataExplorer.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react'
+import LoadingSpinner from './ui/LoadingSpinner'
+import { DuckDbQuery } from '../lib/query/duckdb'
+import type { Dataset } from '../lib/datasets'
+
+// A DuckDB-Wasm-backed data view for a dataset's showcase. Loads the file into an
+// in-browser DuckDB, previews it, and lets the visitor run SQL against the table
+// `data` — all client-side, no server. Rendered in place of the flat <Table />
+// when the portal's DATA_QUERY engine is 'duckdb' (see lib/datasets.ts). Import it
+// via next/dynamic with { ssr: false } so DuckDB only loads in the browser.
+
+const PREVIEW_LIMIT = 50
+
+export default function DataExplorer({ dataset }: { dataset: Dataset }) {
+  const url = `/data/${dataset.file}`
+  const defaultSql = `SELECT * FROM data LIMIT ${PREVIEW_LIMIT}`
+
+  // One engine instance per source file.
+  const engine = useMemo(() => new DuckDbQuery(), [url])
+
+  const [draft, setDraft] = useState(defaultSql)
+  const [columns, setColumns] = useState<string[]>([])
+  const [rows, setRows] = useState<Record<string, unknown>[]>([])
+  const [total, setTotal] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // Open the file once, then run the default preview + a row count.
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    ;(async () => {
+      try {
+        await engine.open({ url, format: dataset.format })
+        const count = await engine.query('SELECT count(*) AS n FROM data')
+        const res = await engine.query(defaultSql)
+        if (cancelled) return
+        setTotal(Number(count.rows[0]?.n ?? 0))
+        setColumns(res.columns)
+        setRows(res.rows)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+      void engine.close()
+    }
+  }, [engine, url, dataset.format, defaultSql])
+
+  const run = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await engine.query(draft)
+      setColumns(res.columns)
+      setRows(res.rows)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-2">
+        <label htmlFor="sql" className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+          SQL
+        </label>
+        {total !== null && (
+          <span className="text-xs text-gray-400">
+            {total.toLocaleString()} rows in <code className="bg-gray-100 px-1 rounded">data</code>
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <textarea
+          id="sql"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            // Cmd/Ctrl+Enter runs the query.
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') run()
+          }}
+          rows={2}
+          spellCheck={false}
+          className="w-full flex-1 rounded-md border border-gray-300 px-3 py-2 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          type="button"
+          onClick={run}
+          disabled={loading}
+          className="h-fit rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? 'Running…' : 'Run'}
+        </button>
+      </div>
+
+      <p className="mt-1 text-xs text-gray-400">
+        Query the dataset as the table <code className="bg-gray-100 px-1 rounded">data</code> — runs
+        in your browser with DuckDB-Wasm. ⌘/Ctrl + Enter to run.
+      </p>
+
+      <div className="mt-4">
+        {error ? (
+          <pre className="overflow-x-auto rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </pre>
+        ) : loading && rows.length === 0 ? (
+          <LoadingSpinner />
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-gray-400">No rows.</p>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  {columns.map((c) => (
+                    <th
+                      key={c}
+                      className="px-3 py-2 text-left font-semibold text-gray-600 whitespace-nowrap"
+                    >
+                      {c}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {rows.map((row, i) => (
+                  <tr key={i} className="hover:bg-gray-50">
+                    {columns.map((c) => (
+                      <td key={c} className="px-3 py-2 text-gray-800 whitespace-nowrap">
+                        {formatCell(row[c])}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}

--- a/examples/portaljs-catalog/lib/datasets.ts
+++ b/examples/portaljs-catalog/lib/datasets.ts
@@ -15,6 +15,15 @@ export type { Dataset } from './providers'
 // metadata label ("Theme" vs "Owner") — the URL is always /@<namespace>/<slug>.
 export const NAMESPACE_TYPE: 'theme' | 'owner' = 'theme'
 
+// The compute engine for a dataset's data on its showcase page:
+//   'flat'   — fetch the file and preview it (papaparse). Lightest; the default.
+//   'duckdb' — load the file into in-browser DuckDB-Wasm and expose a SQL query
+//              view (filter/aggregate/join over CSV/Parquet, no server).
+// This is the "compute" slot on the storage+compute spectrum (see ROADMAP.md);
+// `/architect` flips it to 'duckdb' when the portal needs querying, not just
+// preview. DuckDB only loads in the browser and only when a showcase renders.
+export const DATA_QUERY: 'flat' | 'duckdb' = 'flat'
+
 // Canonical URL for a dataset's showcase page. Datasets are namespaced under `@`
 // so they never collide with regular content/static pages (which never start
 // with `@`). See README for the routing rationale.

--- a/examples/portaljs-catalog/lib/query/duckdb.ts
+++ b/examples/portaljs-catalog/lib/query/duckdb.ts
@@ -17,43 +17,55 @@ export class DuckDbQuery implements DataQuery {
   private worker: Worker | null = null
 
   async open(source: QuerySource): Promise<void> {
+    // Tear down anything from a previous open() so a retry can't leak a worker
+    // or DB handle.
+    await this.close()
+
     const duckdb = await import('@duckdb/duckdb-wasm')
+    let workerUrl: string | null = null
+    try {
+      // Pick the best wasm bundle for this browser and spin up the worker from a
+      // Blob URL — avoids any bundler/worker configuration in the host app.
+      const bundles = duckdb.getJsDelivrBundles()
+      const bundle = await duckdb.selectBundle(bundles)
+      workerUrl = URL.createObjectURL(
+        new Blob([`importScripts("${bundle.mainWorker}");`], {
+          type: 'text/javascript',
+        })
+      )
+      this.worker = new Worker(workerUrl)
+      const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING)
+      this.db = new duckdb.AsyncDuckDB(logger, this.worker)
+      await this.db.instantiate(bundle.mainModule, bundle.pthreadWorker)
 
-    // Pick the best wasm bundle for this browser and spin up the worker from a
-    // Blob URL — avoids any bundler/worker configuration in the host app.
-    const bundles = duckdb.getJsDelivrBundles()
-    const bundle = await duckdb.selectBundle(bundles)
-    const workerUrl = URL.createObjectURL(
-      new Blob([`importScripts("${bundle.mainWorker}");`], {
-        type: 'text/javascript',
-      })
-    )
-    this.worker = new Worker(workerUrl)
-    const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING)
-    this.db = new duckdb.AsyncDuckDB(logger, this.worker)
-    await this.db.instantiate(bundle.mainModule, bundle.pthreadWorker)
-    URL.revokeObjectURL(workerUrl)
+      // Fetch the file and register it in DuckDB's virtual filesystem.
+      const res = await fetch(source.url)
+      if (!res.ok) {
+        throw new Error(`Failed to fetch ${source.url} (${res.status})`)
+      }
+      const buf = new Uint8Array(await res.arrayBuffer())
+      const isParquet = source.format === 'parquet'
+      const fname = isParquet ? 'data.parquet' : 'data.csv'
+      await this.db.registerFileBuffer(fname, buf)
 
-    // Fetch the file and register it in DuckDB's virtual filesystem.
-    const res = await fetch(source.url)
-    if (!res.ok) {
-      throw new Error(`Failed to fetch ${source.url} (${res.status})`)
+      // Materialize the file as the table `data`. read_csv_auto sniffs the
+      // schema; TSV is the same reader with a tab delimiter; Parquet is read
+      // directly.
+      const reader = isParquet
+        ? `read_parquet('${fname}')`
+        : source.format === 'tsv'
+        ? `read_csv_auto('${fname}', delim='\t')`
+        : `read_csv_auto('${fname}')`
+
+      this.conn = await this.db.connect()
+      await this.conn.query(`CREATE OR REPLACE TABLE data AS SELECT * FROM ${reader}`)
+    } catch (e) {
+      // Don't leave a half-initialized engine behind on failure.
+      await this.close()
+      throw e
+    } finally {
+      if (workerUrl) URL.revokeObjectURL(workerUrl)
     }
-    const buf = new Uint8Array(await res.arrayBuffer())
-    const isParquet = source.format === 'parquet'
-    const fname = isParquet ? 'data.parquet' : 'data.csv'
-    await this.db.registerFileBuffer(fname, buf)
-
-    // Materialize the file as the table `data`. read_csv_auto sniffs the schema;
-    // TSV is the same reader with a tab delimiter; Parquet is read directly.
-    const reader = isParquet
-      ? `read_parquet('${fname}')`
-      : source.format === 'tsv'
-      ? `read_csv_auto('${fname}', delim='\t')`
-      : `read_csv_auto('${fname}')`
-
-    this.conn = await this.db.connect()
-    await this.conn.query(`CREATE OR REPLACE TABLE data AS SELECT * FROM ${reader}`)
   }
 
   async query(sql: string): Promise<QueryResult> {

--- a/examples/portaljs-catalog/lib/query/duckdb.ts
+++ b/examples/portaljs-catalog/lib/query/duckdb.ts
@@ -1,0 +1,85 @@
+import type { DataQuery, QueryResult, QuerySource } from './types'
+
+// DuckDB-Wasm data-query engine: runs SQL over a dataset's CSV/TSV/Parquet
+// entirely in the browser — no server, no datastore. The wasm + worker bundles
+// are fetched on demand from jsDelivr (DuckDB's published CDN bundles), and
+// `@duckdb/duckdb-wasm` is imported dynamically, so nothing is added to the app
+// bundle until a query view actually mounts.
+//
+// This is the client-side rung of the compute spectrum. The same DataQuery
+// interface can later be implemented by a server-side / remote DuckDB (for large
+// data) or a backend datastore, without changing the UI that consumes it.
+export class DuckDbQuery implements DataQuery {
+  readonly engine = 'duckdb-wasm'
+
+  private db: any = null
+  private conn: any = null
+  private worker: Worker | null = null
+
+  async open(source: QuerySource): Promise<void> {
+    const duckdb = await import('@duckdb/duckdb-wasm')
+
+    // Pick the best wasm bundle for this browser and spin up the worker from a
+    // Blob URL — avoids any bundler/worker configuration in the host app.
+    const bundles = duckdb.getJsDelivrBundles()
+    const bundle = await duckdb.selectBundle(bundles)
+    const workerUrl = URL.createObjectURL(
+      new Blob([`importScripts("${bundle.mainWorker}");`], {
+        type: 'text/javascript',
+      })
+    )
+    this.worker = new Worker(workerUrl)
+    const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING)
+    this.db = new duckdb.AsyncDuckDB(logger, this.worker)
+    await this.db.instantiate(bundle.mainModule, bundle.pthreadWorker)
+    URL.revokeObjectURL(workerUrl)
+
+    // Fetch the file and register it in DuckDB's virtual filesystem.
+    const res = await fetch(source.url)
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${source.url} (${res.status})`)
+    }
+    const buf = new Uint8Array(await res.arrayBuffer())
+    const isParquet = source.format === 'parquet'
+    const fname = isParquet ? 'data.parquet' : 'data.csv'
+    await this.db.registerFileBuffer(fname, buf)
+
+    // Materialize the file as the table `data`. read_csv_auto sniffs the schema;
+    // TSV is the same reader with a tab delimiter; Parquet is read directly.
+    const reader = isParquet
+      ? `read_parquet('${fname}')`
+      : source.format === 'tsv'
+      ? `read_csv_auto('${fname}', delim='\t')`
+      : `read_csv_auto('${fname}')`
+
+    this.conn = await this.db.connect()
+    await this.conn.query(`CREATE OR REPLACE TABLE data AS SELECT * FROM ${reader}`)
+  }
+
+  async query(sql: string): Promise<QueryResult> {
+    if (!this.conn) throw new Error('Query engine is not open')
+    const table = await this.conn.query(sql)
+    const columns: string[] = table.schema.fields.map((f: any) => f.name)
+    const rows = table.toArray().map((row: any) => {
+      const obj = row.toJSON() as Record<string, unknown>
+      // Arrow returns BigInt for 64-bit ints; coerce so values render/serialize.
+      for (const key of Object.keys(obj)) {
+        if (typeof obj[key] === 'bigint') obj[key] = Number(obj[key])
+      }
+      return obj
+    })
+    return { columns, rows }
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.conn?.close()
+      await this.db?.terminate()
+      this.worker?.terminate()
+    } finally {
+      this.conn = null
+      this.db = null
+      this.worker = null
+    }
+  }
+}

--- a/examples/portaljs-catalog/lib/query/types.ts
+++ b/examples/portaljs-catalog/lib/query/types.ts
@@ -1,0 +1,36 @@
+// The data-query contract.
+//
+// Where the data-provider contract (lib/providers) is about *catalog metadata* —
+// which datasets exist — this is about a dataset's *data*: running structured
+// queries over it, beyond a flat-file preview.
+//
+// The flat/static default doesn't implement this (the showcase just previews the
+// CSV). The DuckDB engine (lib/query/duckdb.ts) runs SQL over CSV/Parquet entirely
+// in the browser; a backend datastore (e.g. CKAN's, or a server-side DuckDB) could
+// implement the same interface. This is the "compute" slot on the storage+compute
+// spectrum — see ROADMAP.md.
+
+export type QueryResult = {
+  columns: string[]
+  rows: Record<string, unknown>[]
+}
+
+export type QuerySource = {
+  // URL to the dataset file (e.g. /data/foo.csv, or a remote URL).
+  url: string
+  format: 'csv' | 'tsv' | 'json' | 'parquet' | string
+}
+
+export interface DataQuery {
+  // Engine identifier, e.g. 'duckdb-wasm'.
+  readonly engine: string
+
+  // Load a dataset's file and expose it as the SQL table `data`.
+  open(source: QuerySource): Promise<void>
+
+  // Run SQL against the opened source and return rows + column order.
+  query(sql: string): Promise<QueryResult>
+
+  // Release engine resources.
+  close(): Promise<void>
+}

--- a/examples/portaljs-catalog/package-lock.json
+++ b/examples/portaljs-catalog/package-lock.json
@@ -8,6 +8,7 @@
       "name": "__PROJECT_SLUG__",
       "version": "0.1.0",
       "dependencies": {
+        "@duckdb/duckdb-wasm": "^1.32.0",
         "@heroicons/react": "^2.0.0",
         "@tanstack/react-table": "^8.21.0",
         "next": "14.2.35",
@@ -38,6 +39,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz",
+      "integrity": "sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==",
+      "license": "MIT",
+      "dependencies": {
+        "apache-arrow": "^17.0.0"
       }
     },
     "node_modules/@heroicons/react": {
@@ -338,11 +348,22 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -386,6 +407,21 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -407,12 +443,50 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.cjs"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -565,6 +639,37 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -608,6 +713,72 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -733,6 +904,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -790,6 +979,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.4",
@@ -882,6 +1080,14 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -900,6 +1106,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -1513,6 +1725,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -1524,6 +1748,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/tailwindcss": {
@@ -1689,11 +1935,19 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -1733,6 +1987,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     }
   }
 }

--- a/examples/portaljs-catalog/package.json
+++ b/examples/portaljs-catalog/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@duckdb/duckdb-wasm": "^1.32.0",
     "@heroicons/react": "^2.0.0",
     "@tanstack/react-table": "^8.21.0",
     "next": "14.2.35",

--- a/examples/portaljs-catalog/pages/[owner]/[slug].tsx
+++ b/examples/portaljs-catalog/pages/[owner]/[slug].tsx
@@ -1,9 +1,17 @@
 import Head from 'next/head'
 import Link from 'next/link'
+import dynamic from 'next/dynamic'
 import type { GetStaticPaths, GetStaticProps } from 'next'
 import { Table } from '../../components/Table'
-import { NAMESPACE_TYPE, type Dataset } from '../../lib/datasets'
+import { DATA_QUERY, NAMESPACE_TYPE, type Dataset } from '../../lib/datasets'
 import { provider } from '../../lib/providers'
+
+// DuckDB only runs in the browser, so load the query view client-side. The chunk
+// (and DuckDB-Wasm) is only fetched when DATA_QUERY === 'duckdb' and a showcase
+// actually renders it — flat portals never pay for it.
+const DataExplorer = dynamic(() => import('../../components/DataExplorer'), {
+  ssr: false,
+})
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const datasets = await provider.listDatasets()
@@ -76,8 +84,11 @@ export default function DatasetPage({ dataset }: { dataset: Dataset }) {
           </div>
         </dl>
 
-        {/* Data preview */}
-        {tabular ? (
+        {/* Data preview — flat <Table /> by default, or a DuckDB-Wasm SQL
+            query view when the portal's DATA_QUERY engine is 'duckdb'. */}
+        {tabular && DATA_QUERY === 'duckdb' ? (
+          <DataExplorer dataset={dataset} />
+        ) : tabular ? (
           <Table url={url} fullWidth />
         ) : (
           <p className="text-gray-500">


### PR DESCRIPTION
Builds **Phase 3a** of the roadmap: a **data-query layer** with a client-side **DuckDB-Wasm** engine. A dataset showcase can now offer SQL over its CSV — filter/aggregate/join in the browser, no server, no datastore.

## What's added — `examples/portaljs-catalog`
- **`lib/query/types.ts`** — the `DataQuery` contract (`open` / `query` / `close`, `QueryResult`). The *compute* counterpart to the `DataProvider` *catalog* contract.
- **`lib/query/duckdb.ts`** — `DuckDbQuery`: dynamically imports `@duckdb/duckdb-wasm`, picks the right jsDelivr wasm bundle, starts the worker from a Blob URL (**no bundler/worker config, no COOP/COEP needed** — `selectBundle` avoids the SharedArrayBuffer path), registers the file, and exposes it as the SQL table `data` (`read_csv_auto` / TSV delim / `read_parquet`).
- **`components/DataExplorer.tsx`** — a client-only view: preview + row count + a SQL box (⌘/Ctrl+Enter to run), error surfacing, results table.
- **`lib/datasets.ts`** — new `DATA_QUERY: "flat" | "duckdb"` config (default **`flat`**).
- **`pages/[owner]/[slug].tsx`** — renders `DataExplorer` via `next/dynamic` (`ssr:false`) in place of the flat `<Table />` when `DATA_QUERY === "duckdb"`.

## Opt-in by design
Flat preview stays the lightweight default; the DuckDB chunk is **lazy** (dynamic import), so flat portals never pay for it. `/architect` flips `DATA_QUERY` to `duckdb` when the portal needs querying — this is the "compute" rung of the storage+compute spectrum, and the same `DataQuery` interface can later be implemented by server-side/remote DuckDB or a backend datastore. Pinned `@duckdb/duckdb-wasm@^1.32.0` (its npm `latest` tag is a `-dev` build).

## Verification
- ✅ `next build` prerenders all **7** pages with **both** `DATA_QUERY=flat` and `=duckdb`. First-load JS for the showcase is unchanged in flat mode (DuckDB stays in its own lazy chunk).
- ⚠️ **In-browser runtime QA pending.** I tried to smoke-test a live query via the local browser tool, but it crashed in my environment, so I could not confirm an actual query round-trip. The integration uses the standard documented DuckDB-Wasm pattern. **Recommended reviewer QA:** set `DATA_QUERY = "duckdb"`, `npm run dev`, open a showcase (e.g. `/@reference/co2-emissions`), confirm the preview loads and `SELECT * FROM data LIMIT 3` returns rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-browser SQL explorer: run custom SQL, view row counts, previews (first 50 rows), re-run queries, keyboard shortcut (Cmd/Ctrl+Enter), and see loading/error states.

* **Dependencies**
  * Added DuckDB WebAssembly support to enable client-side SQL querying of tabular datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->