### PR TITLE
feat(skills): /define-schema — author a dataset's Frictionless metadata profile (po-k07)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,7 @@
     "./.claude/commands/add-chart.md",
     "./.claude/commands/add-map.md",
     "./.claude/commands/connect-ckan.md",
+    "./.claude/commands/define-schema.md",
     "./.claude/commands/deploy.md",
     "./.claude/commands/check-data-quality.md"
   ]

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -159,7 +159,7 @@ Map the brief to concrete next commands and offer to run the first one:
 | Charts / maps on a showcase | `/add-chart` · `/add-map` |
 | Backend with RBAC / existing CKAN | `/connect-ckan` |
 | OpenMetadata backend | `/connect-openmetadata` *(planned)* |
-| Custom / extended / DCAT metadata | `/define-schema` *(planned)* |
+| Custom / extended / DCAT metadata | `/define-schema` — describe a dataset's fields + metadata (Frictionless; DCAT export built later) |
 | Ship it | `/deploy` (Cloudflare Pages, or Workers for the runtime mode) |
 
 End by recommending the exact sequence, e.g.:

--- a/.claude/commands/define-schema.md
+++ b/.claude/commands/define-schema.md
@@ -1,0 +1,235 @@
+---
+description: Define a dataset's metadata profile — infer a Frictionless Table Schema from its data, add Data Package metadata (license, sources, keywords), and write it into datasets.json so the showcase renders a typed field table. Extend or customize via the L0→L3 profile ladder.
+allowed-tools: Read, Write, Edit, Bash
+---
+
+# /define-schema
+
+The **authoring** skill for the metadata-profile contract (`lib/metadata`). Where
+[`/add-dataset`](/docs/skills/add-dataset) registers *that a dataset exists*, this skill
+describes *what its data means*: it infers a Frictionless **Table Schema** (fields, types,
+constraints) from the data, adds the **Data Package** descriptor fields a catalog surfaces
+(title, licenses, sources, keywords), and writes them onto the dataset's entry in
+`datasets.json`. The showcase at `/@<namespace>/<slug>` then renders a typed
+column/description table instead of a bare preview.
+
+The model is **Frictionless-native**. DCAT / DCAT-AP is a serialization layer on top
+(designed-in at `lib/metadata/dcat.ts`, built in the later DCAT-interop phase) — this
+skill authors the native model, not the export.
+
+The skill is **interactive** and **never dead-ends**: if the brief is thin it interviews
+in short rounds, infers sensible defaults from the data, echoes the schema for
+confirmation, and lets you reply **"use defaults"** to accept the inferred schema as-is.
+
+See [`lib/metadata/README.md`](https://github.com/datopian/portaljs/blob/main/examples/portaljs-catalog/lib/metadata/README.md)
+for the contract and the L0→L3 ladder.
+
+## The profile ladder — pick a level
+
+Most datasets want **L0**. Reach for higher levels only when you actually need them.
+
+| Level | What it is | When |
+|-------|-----------|------|
+| **L0** | Use the default `frictionless-tabular` profile as-is; just declare the dataset's schema + metadata. | Default. Tabular CSV/TSV with the standard Frictionless types. |
+| **L1** | Extend L0 — same default profile, plus a few extra package fields you care about. | You need extra descriptive metadata but standard validation is fine. |
+| **L2** | A fully custom profile (your own `schema` template + `validate()`), registered in `lib/metadata`. | A dataset type with validation rules L0 doesn't express. |
+| **L3** | Multiple profiles in the registry, resolved per dataset by its `profile` field. | A portal mixing dataset types, each with its own profile. |
+
+## Steps
+
+### 1. Gather input from `$ARGUMENTS` (interview if thin)
+
+Extract what's present:
+- `PORTAL_DIR` — portal directory (default: `.`)
+- `DATASET` — which dataset to describe, by `slug` or `namespace/slug`
+- `LEVEL` — `L0` (default) · `L1` · `L2` · `L3`
+
+If `DATASET` is missing, read `PORTAL_DIR/datasets.json` and ask which one (list the
+slugs), then wait:
+```
+Which dataset should I define a schema for? (reply with a slug, or "all" to do each in turn)
+  - country-codes        (reference)  — already has a schema
+  - population-2022       (reference)  — no schema yet
+  - co2-emissions         (reference)  — no schema yet
+You can also say "use defaults" and I'll infer the schema from the data and confirm it.
+```
+
+Don't ask about the level up front — default to **L0** and only offer to go higher in
+step 4 if the data or the user's answers call for it.
+
+### 2. Validate the portal directory
+
+The target must be a `portaljs-catalog` portal with the metadata contract. Confirm
+`PORTAL_DIR/datasets.json`, `PORTAL_DIR/lib/metadata/types.ts`, and
+`PORTAL_DIR/pages/[owner]/[slug].tsx` exist. If `lib/metadata/` is missing, the portal
+predates the metadata-profile contract — tell the user and offer to proceed by writing the
+schema onto `datasets.json` anyway (the fields are optional and ignored by older
+showcases) rather than failing.
+
+### 3. Infer the Table Schema from the data
+
+Locate the dataset entry in `datasets.json`, then read its file from
+`PORTAL_DIR/public/data/<file>`. For CSV/TSV, sample the header + first ~50 data rows:
+
+```bash
+# Replace FILE with PORTAL_DIR/public/data/<file>.
+head -1 FILE        # header → field names
+sed -n '2,51p' FILE # sample rows → infer types
+```
+
+Infer each field's `type` from the sampled values, using the contract's vocabulary
+(`lib/metadata/types.ts` → `FieldType`): `integer` if every value matches `^[+-]?\d+$`;
+`number` if numeric but not all integers; `year` if all 4-digit; `boolean` for
+true/false/yes/no/0/1; `date`/`datetime` if `Date.parse`-able; `geopoint` for `"lon, lat"`;
+otherwise `string`. When a column is empty or ambiguous, default to `string` — never guess
+wildly. (This mirrors `coercesTo()` in `frictionless-tabular.ts`, so an inferred schema
+validates clean against its own data.)
+
+Build a `TableSchema`:
+- One `Field` per column: `name` (exact header, spaces preserved), inferred `type`, and a
+  short `title` + `description` you draft from the column name and the dataset's purpose.
+- `constraints`: mark `required: true` for columns with no missing values in the sample;
+  `unique: true` for columns whose sampled values are all distinct; add a `pattern` only
+  when the values clearly fit one (e.g. uppercase codes `^[A-Z]{2}$`).
+- `primaryKey`: the column (or composite) that uniquely identifies a row, if obvious.
+
+For **JSON / GeoJSON** datasets, the L0 tabular profile doesn't apply — explain that
+schema authoring here covers tabular data, offer to capture package metadata only (step 5),
+and stop short of a `fields` schema.
+
+### 4. Confirm the schema (and offer to go beyond L0)
+
+Echo the inferred schema as a compact table for confirmation:
+```
+Inferred schema for <dataset> — say "go" to write it, or correct any field:
+
+  field        type      required  unique  notes
+  -----------  --------  --------  ------  -----------------------------
+  <name>       <type>    <y/n>     <y/n>   <title / pattern>
+  ...
+  primaryKey: <col(s) or none>
+
+This uses the default L0 'frictionless-tabular' profile.
+```
+Then, only if warranted, offer to go higher: "Want extra metadata fields (L1), or a custom
+profile with its own validation rules (L2/L3)?" Default stays **L0** if they say "go".
+
+### 5. Capture Data Package metadata
+
+Ask for the descriptor fields the showcase surfaces (all optional — Enter/"skip" to omit):
+```
+Optional dataset metadata (Enter to skip any):
+  - license      (e.g. ODbL-1.0, CC-BY-4.0)
+  - source(s)    (title + URL of where the data came from)
+  - keywords     (comma-separated)
+  - version      (e.g. 1.0.0)
+```
+Map answers to the `Dataset` fields `licenses[]` ({name,title,path}), `sources[]`
+({title,path}), `keywords[]`, `version` (and `modified` with today's date if the data was
+just updated).
+
+### 6. Write it into `datasets.json`
+
+Open `PORTAL_DIR/datasets.json` and update the target dataset's entry **in place**,
+preserving all other entries and the existing `slug`/`namespace`/`name`/`file`/`format`
+fields. Add:
+
+```json
+{
+  "...": "existing fields unchanged",
+  "profile": "frictionless-tabular",
+  "schema": {
+    "primaryKey": "<col or [cols]>",
+    "fields": [
+      { "name": "<col>", "type": "<type>", "title": "<title>", "description": "<desc>",
+        "constraints": { "required": true } }
+    ]
+  },
+  "licenses": [ { "name": "<id>", "title": "<title>", "path": "<url>" } ],
+  "sources":  [ { "title": "<title>", "path": "<url>" } ],
+  "keywords": ["..."],
+  "version": "<x.y.z>"
+}
+```
+
+This matches the extended `Dataset` shape in `lib/providers/types.ts`. Drop any field with
+no value (all are optional). Omit `profile` to let it default to `frictionless-tabular`, or
+set it explicitly for clarity. For an L2/L3 custom profile, set `profile` to that profile's
+id.
+
+**For L2 / L3 (custom profile):** scaffold a profile module and register it so the
+dataset's `profile` id resolves:
+- Write `PORTAL_DIR/lib/metadata/<profile-id>.ts` exporting a `MetadataProfile`
+  (`id`, `name`, `version`, optional pinned `schema`, and a `validate(input)` — start from
+  `frictionlessTabularProfile`'s shape and add the extra rules).
+- Register it once at load: in `PORTAL_DIR/lib/metadata/registry.ts` import the profile and
+  add `registerProfile(<profile>)`, or call `registerProfile` from app bootstrap.
+- Keep L0 as the fallback — `getProfile(id)` already returns the default for unknown ids.
+
+### 7. Validate the schema against the data (optional but recommended)
+
+The L0 profile can check the schema against the dataset's rows (type-coercion + the
+constraint subset). Offer a quick check using the contract:
+
+```bash
+cd PORTAL_DIR
+npx tsx -e '
+  import { getProfile } from "./lib/metadata";
+  // load the dataset entry + parse its CSV rows, then:
+  // const r = getProfile(ds.profile).validate({ schema: ds.schema, rows });
+  // console.log(JSON.stringify(r, null, 2));
+' 2>/dev/null || echo "skip if tsx is unavailable; the build check below still covers types"
+```
+If validation reports `errors`, surface them (wrong type, missing required, duplicate key)
+and fix the schema (e.g. relax a `type`, drop a `required`) before writing. Warnings are
+advisory.
+
+### 8. Verify the build
+
+```bash
+cd PORTAL_DIR
+npx next build > /tmp/define-schema-build.log 2>&1
+BUILD_EXIT=$?
+tail -20 /tmp/define-schema-build.log
+```
+The common failure is malformed JSON in `datasets.json` (a stray comma) or a type that
+isn't in `FieldType`. Fix and rebuild before reporting success.
+
+### 9. Report
+
+```
+✓ Schema defined: <dataset>
+  - Profile:  <profile-id> (L<level>)
+  - Fields:   <n> (<list of names>)
+  - Metadata: <license / sources / keywords / version that were set, or "none">
+  - Manifest: datasets.json (entry updated in place)
+  - Showcase: /@<namespace>/<slug> now renders a typed field table
+
+Next: run `npm run dev` and open the showcase to see the schema table, or run
+/define-schema on the next dataset. Need machine-readable export for harvesting?
+DCAT serialization is designed-in (lib/metadata/dcat.ts) and built in the DCAT-interop phase.
+```
+
+## Notes
+
+- **One source of truth.** The schema lives on the dataset's `datasets.json` entry, read
+  through the data provider unchanged — no page edits, no separate schema file (except an
+  L2/L3 custom profile module in `lib/metadata`).
+- **Degrades cleanly.** Every metadata field is optional; a dataset with none still lists,
+  previews, and renders — the showcase just omits the schema table.
+- **Frictionless-native, DCAT on top.** This authors the native model. `toDCAT`/`fromDCAT`
+  in `lib/metadata/dcat.ts` are the interop layer (DCAT-AP / national / domain profiles),
+  designed-in now and built in the DCAT-interop phase — don't hand-write DCAT here.
+- **Backends.** A CKAN / OpenMetadata provider maps its native metadata onto these same
+  fields; this skill is for the static/git-authored catalog.
+
+## Example
+
+```
+/define-schema population-2022
+```
+The skill reads `public/data/population-2022.csv`, infers fields (e.g. `country: string`,
+`population: integer`), drafts titles/descriptions, asks for a license + source, writes the
+schema + metadata onto the `population-2022` entry in `datasets.json` under the default
+`frictionless-tabular` profile, validates it against the rows, verifies the build, and
+reports the showcase URL. With no arguments it lists the datasets and asks which to describe.

--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -61,6 +61,10 @@
         "href": "/docs/skills/connect-ckan"
       },
       {
+        "title": "/define-schema",
+        "href": "/docs/skills/define-schema"
+      },
+      {
         "title": "/deploy",
         "href": "/docs/skills/deploy"
       }

--- a/site/content/docs/skills.md
+++ b/site/content/docs/skills.md
@@ -18,14 +18,15 @@ portal. You describe intent; the skill writes the code.
   [`/new-portal`](/docs/skills/new-portal), load data with
   [`/add-dataset`](/docs/skills/add-dataset), enrich with
   [`/add-chart`](/docs/skills/add-chart) or [`/add-map`](/docs/skills/add-map),
-  swap the data source with [`/connect-ckan`](/docs/skills/connect-ckan), and go
-  live with [`/deploy`](/docs/skills/deploy).
+  describe it with [`/define-schema`](/docs/skills/define-schema), swap the data
+  source with [`/connect-ckan`](/docs/skills/connect-ckan), and go live with
+  [`/deploy`](/docs/skills/deploy).
 - **Plain, editable output.** Every skill writes ordinary Next.js, Tailwind, and
   React code into your project — no magic runtime interpreting a config at request
   time, nothing feature-gated behind a hosted product. You can clone, fork, and
   hand-edit everything they produce. This is what _AI-native, not AI-only_ means.
 
-## The six skills
+## The skills
 
 | Skill | What it does |
 | ----- | ------------ |
@@ -34,6 +35,7 @@ portal. You describe intent; the skill writes the code.
 | [`/add-chart`](/docs/skills/add-chart) | Add a line, bar, area, pie, or scatter chart to a dataset page using `recharts`. |
 | [`/add-map`](/docs/skills/add-map) | Render a GeoJSON dataset on an interactive Leaflet map and register it on the home page. |
 | [`/connect-ckan`](/docs/skills/connect-ckan) | Wire the portal to a [CKAN](/ckan) backend over its API instead of static files. |
+| [`/define-schema`](/docs/skills/define-schema) | Infer a Frictionless Table Schema from a dataset's data, add license/source/keyword metadata, and surface a typed field table on its showcase. |
 | [`/deploy`](/docs/skills/deploy) | Build and publish the portal to Vercel or any static host — with a live URL at the end. |
 
 ## Author your own

--- a/site/content/docs/skills/connect-ckan.md
+++ b/site/content/docs/skills/connect-ckan.md
@@ -75,4 +75,4 @@ It verifies the build before reporting success. When it finishes:
   backend.
 - **[`/deploy`](/docs/skills/deploy)** — publish the connected portal.
 
-<DocsPagination prev="/docs/skills/add-map" next="/docs/skills/deploy" />
+<DocsPagination prev="/docs/skills/add-map" next="/docs/skills/define-schema" />

--- a/site/content/docs/skills/define-schema.md
+++ b/site/content/docs/skills/define-schema.md
@@ -1,0 +1,86 @@
+---
+metatitle: /define-schema – Author a Dataset's Frictionless Metadata Profile
+metadescription: The /define-schema skill infers a Frictionless Table Schema from your data, adds Data Package metadata (license, sources, keywords), and writes it into datasets.json so the showcase renders a typed field reference. Extend or customize via the L0→L3 profile ladder.
+title: /define-schema
+description: Describe what a dataset's data means — infer a Frictionless Table Schema from the file, add license/source/keyword metadata, and surface a typed field table on the showcase.
+---
+
+`/define-schema` is the **authoring** skill for the metadata-profile contract. Where
+[`/add-dataset`](/docs/skills/add-dataset) registers *that a dataset exists*, this skill
+describes *what its data means*: it infers a Frictionless **Table Schema** (fields, types,
+constraints) from the data, adds the **Data Package** descriptor fields a catalog surfaces
+(title, licenses, sources, keywords), and writes them onto the dataset's entry in
+`datasets.json`. The showcase at `/@<namespace>/<slug>` then renders a typed
+column/description table instead of a bare preview.
+
+The model is **Frictionless-native**. DCAT / DCAT-AP is a serialization layer on top
+(designed-in at `lib/metadata/dcat.ts`, built in the later DCAT-interop phase) — this skill
+authors the native model, not the export.
+
+It's interactive and never dead-ends: if your brief is thin it lists your datasets, infers
+a schema from the data, echoes it for confirmation, and lets you reply "use defaults" to
+accept the inferred schema as-is.
+
+## When to use it
+
+Run it after [`/add-dataset`](/docs/skills/add-dataset), once a dataset is in the catalog
+and you want its showcase to document the columns — their types, meaning, and constraints —
+and carry proper license/source metadata. Skip it for a quick throwaway preview; reach for
+it when the dataset is something other people will read or reuse.
+
+## The profile ladder
+
+Most datasets want **L0**. Higher levels are there when you need them.
+
+| Level | What it is | When |
+| ----- | ---------- | ---- |
+| **L0** | The default `frictionless-tabular` profile; just declare the dataset's schema + metadata. | Default. Standard tabular CSV/TSV. |
+| **L1** | Extend L0 with extra package fields. | Need more descriptive metadata, standard validation is fine. |
+| **L2** | A fully custom profile (own `schema` + `validate()`) in `lib/metadata`. | A dataset type with validation rules L0 doesn't express. |
+| **L3** | Multiple profiles in the registry, resolved per dataset by its `profile` field. | A portal mixing dataset types, each with its own profile. |
+
+See the [metadata contract README](https://github.com/datopian/portaljs/blob/main/examples/portaljs-catalog/lib/metadata/README.md)
+for the ladder in full.
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Dataset | No | Which dataset (slug or `namespace/slug`). Asked — with a list — if missing. |
+| Portal directory | No | Defaults to the current directory. |
+| Level | No | Defaults to **L0**; the skill offers to go higher only when warranted. |
+
+Nothing is required — with no input it lists your datasets and asks which to describe.
+
+## What it produces
+
+- A **Frictionless Table Schema** inferred from the data — one field per column with an
+  inferred `type`, drafted `title`/`description`, and `constraints` (`required`, `unique`,
+  `pattern`, `primaryKey`) — confirmed with you before writing.
+- **Data Package metadata** — `licenses`, `sources`, `keywords`, `version` — captured in a
+  short optional prompt.
+- An **updated `datasets.json`**: the schema + metadata written onto the dataset's entry in
+  place, matching the extended `Dataset` shape. For L2/L3, a custom profile module in
+  `lib/metadata` plus its registration.
+- A **typed field table** on the `/@<namespace>/<slug>` showcase, replacing the bare preview.
+
+## Example
+
+```
+/define-schema population-2022
+```
+
+The skill reads `public/data/population-2022.csv`, infers the fields (e.g.
+`country: string`, `population: integer`), drafts titles and descriptions, asks for a
+license and source, writes the schema + metadata onto the `population-2022` entry under the
+default `frictionless-tabular` profile, validates it against the rows, verifies the build,
+and reports the showcase URL. With no arguments it lists the datasets and asks which to
+describe.
+
+## Where to go next
+
+- **[`/add-dataset`](/docs/skills/add-dataset)** — add another dataset to describe.
+- **[`/architect`](/docs/skills/architect)** — decide the metadata strategy (Frictionless,
+  extended, custom, or multi-profile + DCAT) before authoring.
+
+<DocsPagination prev="/docs/skills/connect-ckan" next="/docs/skills/deploy" />

--- a/site/content/docs/skills/deploy.md
+++ b/site/content/docs/skills/deploy.md
@@ -78,4 +78,4 @@ Force a target, or promote a preview to production:
 - **[`/connect-ckan`](/docs/skills/connect-ckan)** — point the portal at a live
   backend before deploying.
 
-<DocsPagination prev="/docs/skills/connect-ckan" />
+<DocsPagination prev="/docs/skills/define-schema" />

--- a/tests/skill-triggering/prompts/define-schema.txt
+++ b/tests/skill-triggering/prompts/define-schema.txt
@@ -1,0 +1,1 @@
+I've added a few CSV datasets to my portal but the dataset pages just show a plain table. I want to properly describe each column — its type, what it means, which ones are required — and add a license and the source it came from, so the page shows a real field reference. Can you set that up from the data?

--- a/tests/skill-triggering/run-all.sh
+++ b/tests/skill-triggering/run-all.sh
@@ -14,6 +14,7 @@ SKILLS=(
   add-chart
   add-map
   connect-ckan
+  define-schema
   deploy
   check-data-quality
 )


### PR DESCRIPTION
The **authoring/build layer** for the metadata-profile contract that landed in #1543's successor (commit `434a1ad`, po-2ta). Closes **po-k07**.

## What it does
Where `/add-dataset` registers *that a dataset exists*, `/define-schema` describes *what its data means*: it infers a Frictionless **Table Schema** (fields, types, constraints) from the dataset's file, adds **Data Package** metadata (license, sources, keywords, version), and writes them onto the dataset's entry in `datasets.json` — so the `/@<namespace>/<slug>` showcase renders a typed field table instead of a bare preview.

- **Interactive, never dead-ends** — lists datasets, infers a schema from the data, confirms before writing, `"use defaults"` accepts the inferred schema. Type inference mirrors `coercesTo()` in `frictionless-tabular.ts`, so an inferred schema validates clean against its own rows.
- **L0 default**, with the L0→L3 ladder (extend / custom profile / registry) offered only when warranted. L2/L3 scaffold a profile module + `registerProfile()`.
- **Frictionless-native authoring.** DCAT export stays designed-in (`lib/metadata/dcat.ts`), built in the later DCAT-interop phase — the skill does not hand-write DCAT.

## Registration (mirrors the other skills)
- `.claude/commands/define-schema.md` — the skill
- `.claude-plugin/plugin.json` — command registered
- `tests/skill-triggering/{run-all.sh, prompts/define-schema.txt}` — naive-trigger test
- `site/content/docs/skills/define-schema.md` + sidebar + skills index
- `/architect` handoff table — `/define-schema` no longer marked *(planned)*

Docs/skill-content only — no app code touched, so the catalog build is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `/define-schema` skill for automated dataset schema inference and metadata enrichment, enabling users to add structured field descriptions, licenses, and sources to portal dataset pages.

* **Documentation**
  * Added comprehensive documentation and guides for the new `/define-schema` skill.
  * Updated skill navigation and workflow documentation to include the new capability.

* **Tests**
  * Added test coverage for the new `/define-schema` skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->