### PR TITLE
docs(architecture): cost & lock-in rationale for the decision framework

### DIFF
--- a/site/content/docs/architecture/decision-framework.md
+++ b/site/content/docs/architecture/decision-framework.md
@@ -81,10 +81,10 @@ warehouse, and worth weighing explicitly when you architect a portal.
 **Cloud warehouses bill per scan.** Snowflake, BigQuery, Databricks et al. charge for
 the compute a query consumes, and a heavy join/aggregate re-scans the data **every time
 it runs**. Put that on a schedule and the cost compounds. A community-reported example
-(see the [DuckDB vs. warehouse thread](https://www.reddit.com/r/DuckDB/comments/1u0c8g0/why_pay_snowflake_to_scan_a_billion_rows_every_15/)):
 a 1-billion-row join + aggregate that returns a ~2,000-row summary needs a Large
-warehouse (~8 credits/hr, ~2 min/run) to finish — about **0.27 credits/run**. Refreshed
-every 15 minutes that's ~26 credits/day ≈ **$75/day ≈ $27,000/year — from one pipeline**.
+warehouse (~8 credits/hr, ~2 min/run) to finish — about **0.27 credits/run**. Using the
+thread's assumptions (credit price and schedule, as reported in June 2026), refreshing
+every 15 minutes is ~26 credits/day (about **$75/day ≈ $27,000/year**) for one pipeline.
 
 **Push the compute to where the data lives.** The same workload runs in ~23 seconds on
 a laptop with DuckDB reading Parquet directly — no cluster, no warehouse. The expensive

--- a/site/content/docs/architecture/decision-framework.md
+++ b/site/content/docs/architecture/decision-framework.md
@@ -91,8 +91,9 @@ a laptop with DuckDB reading Parquet directly — no cluster, no warehouse. The 
 scan/join/aggregate happens locally (or at the edge in a Worker); the warehouse, if it's
 in the picture at all, only **stores the small answer**. Recurring compute cost →
 effectively **zero**. This is exactly PortalJS's compute slot: DuckDB-Wasm in the
-browser, escalating to server-side DuckDB only when data size forces it — never a
-per-query warehouse charge for what a reader filters or aggregates.
+browser, escalating to server-side DuckDB only when data size forces it — avoiding
+warehouse per-scan charges for reader-driven filtering/aggregation, while still paying
+normal runtime compute where the query executes.
 
 **Open formats + object storage = no lock-in.** Parquet on S3-compatible storage (R2 by
 default) is portable; you rent **storage** (cheap, flat) rather than **per-query compute**

--- a/site/content/docs/architecture/decision-framework.md
+++ b/site/content/docs/architecture/decision-framework.md
@@ -72,6 +72,39 @@ When in doubt, PortalJS recommends the **open, cheap, composable** path:
 - **Tiny, static, a handful of CSVs** → don't reach for the lakehouse; flat files +
   client-side preview is the whole stack.
 
+## Cost & lock-in: why we push compute to the data
+
+The defaults above aren't just an aesthetic preference for open source — they follow
+from how the bill works. It's the main reason `/architect` reaches for DuckDB over a
+warehouse, and worth weighing explicitly when you architect a portal.
+
+**Cloud warehouses bill per scan.** Snowflake, BigQuery, Databricks et al. charge for
+the compute a query consumes, and a heavy join/aggregate re-scans the data **every time
+it runs**. Put that on a schedule and the cost compounds. A community-reported example
+(see the [DuckDB vs. warehouse thread](https://www.reddit.com/r/DuckDB/comments/1u0c8g0/why_pay_snowflake_to_scan_a_billion_rows_every_15/)):
+a 1-billion-row join + aggregate that returns a ~2,000-row summary needs a Large
+warehouse (~8 credits/hr, ~2 min/run) to finish — about **0.27 credits/run**. Refreshed
+every 15 minutes that's ~26 credits/day ≈ **$75/day ≈ $27,000/year — from one pipeline**.
+
+**Push the compute to where the data lives.** The same workload runs in ~23 seconds on
+a laptop with DuckDB reading Parquet directly — no cluster, no warehouse. The expensive
+scan/join/aggregate happens locally (or at the edge in a Worker); the warehouse, if it's
+in the picture at all, only **stores the small answer**. Recurring compute cost →
+effectively **zero**. This is exactly PortalJS's compute slot: DuckDB-Wasm in the
+browser, escalating to server-side DuckDB only when data size forces it — never a
+per-query warehouse charge for what a reader filters or aggregates.
+
+**Open formats + object storage = no lock-in.** Parquet on S3-compatible storage (R2 by
+default) is portable; you rent **storage** (cheap, flat) rather than **per-query compute**
+from a single vendor. You can move the bytes to any S3 target and keep the same engine.
+
+**The honest trade-off.** A warehouse still earns its place for genuinely huge data,
+concurrent multi-user SQL, or a team already invested in one — that's the "existing
+warehouse / SQL-native team" deviation above, and the data-query contract has a datastore
+implementation for it. The point isn't *never a warehouse*; it's **don't pay a warehouse
+to re-scan a billion rows every 15 minutes when DuckDB over Parquet does it for the price
+of object storage.** When unsure, the cheap, portable path is the default.
+
 ## The `/architect` skill (design)
 
 A new advisory skill that runs the framework as an interview and emits an


### PR DESCRIPTION
Captures the **cost-of-compute / OSS-vs-warehouse** argument in the architecture decision framework, so it's available when architecting a portal and `/architect` can weigh and cite it.

Adds a **"Cost & lock-in: why we push compute to the data"** section to `site/content/docs/architecture/decision-framework.md`:

- **Warehouses bill per scan** — a scheduled heavy join/aggregate re-scans every run; on a 15-min refresh the cost compounds. Community example (cited): a 1B-row pipeline ≈ **$27k/yr from one pipeline**.
- **Push compute to where the data lives** — DuckDB over Parquet does the scan/join/aggregate locally or at the edge; the warehouse (if any) only stores the small result → recurring compute ≈ **$0**. This is exactly PortalJS's compute slot.
- **Open formats + object storage = no lock-in** — Parquet on S3-compatible R2 means you rent storage, not per-query compute.
- **Honest trade-off kept** — a warehouse still earns its place for huge data / concurrent SQL / existing investment (the already-documented deviation); the data-query contract has a datastore impl.

Docs-only; reinforces the already-locked opinionated default with the *why*. Cites the [DuckDB vs. warehouse community thread](https://www.reddit.com/r/DuckDB/comments/1u0c8g0/why_pay_snowflake_to_scan_a_billion_rows_every_15/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the architecture decision framework with a new "Cost & lock-in" section: explains recurring compute cost behavior, contrasts per-scan warehouses vs. local Parquet-based reads, highlights portability via open object formats, and clarifies when warehouse-style compute remains preferable (very large, highly concurrent, or SQL-native teams).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->