### PR TITLE
feat(catalog): DCAT interop — toDCAT/fromDCAT + harvestable /catalog.jsonld (po-mo2)

### DIFF
--- a/examples/portaljs-catalog/.gitignore
+++ b/examples/portaljs-catalog/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 .env
 .env.local
 out/
+
+# Generated DCAT harvest document (npm run generate:dcat → predev/prebuild)
+public/catalog.jsonld

--- a/examples/portaljs-catalog/lib/metadata/README.md
+++ b/examples/portaljs-catalog/lib/metadata/README.md
@@ -14,8 +14,8 @@ The model is **Frictionless-native**: a dataset is authored as a Frictionless Da
 Package — a [Table Schema](https://specs.frictionlessdata.io/table-schema/)
 (`fields[]` with types + constraints) plus the Data Package descriptor fields a
 catalog cares about (`title`, `licenses`, `sources`, `keywords`, ...). **DCAT /
-DCAT-AP is a serialization + harvest layer ON TOP of this model** — designed-in here
-(`dcat.ts`), built in the later DCAT-interop phase.
+DCAT-AP is a serialization + harvest layer ON TOP of this model** (`dcat.ts`) — the
+portal emits a DCAT-3 `/catalog.jsonld` so external catalogs can harvest it.
 
 ```
    the showcase surface  /@<namespace>/<slug>
@@ -131,16 +131,36 @@ getProfile(undefined)                // -> the L0 default
 getProfile('nope')                   // unknown -> falls back to L0 default
 ```
 
-## DCAT interop (designed-in, not built)
+## DCAT interop
 
-`dcat.ts` pins the contract — `DcatDataset` types + `toDCAT()` / `fromDCAT()`
-signatures (which currently throw). DCAT/DCAT-AP is how a portal **exposes** its
-catalog for harvest (e.g. a `/catalog.jsonld`) and **ingests** from external
-catalogs. The Frictionless-native fields map cleanly onto it (`title→dct:title`,
-`keywords→dcat:keyword`, `licenses→dct:license`, `file/format→dcat:distribution`).
-The mapping is built in the DCAT-interop phase — see the sketch in `dcat.ts`.
+`dcat.ts` is the serialization + harvest layer over the Frictionless-native model.
+DCAT/DCAT-AP is how a portal **exposes** its catalog for harvest and **ingests**
+from external catalogs. The Frictionless fields map onto DCAT-3 JSON-LD
+(`title→dct:title`, `keywords→dcat:keyword`, `licenses→dct:license`,
+`sources→dct:source`, `file/format→dcat:distribution`).
+
+```ts
+import { toDCAT, fromDCAT, toDCATCatalog, fromDCATCatalog } from './lib/metadata'
+
+toDCAT(dataset, { baseUrl, identifier, landingPage })  // one Frictionless dataset → dcat:Dataset
+toDCATCatalog(datasets, { baseUrl, title })            // the whole catalog → dcat:Catalog
+fromDCAT(node) / fromDCATCatalog(catalog)              // harvest/import back to Frictionless
+```
+
+**The harvest endpoint.** `scripts/generate-dcat.ts` reads the catalog through the
+data provider and writes `public/catalog.jsonld` (a DCAT-3 `dcat:Catalog`). It runs
+automatically on `predev`/`prebuild`, so the file is always fresh — and because it's
+a static file it harvests on **any** host (static Cloudflare Pages, a CDN, a Worker),
+no runtime required. Set `SITE_URL` to emit absolute landing/download URLs; without
+it links are root-relative (fine for same-origin harvest).
+
+**What DCAT does not carry.** DCAT has no inline field schema — the Table Schema is
+referenced via a distribution's `dcat:describedBy`, not embedded. So `fromDCAT`
+recovers package metadata + the distribution (file/format), **not** the field-level
+schema. That asymmetry is intrinsic to DCAT.
 
 ## Out of scope here
 
-- `/define-schema` authoring skill (the interview/build layer) — separate bead.
-- The actual DCAT mapping — DCAT-interop phase.
+- `/define-schema` authoring skill (the interview/build layer) — see that skill.
+- A full DCAT-AP profile (mandatory EU-portal classes/properties) — this is the
+  pragmatic DCAT-3 core; extend `dcat.ts` for a specific national/domain profile.

--- a/examples/portaljs-catalog/lib/metadata/dcat.ts
+++ b/examples/portaljs-catalog/lib/metadata/dcat.ts
@@ -1,50 +1,70 @@
-// DCAT interop — DESIGNED-IN, NOT BUILT.
+// DCAT interop — the serialization + harvest layer.
 //
 // The metadata-profile contract (./types.ts) is Frictionless-native: a dataset is
 // authored as a Frictionless Data Package (Table Schema + descriptor fields). DCAT
 // / DCAT-AP is the *serialization + harvest* layer ON TOP of that model — the
-// interop format a portal exposes (e.g. a /catalog.jsonld) so external catalogs and
-// government data portals can harvest it, and ingests when importing from one.
+// interop format a portal exposes (a `/catalog.jsonld`) so external catalogs and
+// government data portals (e.g. data.europa.eu) can harvest it, and ingests from
+// when importing.
 //
-// This file pins the contract — the types and the two function signatures — so the
-// rest of the system can reference DCAT without it existing yet. The actual mapping
-// is built in the DCAT-interop phase (a separate bead). DO NOT implement the field
-// mapping here.
+// This maps the Frictionless-native shape to/from DCAT-3 JSON-LD. The mapping is
+// deliberately pragmatic, not a complete DCAT-AP profile: it covers the
+// package-level descriptor fields + distributions that round-trip cleanly. DCAT
+// does not carry a full Table Schema inline — the field-level schema is linked via
+// a distribution's `dcat:describedBy` (a Frictionless resource descriptor) rather
+// than embedded, so `fromDCAT` recovers package metadata + distribution, not the
+// field schema. That asymmetry is intrinsic to DCAT, not a shortcut here.
 //
-// Mapping sketch (for the implementer of that phase):
-//   PackageMetadata.title       -> dct:title
-//   PackageMetadata.description  -> dct:description
-//   PackageMetadata.keywords[]   -> dcat:keyword[]
-//   PackageMetadata.licenses[]   -> dct:license
-//   PackageMetadata.modified     -> dct:modified
-//   Dataset.file/format          -> dcat:distribution[] (dcat:Distribution)
-//   TableSchema.fields[]         -> a Frictionless schema reference or
-//                                   csvw/dcat:Distribution describedBy link
 // Spec: https://www.w3.org/TR/vocab-dcat-3/ · DCAT-AP for EU data portals.
 
-import type { PackageMetadata, TableSchema } from './types'
+import type { License, PackageMetadata, TableSchema } from './types'
 
-// A minimal JSON-LD-shaped DCAT Dataset node. Expanded in the DCAT-interop phase.
+// --- JSON-LD shapes (DCAT-3) ---------------------------------------------------
+
 export type DcatDistribution = {
   '@type': 'dcat:Distribution'
+  'dct:title'?: string
+  // Where to get the bytes (the raw file) and where to land (the showcase page).
+  'dcat:downloadURL'?: string
   'dcat:accessURL'?: string
-  'dcat:mediaType'?: string
+  // Human label (e.g. "CSV") and IANA media type (e.g. "text/csv").
   'dct:format'?: string
+  'dcat:mediaType'?: string
+  // Link to a schema description (Frictionless resource descriptor / CSVW), when
+  // the field schema is published as its own document.
+  'dcat:describedBy'?: string
 }
 
 export type DcatDataset = {
-  '@context'?: Record<string, string>
+  '@id'?: string
   '@type': 'dcat:Dataset'
+  'dct:identifier'?: string
   'dct:title'?: string
   'dct:description'?: string
   'dcat:keyword'?: string[]
+  // A license URI (Frictionless license.path) or its SPDX id (license.name).
   'dct:license'?: string
+  // URLs the data was sourced from (Frictionless sources[].path).
+  'dct:source'?: string[]
+  'dct:issued'?: string
   'dct:modified'?: string
+  'dcat:version'?: string
+  'dcat:landingPage'?: string
   'dcat:distribution'?: DcatDistribution[]
 }
 
+export type DcatCatalog = {
+  '@context': Record<string, string>
+  '@type': 'dcat:Catalog'
+  'dct:title'?: string
+  'dct:description'?: string
+  'dct:modified'?: string
+  'dcat:dataset': DcatDataset[]
+}
+
 // The Frictionless-native shape this maps to/from. Mirrors what a Dataset carries
-// (kept structural to avoid a dependency on lib/providers).
+// (kept structural to avoid a dependency on lib/providers — the dependency runs the
+// other way).
 export type FrictionlessLike = PackageMetadata & {
   name?: string
   file?: string
@@ -52,17 +72,187 @@ export type FrictionlessLike = PackageMetadata & {
   schema?: TableSchema
 }
 
-const NOT_BUILT =
-  'DCAT interop is designed-in but not yet built — see lib/metadata/dcat.ts and the DCAT-interop phase.'
+// A catalog entry adds the routing identity (namespace/slug) the catalog uses to
+// build per-dataset landing pages + download URLs. A providers' Dataset is
+// structurally assignable to this.
+export type CatalogEntry = FrictionlessLike & {
+  namespace?: string
+  slug?: string
+  description?: string
+}
+
+// The JSON-LD context: the prefixes used above. Kept compact and stable so a
+// harvester resolves the terms.
+export const DCAT_CONTEXT: Record<string, string> = {
+  dcat: 'http://www.w3.org/ns/dcat#',
+  dct: 'http://purl.org/dc/terms/',
+}
+
+// --- format helpers ------------------------------------------------------------
+
+const MEDIA_TYPES: Record<string, string> = {
+  csv: 'text/csv',
+  tsv: 'text/tab-separated-values',
+  json: 'application/json',
+  geojson: 'application/geo+json',
+}
+
+const FORMAT_LABELS: Record<string, string> = {
+  csv: 'CSV',
+  tsv: 'TSV',
+  json: 'JSON',
+  geojson: 'GeoJSON',
+}
+
+function mediaType(format?: string): string | undefined {
+  return format ? MEDIA_TYPES[format.toLowerCase()] : undefined
+}
+
+function formatLabel(format?: string): string | undefined {
+  if (!format) return undefined
+  return FORMAT_LABELS[format.toLowerCase()] ?? format.toUpperCase()
+}
+
+// Invert a media type back to the short format token (for fromDCAT).
+function formatFromMedia(media?: string): string | undefined {
+  if (!media) return undefined
+  const hit = Object.entries(MEDIA_TYPES).find(([, m]) => m === media)
+  return hit?.[0]
+}
+
+// Join a base URL and a path without doubling or dropping the slash. An empty base
+// yields a root-relative path (fine for same-origin harvest).
+function joinUrl(base: string | undefined, path: string): string {
+  const p = path.replace(/^\/+/, '')
+  if (!base) return `/${p}`
+  return `${base.replace(/\/+$/, '')}/${p}`
+}
+
+// First license as a single URI/id (DCAT dct:license is one value).
+function licenseUri(licenses?: License[]): string | undefined {
+  const l = licenses?.[0]
+  return l?.path ?? l?.name
+}
+
+// Drop undefined/empty entries so the JSON-LD stays clean.
+function compact<T extends Record<string, unknown>>(obj: T): T {
+  for (const k of Object.keys(obj)) {
+    if (obj[k] === undefined) delete obj[k]
+    else if (Array.isArray(obj[k]) && (obj[k] as unknown[]).length === 0) delete obj[k]
+  }
+  return obj
+}
+
+// --- mapping -------------------------------------------------------------------
+
+export type ToDcatOptions = {
+  // Absolute site origin (e.g. https://portal.example.org). Empty → root-relative.
+  baseUrl?: string
+  // The dataset's showcase/landing page (defaults to the download URL).
+  landingPage?: string
+  // Stable identifier (e.g. "<namespace>/<slug>").
+  identifier?: string
+  // Explicit download URL for the data file (defaults to `${baseUrl}/data/<file>`).
+  downloadUrl?: string
+}
 
 // Serialize a dataset's Frictionless-native metadata to a DCAT Dataset node.
-// Built in the DCAT-interop phase.
-export function toDCAT(_dataset: FrictionlessLike): DcatDataset {
-  throw new Error(NOT_BUILT)
+export function toDCAT(input: FrictionlessLike, opts: ToDcatOptions = {}): DcatDataset {
+  const downloadURL =
+    opts.downloadUrl ?? (input.file ? joinUrl(opts.baseUrl, `data/${input.file}`) : undefined)
+  const landingPage = opts.landingPage
+
+  const distribution: DcatDistribution | undefined = input.file
+    ? compact({
+        '@type': 'dcat:Distribution',
+        'dct:title': input.title ?? input.name,
+        'dcat:downloadURL': downloadURL,
+        'dcat:accessURL': landingPage ?? downloadURL,
+        'dct:format': formatLabel(input.format),
+        'dcat:mediaType': mediaType(input.format),
+      } as DcatDistribution)
+    : undefined
+
+  return compact({
+    '@id': landingPage ?? (opts.identifier ? joinUrl(opts.baseUrl, opts.identifier) : undefined),
+    '@type': 'dcat:Dataset',
+    'dct:identifier': opts.identifier,
+    'dct:title': input.title ?? input.name,
+    'dct:description': input.description,
+    'dcat:keyword': input.keywords,
+    'dct:license': licenseUri(input.licenses),
+    'dct:source': input.sources
+      ?.map((s) => s.path ?? s.title)
+      .filter((v): v is string => Boolean(v)),
+    'dct:issued': input.created,
+    'dct:modified': input.modified,
+    'dcat:version': input.version,
+    'dcat:landingPage': landingPage,
+    'dcat:distribution': distribution ? [distribution] : undefined,
+  } as DcatDataset)
 }
 
 // Parse a DCAT Dataset node into the Frictionless-native shape (harvest / import).
-// Built in the DCAT-interop phase.
-export function fromDCAT(_dcat: DcatDataset): FrictionlessLike {
-  throw new Error(NOT_BUILT)
+// Recovers package metadata + the first distribution's file/format. The field-level
+// Table Schema is NOT recovered (DCAT links it via describedBy rather than carrying
+// it inline) — re-author or fetch the linked schema separately if needed.
+export function fromDCAT(node: DcatDataset): FrictionlessLike {
+  const dist = node['dcat:distribution']?.[0]
+  const downloadURL = dist?.['dcat:downloadURL']
+  const file = downloadURL ? downloadURL.split('/').pop() || undefined : undefined
+  const format =
+    formatFromMedia(dist?.['dcat:mediaType']) ??
+    (dist?.['dct:format'] ? dist['dct:format'].toLowerCase() : undefined)
+
+  const license = node['dct:license']
+  return compact({
+    name: node['dct:title'] ?? node['dct:identifier'],
+    title: node['dct:title'],
+    description: node['dct:description'],
+    keywords: node['dcat:keyword'],
+    licenses: license
+      ? [/^https?:\/\//.test(license) ? { path: license } : { name: license }]
+      : undefined,
+    sources: node['dct:source']?.map((p) => ({ title: p, path: p })),
+    created: node['dct:issued'],
+    modified: node['dct:modified'],
+    version: node['dcat:version'],
+    file,
+    format,
+  } as FrictionlessLike)
+}
+
+export type ToDcatCatalogOptions = {
+  baseUrl?: string
+  title?: string
+  description?: string
+  modified?: string
+}
+
+// Serialize the whole catalog to a DCAT Catalog node — the harvestable document a
+// portal exposes at `/catalog.jsonld`. Each entry's landing page + download URL are
+// derived from its namespace/slug/file so harvesters get resolvable links.
+export function toDCATCatalog(
+  entries: CatalogEntry[],
+  opts: ToDcatCatalogOptions = {}
+): DcatCatalog {
+  return compact({
+    '@context': DCAT_CONTEXT,
+    '@type': 'dcat:Catalog',
+    'dct:title': opts.title,
+    'dct:description': opts.description,
+    'dct:modified': opts.modified,
+    'dcat:dataset': entries.map((e) => {
+      const identifier =
+        e.namespace && e.slug ? `${e.namespace}/${e.slug}` : e.slug ?? e.name
+      const landingPage =
+        e.namespace && e.slug ? joinUrl(opts.baseUrl, `@${e.namespace}/${e.slug}`) : undefined
+      return toDCAT(e, { baseUrl: opts.baseUrl, identifier, landingPage })
+    }),
+  } as DcatCatalog)
+}
+
+// Parse a DCAT Catalog node back into Frictionless-native entries (bulk harvest).
+export function fromDCATCatalog(catalog: DcatCatalog): FrictionlessLike[] {
+  return (catalog['dcat:dataset'] ?? []).map(fromDCAT)
 }

--- a/examples/portaljs-catalog/lib/metadata/index.ts
+++ b/examples/portaljs-catalog/lib/metadata/index.ts
@@ -3,7 +3,8 @@
 // A dataset declares a Frictionless Table Schema + Data Package descriptor fields;
 // a MetadataProfile names + validates that shape; the registry resolves a profile
 // by id (default = the L0 Frictionless Tabular profile). DCAT interop is the
-// serialization layer on top, designed-in here and built later. See ./README.md.
+// serialization + harvest layer on top (toDCAT/toDCATCatalog → a /catalog.jsonld).
+// See ./README.md.
 
 export type {
   FieldType,
@@ -31,7 +32,14 @@ export {
 export {
   toDCAT,
   fromDCAT,
+  toDCATCatalog,
+  fromDCATCatalog,
+  DCAT_CONTEXT,
   type DcatDataset,
   type DcatDistribution,
+  type DcatCatalog,
   type FrictionlessLike,
+  type CatalogEntry,
+  type ToDcatOptions,
+  type ToDcatCatalogOptions,
 } from './dcat'

--- a/examples/portaljs-catalog/package-lock.json
+++ b/examples/portaljs-catalog/package-lock.json
@@ -25,6 +25,7 @@
         "autoprefixer": "^10.0.0",
         "postcss": "^8.0.0",
         "tailwindcss": "^3.0.0",
+        "tsx": "^4.19.0",
         "typescript": "^5.0.0"
       }
     },
@@ -48,6 +49,448 @@
       "license": "MIT",
       "dependencies": {
         "apache-arrow": "^17.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@heroicons/react": {
@@ -839,6 +1282,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -1920,6 +2405,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/examples/portaljs-catalog/package.json
+++ b/examples/portaljs-catalog/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "generate:dcat": "tsx scripts/generate-dcat.ts",
+    "predev": "npm run generate:dcat",
     "dev": "next dev",
+    "prebuild": "npm run generate:dcat",
     "build": "next build",
     "start": "next start"
   },
@@ -25,6 +28,7 @@
     "autoprefixer": "^10.0.0",
     "postcss": "^8.0.0",
     "tailwindcss": "^3.0.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.0.0"
   }
 }

--- a/examples/portaljs-catalog/scripts/generate-dcat.ts
+++ b/examples/portaljs-catalog/scripts/generate-dcat.ts
@@ -1,0 +1,42 @@
+// Build-time generator for the DCAT harvest document.
+//
+// Reads the catalog through the data provider (the same seam the pages use) and
+// writes public/catalog.jsonld — a DCAT-3 JSON-LD Catalog. Because it's a static
+// file it harvests on ANY host (static Cloudflare Pages, a CDN, a Worker), with no
+// runtime needed. Wired into `predev`/`prebuild` so it's always fresh.
+//
+// Set SITE_URL (e.g. https://portal.example.org) to emit absolute landing/download
+// URLs; without it, links are root-relative (fine for same-origin harvest).
+//
+// Run: `tsx scripts/generate-dcat.ts` (invoked automatically by npm pre-scripts).
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { provider } from '../lib/providers'
+import { toDCATCatalog, type CatalogEntry } from '../lib/metadata'
+
+const OUT_DIR = join(process.cwd(), 'public')
+const OUT_FILE = join(OUT_DIR, 'catalog.jsonld')
+
+async function main() {
+  const datasets = (await provider.listDatasets()) as CatalogEntry[]
+  const catalog = toDCATCatalog(datasets, {
+    baseUrl: process.env.SITE_URL,
+    title: 'Data catalog',
+    description: 'DCAT-3 catalog of datasets in this portal.',
+    // No argless Date here would be reproducible; stamp with SOURCE_DATE_EPOCH when
+    // set (reproducible builds), else now.
+    modified: new Date(
+      process.env.SOURCE_DATE_EPOCH ? Number(process.env.SOURCE_DATE_EPOCH) * 1000 : Date.now()
+    ).toISOString(),
+  })
+
+  await mkdir(OUT_DIR, { recursive: true })
+  await writeFile(OUT_FILE, JSON.stringify(catalog, null, 2) + '\n', 'utf8')
+  console.log(`✓ DCAT catalog written: public/catalog.jsonld (${datasets.length} datasets)`)
+}
+
+main().catch((err) => {
+  console.error('Failed to generate DCAT catalog:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Builds the **DCAT serialization + harvest layer** that was designed-in at `lib/metadata/dcat.ts` (po-2ta), over the Frictionless-native metadata model. Closes **po-mo2**. This is the next contract after metadata-profile in the locked roadmap sequence (metadata → **DCAT** → RBAC).

## What it does
- **`toDCAT` / `fromDCAT`** — real Frictionless ⇄ DCAT-3 JSON-LD mapping: `title`, `description`, `keywords`, `license`, `sources`, `issued`/`modified`, `version`, and a `dcat:Distribution` from `file`/`format` (downloadURL/accessURL/format/mediaType). Round-trips package metadata + distribution.
- **`toDCATCatalog` / `fromDCATCatalog`** — the whole catalog as a `dcat:Catalog`, with per-dataset landing pages + download URLs derived from `namespace`/`slug`/`file`.
- **Harvest endpoint** — `scripts/generate-dcat.ts` reads the catalog **through the data provider** and writes `public/catalog.jsonld` (a DCAT-3 `dcat:Catalog`). Wired into `predev`/`prebuild` so it's always fresh. It's a **static file → harvests on any host** (static Cloudflare Pages, CDN, Worker), no runtime needed — honoring static-first. `SITE_URL` emits absolute URLs.

## Honest scope
- DCAT has **no inline field schema** — the Table Schema is referenced via `dcat:describedBy`, not embedded, so `fromDCAT` recovers package metadata + distribution, **not** the field-level schema. Documented; intrinsic to DCAT.
- This is the **pragmatic DCAT-3 core**, not a full DCAT-AP profile (mandatory EU-portal classes). `dcat.ts` is the place to extend for a national/domain profile.

## Verification
- Generator emits valid DCAT-3 for the 3 sample datasets — full metadata on `country-codes`, bare datasets degrade cleanly. (See example output in the diff/README.)
- `toDCAT → fromDCAT` round-trip recovers title/license/keywords/sources/file/format/version; schema correctly absent.
- `npm run build` passes with the `prebuild` generator hook.

Adds `tsx` (devDependency) to run the generator; `public/catalog.jsonld` is gitignored (build output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented DCAT-3 JSON-LD catalog serialization and import/export capabilities for metadata interchange.
  * Added automated catalog generation during development and production builds.

* **Documentation**
  * Enhanced metadata documentation to clarify DCAT as a serialization layer and its relationship to the core metadata model.

* **Chores**
  * Configured build scripts for automatic catalog generation.
  * Updated ignore rules for generated catalog artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->