### PR TITLE
fix(scaffold): use tiged not degit — degit silently shipped the whole monorepo

### DIFF
--- a/.claude/INSTALL.md
+++ b/.claude/INSTALL.md
@@ -53,7 +53,7 @@ Plugin commands are namespaced — run them as `/portaljs:new-portal`,
 ## Notes
 
 - `/new-portal` prefers a local checkout of the template when run inside this repo, and
-  otherwise fetches it remotely via `npx degit`. Override the template ref with
+  otherwise fetches it remotely via `npx tiged`. Override the template ref with
   `PORTALJS_TEMPLATE_REF` (default `main`). Requires **Node.js >= 18**.
 - Only the OSS skills are packaged. Gas Town internal commands (`done`, `handoff`,
   `review`) are intentionally excluded.

--- a/.claude/commands/new-portal.md
+++ b/.claude/commands/new-portal.md
@@ -145,14 +145,18 @@ if [ "$TEMPLATE_MODE" = "local" ]; then
   # Remove build artifacts that must not be copied
   rm -rf "./$PROJECT_SLUG/node_modules" "./$PROJECT_SLUG/.next"
 else
-  # degit fetches a subdirectory of a repo with no git history or node_modules.
-  npx --yes degit "datopian/portaljs/$TEMPLATE_VARIANT#$PORTALJS_TEMPLATE_REF" "./$PROJECT_SLUG"
+  # tiged (maintained degit fork) fetches a subdirectory of a repo with no git
+  # history or node_modules. NOTE: plain `degit` is NOT reliable here — when its
+  # tarball fetch fails it silently falls back to a full `git clone` that ignores
+  # the subdirectory, dropping the WHOLE monorepo into the target (exit 0). tiged
+  # extracts the subdirectory correctly.
+  npx --yes tiged "datopian/portaljs/$TEMPLATE_VARIANT#$PORTALJS_TEMPLATE_REF" "./$PROJECT_SLUG"
 fi
 ```
 
-If the remote fetch fails (bad ref, network, or degit unavailable), tell the user plainly
+If the remote fetch fails (bad ref, network, or tiged unavailable), tell the user plainly
 and ask how to proceed (retry / different ref / check network) — requires Node.js >=18 so
-`npx degit` is available. If running locally and the variant directory is missing, tell
+`npx tiged` is available. If running locally and the variant directory is missing, tell
 the user the local checkout is out of date and offer to fetch remotely instead.
 
 ### 5. Substitute placeholder tokens

--- a/.claude/commands/new-portal.md
+++ b/.claude/commands/new-portal.md
@@ -155,9 +155,10 @@ fi
 ```
 
 If the remote fetch fails (bad ref, network, or tiged unavailable), tell the user plainly
-and ask how to proceed (retry / different ref / check network) — requires Node.js >=18 so
-`npx tiged` is available. If running locally and the variant directory is missing, tell
-the user the local checkout is out of date and offer to fetch remotely instead.
+and ask how to proceed (retry / different ref / check network). The scaffolded portal
+(Next.js) requires **Node.js >=18**; `npx tiged` itself runs on older Node, but use >=18
+to match the template. If running locally and the variant directory is missing, tell the
+user the local checkout is out of date and offer to fetch remotely instead.
 
 ### 5. Substitute placeholder tokens
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ have a portal.
 not a requirement:
 
 ```bash
-npx degit datopian/portaljs/examples/portaljs-catalog my-portal
+npx tiged datopian/portaljs/examples/portaljs-catalog my-portal
 ```
 
 ### Available skills

--- a/VISION.md
+++ b/VISION.md
@@ -30,7 +30,7 @@ And scaffolding is only the start. The same model — describe intent, get plain
 
 ### Next — make skills installable anywhere
 Today the skills are **repo-local**: they run from inside a clone of this repo because `/new-portal` resolves the template via `git rev-parse --show-toplevel`. To let users run them from any project:
-- [x] Fetch the template remotely (`npx degit`) instead of from the local checkout, so `/new-portal` works outside this repo
+- [x] Fetch the template remotely (`npx tiged`) instead of from the local checkout, so `/new-portal` works outside this repo
 - [x] Support installing the commands into `~/.claude/commands/` (personal scope), with docs ([`.claude/INSTALL.md`](.claude/INSTALL.md))
 - [x] Package the skills + template as a distributable Claude Code plugin (`.claude-plugin/`)
 

--- a/site/content/docs/manual-setup.md
+++ b/site/content/docs/manual-setup.md
@@ -16,11 +16,11 @@ the same project by hand. This page shows how.
 
 ## 1. Get the template
 
-Grab the canonical catalog template with [degit](https://github.com/Rich-Harris/degit)
-(no git history, just the files):
+Grab the canonical catalog template with [tiged](https://github.com/tiged/tiged)
+(a maintained `degit` fork that reliably extracts the subdirectory — no git history, just the files):
 
 ```bash
-npx degit datopian/portaljs/examples/portaljs-catalog my-portal
+npx tiged datopian/portaljs/examples/portaljs-catalog my-portal
 cd my-portal
 npm install
 npm run dev

--- a/site/content/docs/templates.md
+++ b/site/content/docs/templates.md
@@ -42,10 +42,10 @@ the URL is always `/@<namespace>/<slug>`. See [Core concepts](/docs/core-concept
 the rationale. [`/add-dataset`](/docs/skills/add-dataset) appends a manifest entry
 against this template.
 
-Clone it by hand with [degit](https://github.com/Rich-Harris/degit):
+Clone it by hand with [tiged](https://github.com/tiged/tiged) (a maintained `degit` fork that reliably extracts a subdirectory):
 
 ```bash
-npx degit datopian/portaljs/examples/portaljs-catalog my-portal
+npx tiged datopian/portaljs/examples/portaljs-catalog my-portal
 ```
 
 ## Minimal variant — single page
@@ -56,7 +56,7 @@ no catalog, no per-dataset pages. Use it when you want a single landing page and
 add structure yourself, or as the smallest possible base to build on.
 
 ```bash
-npx degit datopian/portaljs/examples/portaljs-template my-portal
+npx tiged datopian/portaljs/examples/portaljs-template my-portal
 ```
 
 ## Which should I use?


### PR DESCRIPTION
## The bug (found via a cold-start dogfood)

Running the documented first-run from a clean dir, as a newcomer would:

```
npx degit datopian/portaljs/examples/portaljs-catalog my-portal
```

…**silently produces the entire portaljs monorepo**, not the template. degit's tarball fetch fails and it falls back to a full `git clone` that **ignores the subdirectory**, dropping the workspaces root (`packages/`, `site/`, `tests/`, `.changeset`, …) into the target — and **exits 0**. Reproduced 2/2.

This affects **every newcomer path**: the README quickstart, the docs, *and the `/new-portal` skill's own scaffold step*. Single biggest blocker on the adoption funnel.

## The fix

`tiged` (a maintained `degit` fork, drop-in same args) extracts the subdirectory correctly. Verified end-to-end from a clean dir: `tiged` → `npm install` → `npm run build` all pass with just the template (build even ran the new DCAT prebuild generator cleanly).

Swapped `degit`→`tiged` in all 6 spots: README, VISION checklist, `.claude/INSTALL.md`, the **`/new-portal` skill scaffold command** (the important one), and the manual-setup + templates docs.

## Follow-up

An adoption-grade `create-portaljs` CLI (`npm create portaljs@latest`) is the better long-term DX — filed as po-pd1. This PR stops the bleeding now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced scaffold-fetch instructions to use npx tiged for PortalJS templates across README, setup guides, templates docs, and new-portal instructions.
  * Clarified that scaffolding requires Node.js >= 18 for the generated Next.js portal.
  * Updated guidance to proceed with setup if remote tiged-based fetching fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->