### PR TITLE
docs(readme): above-the-fold Quickstart (adoption funnel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@
 
 ---
 
+## Quickstart
+
+**Build one with your AI assistant** — the PortalJS way. In a [Claude Code](https://claude.com/claude-code) session:
+
+```bash
+git clone https://github.com/datopian/portaljs && cd portaljs && claude
+# then, in the session:
+/new-portal   "Auckland Council open data portal"
+```
+
+`/new-portal` scaffolds the three surfaces; `/add-dataset` loads your data; `/architect`
+picks an architecture first if you're unsure. No install step — Claude Code auto-discovers
+the skills. ([Install them anywhere →](.claude/INSTALL.md))
+
+**Or run the template directly** — plain Next.js, no account, no lock-in:
+
+```bash
+npx tiged datopian/portaljs/examples/portaljs-catalog my-portal
+cd my-portal && npm install && npm run dev      # → http://localhost:3000
+```
+
+You get Home, a Catalog (`/search`), and a dataset Showcase (`/@<namespace>/<slug>`) over
+sample data. Add your own CSV/JSON to `datasets.json` and it renders automatically.
+
+⭐ If it's useful, a star helps others find it.
+
 ## Why PortalJS
 
 Building a data portal has always meant more than a website. You have to decide where


### PR DESCRIPTION
Part of the OSS-adoption push. The README's first **runnable** command was ~100 lines down, below the Why + architecture diagram — consideration content before action. For conversion, a newcomer should hit a runnable path right after the hero.

Adds a **Quickstart** section directly under the hero with two paths:
- **AI-first** (clone → `claude` → `/new-portal`) — the product identity.
- **Zero-dependency local run** (`npx tiged … && npm install && npm run dev`) — for a 30-second eval with no Claude Code account.

Plus a ⭐ star nudge. The detailed Setup/Use sections below are unchanged (Quickstart = TL;DR up top, details below — standard README pattern).

Pairs with #1549 (the `tiged` scaffold fix) — the quickstart now leads people down a path that actually works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Quickstart" section to the README with step-by-step guidance for getting started
  * Included instructions for scaffolding portals and loading datasets using AI assistants
  * Documented an alternative setup method for direct template usage via command line

<!-- end of auto-generated comment: release notes by coderabbit.ai -->