### PR TITLE
fix: tolerant CSV parsing + dev-server-safe verify (from QA review)

### DIFF
--- a/.claude/commands/add-map.md
+++ b/.claude/commands/add-map.md
@@ -286,17 +286,21 @@ view-dispatch block, **extend** that block with another `dataset.namespace === �
 dataset.slug === …` branch (or add the `<Map />` alongside an existing `<Chart />` for the
 same dataset) rather than overwriting it.
 
-### 7. Verify the build
+### 7. Verify
+
+Type-check (do NOT run `next build` here). `next build` writes to `.next/`, the same
+directory a running `npm run dev` uses — building over a live dev server corrupts it.
+`tsc` writes nothing to `.next/`, so it's safe while the user's portal is running:
 
 ```bash
 cd PORTAL_DIR
-npx next build > /tmp/add-map-build.log 2>&1
-BUILD_EXIT=$?
-tail -20 /tmp/add-map-build.log
+npx tsc --noEmit > /tmp/add-map-verify.log 2>&1
+VERIFY_EXIT=$?
+tail -20 /tmp/add-map-verify.log
 ```
 
-If `BUILD_EXIT` is non-zero, print the log and fix the error before reporting success.
-Do not report success while the build is failing.
+If `VERIFY_EXIT` is non-zero, print the log and fix the error before reporting success.
+Do not report success while type-checking still fails.
 
 ### 8. Report success
 

--- a/.claude/commands/new-portal.md
+++ b/.claude/commands/new-portal.md
@@ -240,17 +240,21 @@ and network access before retrying.
 
 ### 9. Verify scaffold-ready
 
-Capture build output and exit code separately so a failure is never silently missed:
+Type-check (do NOT run `next build` here). `next build` writes to `.next/`, the same
+directory a running `npm run dev` uses — building over a live dev server corrupts it
+(the portal then 404s its own chunks). The normal flow is "scaffold → `npm run dev` to
+watch it → keep adding datasets," so verify with `tsc`, which writes nothing to `.next/`:
 
 ```bash
 cd "./$PROJECT_SLUG"
-npx next build > /tmp/next-build.log 2>&1
-BUILD_EXIT=$?
-tail -20 /tmp/next-build.log
+npx tsc --noEmit > /tmp/new-portal-verify.log 2>&1
+VERIFY_EXIT=$?
+tail -20 /tmp/new-portal-verify.log
 ```
 
-If `BUILD_EXIT` is non-zero, print the full log and fix the error before reporting
-success. Do not report success while the build is still failing.
+If `VERIFY_EXIT` is non-zero, print the log and fix the error before reporting success.
+Do not report success while type-checking still fails. (A full `next build` happens in
+`/deploy`, which guards against a running dev server.)
 
 ### 10. Report success
 

--- a/examples/portaljs-catalog/components/ui/parseCsv.ts
+++ b/examples/portaljs-catalog/components/ui/parseCsv.ts
@@ -12,7 +12,10 @@ export function parseCsv(csv: string) {
   })
   const rows = (result.data as Record<string, string>[]) ?? []
   const fields = (result.meta.fields ?? []).map((f) => ({ key: f, name: f }))
-  if (rows.length === 0 || fields.length === 0) {
+  // Throw only when NOTHING parsed (no header AND no rows). A header with zero
+  // data rows still returns its fields, so the table renders columns + an empty
+  // state rather than erroring.
+  if (rows.length === 0 && fields.length === 0) {
     const msg = result.errors.map((e) => `row ${e.row ?? '?'}: ${e.message}`).join('; ')
     throw new Error(`CSV parse error — ${msg || 'no rows parsed'}`)
   }

--- a/examples/portaljs-catalog/components/ui/parseCsv.ts
+++ b/examples/portaljs-catalog/components/ui/parseCsv.ts
@@ -1,13 +1,25 @@
 import Papa from 'papaparse'
 
+// Tolerant CSV parse. Real-world CSV exports often carry a `#` comment/metadata
+// preamble, a BOM, or a few ragged rows — none of which should blank the whole
+// table. We skip `#` comment lines and only throw when NOTHING parses; otherwise
+// we render the valid rows and warn about the rest.
 export function parseCsv(csv: string) {
-  const result = Papa.parse(csv.trim(), { header: true, skipEmptyLines: true })
-  if (result.errors.length > 0) {
+  const result = Papa.parse(csv.trim(), {
+    header: true,
+    skipEmptyLines: true,
+    comments: '#',
+  })
+  const rows = (result.data as Record<string, string>[]) ?? []
+  const fields = (result.meta.fields ?? []).map((f) => ({ key: f, name: f }))
+  if (rows.length === 0 || fields.length === 0) {
     const msg = result.errors.map((e) => `row ${e.row ?? '?'}: ${e.message}`).join('; ')
-    throw new Error(`CSV parse error — ${msg}`)
+    throw new Error(`CSV parse error — ${msg || 'no rows parsed'}`)
   }
-  return {
-    rows: result.data as Record<string, string>[],
-    fields: (result.meta.fields ?? []).map((f) => ({ key: f, name: f })),
+  if (result.errors.length > 0 && typeof console !== 'undefined') {
+    console.warn(
+      `parseCsv: ${result.errors.length} non-fatal issue(s); rendering ${rows.length} rows.`
+    )
   }
+  return { rows, fields }
 }


### PR DESCRIPTION
From a colleague's hands-on QA of the skills (building a real portal). Triaged against current `main` — most of the review's findings were already resolved by the catalog-template/`datasets.json` model and the metadata-profile contract; these **two were still valid** against the current canonical template and are fixed here.

### FIX-005 — a single comment line blanked the whole table  [High]
Real CSV exports often start with a `#` comment/metadata preamble (or a BOM). `examples/portaljs-catalog/components/ui/parseCsv.ts` parsed with no `comments` option and **threw on any error**, so papaparse read the `#` line as a 1-field header, every real row became `TooManyFields`, and the showcase `Table` showed *"Failed to load data"* — for completely valid data.

Now: skip `#` comments, only throw when **nothing** parses, and `console.warn` (not throw) on non-fatal issues — rendering the valid rows.

### FIX-003 — the verify build corrupted a running dev server  [Medium]
`/new-portal` and `/add-map` verified with `npx next build`, which writes to `.next/` — the same dir a running `npm run dev` uses. The normal flow keeps a dev server open while adding datasets/maps; building over it makes the live portal 404 its own chunks (recovery: kill dev, `rm -rf .next`, restart — not obvious to a self-serve user).

Now: both verify with `npx tsc --noEmit` (writes nothing to `.next/`). A real `next build` still runs in `/deploy`.

**Verified:** `tsc --noEmit` clean on the catalog template.

### Tracked separately
- **FIX-006** (deploy reports success but the URL 401s behind Vercel SSO; `npm i -g vercel` perms; no reachability check) → folded into the `/deploy` rework (po-tse).
- **Suggestion 2** (multi-resource datasets) → po-647.
- Already-resolved by current architecture: FIX-001 (unescaped values — now `datasets.json`), FIX-002 (JSON bundle inlining — now runtime `fetch`), Suggestion 1 (Frictionless schema — shipped via the metadata-profile contract + `/define-schema`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV import is more tolerant of real-world exports: comment lines are ignored, partial parse errors emit warnings, and valid rows are returned instead of failing.

* **Documentation**
  * Scaffold/verify commands now use a faster TypeScript type-check for verification (avoids producing build artifacts during dev workflows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->