### PR TITLE
style(site): load the brand font site-wide + drop dark-bg leftover

### DIFF
--- a/site/components/ShowcasesItem.tsx
+++ b/site/components/ShowcasesItem.tsx
@@ -32,6 +32,8 @@ export default function ShowcasesItem({ item }) {
           <img
             src={item.image}
             alt={item.title}
+            loading="lazy"
+            decoding="async"
             className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
           />
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />

--- a/site/pages/_app.tsx
+++ b/site/pages/_app.tsx
@@ -109,7 +109,7 @@ function MyApp({ Component, pageProps }) {
         </>
       )}
       <PostHogProvider client={posthog}>
-        <main className={` font-sans`}>
+        <main className={`${RobotoCondensed.variable} font-sans`}>
           <Component {...pageProps} />
         </main>
       </PostHogProvider>

--- a/site/styles/global.css
+++ b/site/styles/global.css
@@ -18,10 +18,12 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+  font-family: var(--font-roco), -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   overflow-x: hidden;
-  background-color: #1e293b;
+  /* Light-only site: the previous #1e293b (dark slate) was a pre-redesign
+     leftover that showed through on short pages and overscroll. */
+  background-color: #ffffff;
 }
 
 /* mathjax */


### PR DESCRIPTION
Site-wide design-consistency sweep after the landing redesign. Yoana flagged: colors/fonts on other pages not aligned with the new home; pale logos; `/data-portals` looks bad.

## Root cause found + fixed (this PR so far)

**The brand font never loaded — site-wide.** `_app.tsx` configures Noto Sans via `next/font` with `variable: '--font-roco'`, but `RobotoCondensed.variable` was **never attached to any element**. So `--font-roco` was never injected, `font-sans` (= `var(--font-roco)`) resolved to nothing, and **every page fell back to the system font stack** (verified on the live site via computed styles). This is the core "fonts not aligned with the new design" issue — the intended typography wasn't rendering anywhere.
- Fix: attach `RobotoCondensed.variable` to `<main>`. Every page renders inside `<main>`, so the brand font now applies site-wide.

**Dark-bg leftover.** `body { background-color: #1e293b }` (dark slate) on a light-only site — showed through on short pages / overscroll. Set to `#ffffff`; body font-family now falls back through `var(--font-roco)`.

## Why ship this first

The font fix changes how the **entire site** renders. Best to deploy it (Vercel preview), re-audit against the new baseline, then fix what's genuinely still inconsistent — rather than chase per-page palette drift while the baseline is mid-change.

## Still to do (tracked, continuing on this branch / follow-ups)
- `/data-portals` (`components/Showcases.tsx`): busy gallery of varied-quality portal screenshots + pale imagery; align card/typography treatment to the new design.
- Scattered old-palette hardcoded colors across `layouts/*` and pages (`text-blue-400`, `text-slate-400`, …) → align to the new tokens.
- Full sweep of remaining routes (ckan, datahub, pricing, features, compare/*, solutions/*, learn/*, docs) against the home reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Applied Roboto Condensed across the site for improved typography consistency.
  * Switched the page background to white and updated the global font stack for a cleaner, light-focused appearance.

* **Performance**
  * Images in showcase listings now load lazily and decode asynchronously to reduce initial load and improve rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->