### PR TITLE
style(site): logo + card consistency, pt2 (logos grayscale-match home, /data-portals cards, compare strip)

### DIFF
--- a/site/components/Showcases.tsx
+++ b/site/components/Showcases.tsx
@@ -1,4 +1,3 @@
-import ShowCaseMobile from './ShowCaseMobile'
 import ShowcasesItem from './ShowcasesItem'
 
 export const dataPortals = [
@@ -219,21 +218,10 @@ export default function Showcases() {
           </p>
         </div>
       </div>
-      <div className="not-prose my-12 grid grid-cols-1 gap-6 lg:gap-12 md:grid-cols-2">
-        {dataPortals.map((item) => {
-          return (
-            <div className="hidden sm:block" key={item.title}>
-              <ShowcasesItem item={item} />
-            </div>
-          )
-        })}
-        {dataPortals.map((item) => {
-          return (
-            <div className="sm:hidden" key={item.title}>
-              <ShowCaseMobile item={item} />
-            </div>
-          )
-        })}
+      <div className="not-prose my-12 grid grid-cols-1 gap-[22px] sm:grid-cols-2">
+        {dataPortals.map((item) => (
+          <ShowcasesItem item={item} key={item.title} />
+        ))}
       </div>
     </div>
   )

--- a/site/components/ShowcasesItem.tsx
+++ b/site/components/ShowcasesItem.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image'
+
 function getRepositoryLabel(item) {
   if (!item?.repository) {
     return '';
@@ -17,6 +19,10 @@ function getRepositoryLabel(item) {
   return 'Visit repository on GitHub';
 }
 
+// Showcase card for /data-portals. Matches the home "Real portals" cards
+// (components/home/Showcase.tsx): light card, 16:9 cover image, title + subtitle
+// footer, hover lift. The GitHub-repo link (unique to this page) is kept as a
+// subtle corner badge.
 export default function ShowcasesItem({ item }) {
   const repositoryLabel = getRepositoryLabel(item);
   return (
@@ -26,52 +32,35 @@ export default function ShowcasesItem({ item }) {
         target="_blank"
         rel="noreferrer"
         aria-label={`Visit ${item.title} portal`}
-        className="block h-full overflow-hidden rounded-2xl ring-1 ring-white/15 bg-slate-950/40 transition-shadow duration-300 hover:ring-primary"
+        className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white transition-all duration-200 hover:-translate-y-[3px] hover:shadow-[0_20px_44px_-24px_rgba(15,23,42,0.35)]"
       >
-        <div className="relative w-full overflow-hidden aspect-[16/9]">
-          <img
+        <div className="relative aspect-[16/9] overflow-hidden border-b border-slate-200 bg-slate-100">
+          <Image
             src={item.image}
-            alt={item.title}
-            loading="lazy"
-            decoding="async"
-            className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            alt={`${item.title} portal`}
+            fill
+            sizes="(max-width: 640px) 100vw, 50vw"
+            className="object-cover object-top transition-transform duration-[400ms] group-hover:scale-[1.03]"
           />
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />
         </div>
-        <div className="flex h-full flex-col gap-3 p-4 text-white">
-          <div className="text-xs uppercase tracking-wide text-white/70">
-            {item.subtitle}
-          </div>
-          <div className="space-y-1">
-            <p className="text-xl font-semibold">{item.title}</p>
-            <p className="text-sm text-white/80">{item.description}</p>
-          </div>
-          <div className="mt-auto inline-flex items-center text-sm font-semibold text-primary">
-            Visit portal
-            <svg
-              className="ml-2 h-4 w-4"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M5 12h14" />
-              <path d="m12 5 7 7-7 7" />
-            </svg>
-          </div>
+        <div className="flex items-center justify-between gap-3 px-[18px] py-4">
+          <h3 className="text-base font-semibold text-slate-900">{item.title}</h3>
+          {item.subtitle && (
+            <span className="hidden text-right font-mono text-xs font-medium text-slate-400 sm:block">
+              {item.subtitle}
+            </span>
+          )}
         </div>
       </a>
       {item.repository && (
         <a
           target="_blank"
           rel="noreferrer"
-          className="absolute top-3 right-3 z-20 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/80 text-white transition-transform duration-200 hover:scale-110"
+          className="absolute top-3 right-3 z-20 inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-slate-700 ring-1 ring-slate-200 shadow-sm transition-transform duration-200 hover:scale-110 hover:text-slate-900"
           href={item.repository}
           aria-label={repositoryLabel}
         >
-          <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+          <svg aria-hidden="true" className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z" />
           </svg>
         </a>

--- a/site/components/SocialProofStrip.tsx
+++ b/site/components/SocialProofStrip.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+
+// Shared "trusted by" logo strip for the compare/* pages. Uses the same grayscale
+// treatment as the home SocialProof (components/home/SocialProof.tsx): grayscale,
+// a single opacity-70 (hover -> full), uniform small height — no stacked opacity
+// (the old per-page strips double-faded with opacity-75 on both the link and the
+// image, which read as "pale").
+//
+// White-on-transparent assets are inverted so grayscale doesn't render them
+// invisible on the light background.
+const WHITE_ASSETS =
+  /(sse-logo-white|sigma2-light-transparent|hounslow|UNIOFSY|usyd-dark|mtc-logo|bank-of-england)/i
+
+type Logo = { name: string; src: string; url: string; width?: number }
+
+export default function SocialProofStrip({
+  heading = 'Trusted by leading organizations worldwide',
+  logos,
+}: {
+  heading?: string
+  logos: Logo[]
+}) {
+  return (
+    <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-blue-500">
+        {heading}
+      </h2>
+      <div className="mx-auto mt-10 grid max-w-6xl grid-cols-2 items-center justify-items-center gap-x-8 gap-y-10 sm:grid-cols-3 lg:grid-cols-5">
+        {logos.map((logo) => (
+          <Link
+            key={logo.name}
+            href={logo.url}
+            title={logo.name}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center justify-center opacity-70 transition hover:opacity-100"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              className={`h-9 w-auto max-w-[150px] object-contain grayscale ${
+                WHITE_ASSETS.test(logo.src) ? 'invert' : ''
+              }`}
+              src={logo.src}
+              alt={`${logo.name} logo`}
+              title={logo.name}
+              loading="lazy"
+            />
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/site/components/ckan/SocialProof.tsx
+++ b/site/components/ckan/SocialProof.tsx
@@ -9,7 +9,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/TDC_logo.svg',
       srcLight: '/static/img/social-proof/TDC_logo.svg',
       url: 'https://portal.transport-data.org/',
-      style: 'grayscale dark:invert',
+      style: '',
       width: 240,
     },
     {
@@ -17,7 +17,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/dx-connect-find.svg',
       srcLight: '/static/img/social-proof/dx-connect-find.svg',
       url: 'https://finddx.portaljs.com/',
-      style: ' grayscale dark:invert',
+      style: '',
       width: 170,
     },
     {
@@ -25,7 +25,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/sse-logo-white.png',
       srcLight: '/static/img/social-proof/sse-logo-white.png',
       url: 'https://data.ssen.co.uk/',
-      style: 'max-h-28 grayscale invert dark:invert-0 opacity-75',
+      style: 'max-h-28 invert',
       width: 200,
     },
     {
@@ -41,7 +41,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/uae_moei_eng-logo.png',
       srcLight: '/static/img/social-proof/uae_moei_eng-logo.png',
       url: 'https://opendata.moei.gov.ae/',
-      style: ' grayscale',
+      style: '',
       width: 230,
     },
     {
@@ -50,7 +50,7 @@ export default function SocialProof() {
         '/static/img/social-proof/Marcus_Institute_HMS_vertical-grey-transparent.png',
       srcLight: '/static/img/social-proof/Marcus_Institute_HMS-light.png',
       url: 'https://data.hsl.harvard.edu/',
-      style: 'grayscale',
+      style: '',
       width: 200,
     },
     {
@@ -58,7 +58,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/Open-Data-Northern-Ireland-grey.png',
       srcLight: '/static/img/social-proof/Open-Data-Northern-Ireland-light.png',
       url: 'https://www.opendatani.gov.uk/',
-      style: 'grayscale',
+      style: '',
       width: 180,
     },
     {
@@ -66,7 +66,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/hounslow.svg',
       srcLight: '/static/img/social-proof/hounslow-light.svg',
       url: 'https://data.hounslow.gov.uk',
-      style: 'grayscale  dark:invert-0 opacity-80',
+      style: '',
       width: 200,
     },
   ]
@@ -81,7 +81,7 @@ export default function SocialProof() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
           {logos.map((logo, index) => (
             <Link
-              className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
+              className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-100 transition-all duration-300"
               key={logo.srcDark + index}
               title={logo.name}
               href={logo.url}

--- a/site/components/ckan/SocialProof.tsx
+++ b/site/components/ckan/SocialProof.tsx
@@ -9,7 +9,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/TDC_logo.svg',
       srcLight: '/static/img/social-proof/TDC_logo.svg',
       url: 'https://portal.transport-data.org/',
-      style: '',
+      style: 'grayscale',
       width: 240,
     },
     {
@@ -17,7 +17,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/dx-connect-find.svg',
       srcLight: '/static/img/social-proof/dx-connect-find.svg',
       url: 'https://finddx.portaljs.com/',
-      style: '',
+      style: 'grayscale',
       width: 170,
     },
     {
@@ -25,7 +25,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/sse-logo-white.png',
       srcLight: '/static/img/social-proof/sse-logo-white.png',
       url: 'https://data.ssen.co.uk/',
-      style: 'max-h-28 invert',
+      style: 'max-h-28 grayscale invert',
       width: 200,
     },
     {
@@ -34,7 +34,7 @@ export default function SocialProof() {
       srcLight: '/static/img/social-proof/usyd-dark.svg',
       url: 'https://www.idpo.org.au',
       // White-on-transparent asset — invert so it reads as dark on the light bg.
-      style: 'invert',
+      style: 'grayscale invert',
       width: 115,
     },
     {
@@ -42,7 +42,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/uae_moei_eng-logo.png',
       srcLight: '/static/img/social-proof/uae_moei_eng-logo.png',
       url: 'https://opendata.moei.gov.ae/',
-      style: '',
+      style: 'grayscale',
       width: 230,
     },
     {
@@ -51,7 +51,7 @@ export default function SocialProof() {
         '/static/img/social-proof/Marcus_Institute_HMS_vertical-grey-transparent.png',
       srcLight: '/static/img/social-proof/Marcus_Institute_HMS-light.png',
       url: 'https://data.hsl.harvard.edu/',
-      style: '',
+      style: 'grayscale',
       width: 200,
     },
     {
@@ -59,7 +59,7 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/Open-Data-Northern-Ireland-grey.png',
       srcLight: '/static/img/social-proof/Open-Data-Northern-Ireland-light.png',
       url: 'https://www.opendatani.gov.uk/',
-      style: '',
+      style: 'grayscale',
       width: 180,
     },
     {
@@ -68,7 +68,7 @@ export default function SocialProof() {
       srcLight: '/static/img/social-proof/hounslow-light.svg',
       url: 'https://data.hounslow.gov.uk',
       // White-on-transparent asset — invert so it reads as dark on the light bg.
-      style: 'invert',
+      style: 'grayscale invert',
       width: 200,
     },
   ]
@@ -83,7 +83,7 @@ export default function SocialProof() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
           {logos.map((logo, index) => (
             <Link
-              className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-100 transition-all duration-300"
+              className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-70 hover:opacity-100 transition-all duration-300"
               key={logo.srcDark + index}
               title={logo.name}
               href={logo.url}

--- a/site/components/ckan/SocialProof.tsx
+++ b/site/components/ckan/SocialProof.tsx
@@ -33,7 +33,8 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/UNIOFSY.png',
       srcLight: '/static/img/social-proof/usyd-dark.svg',
       url: 'https://www.idpo.org.au',
-      style: '',
+      // White-on-transparent asset — invert so it reads as dark on the light bg.
+      style: 'invert',
       width: 115,
     },
     {
@@ -66,7 +67,8 @@ export default function SocialProof() {
       srcDark: '/static/img/social-proof/hounslow.svg',
       srcLight: '/static/img/social-proof/hounslow-light.svg',
       url: 'https://data.hounslow.gov.uk',
-      style: '',
+      // White-on-transparent asset — invert so it reads as dark on the light bg.
+      style: 'invert',
       width: 200,
     },
   ]

--- a/site/components/home/Schedule.tsx
+++ b/site/components/home/Schedule.tsx
@@ -44,7 +44,7 @@ export default function Schedule({ calendar = "https://calendar.app.google/sn2PU
               clipPath:
                 'polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)',
             }}
-            className="aspect-[1318/752] w-[82.375rem] flex-none bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-25 rotate-180"
+            className="aspect-[1318/752] w-[82.375rem] flex-none bg-gradient-to-r from-[#38bdf8] to-[#5eead4] opacity-25 rotate-180"
           />
         </div>
       </div>

--- a/site/pages/compare/arcgis-hub.tsx
+++ b/site/pages/compare/arcgis-hub.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout'
+import SocialProofStrip from '@/components/SocialProofStrip'
 import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
@@ -259,32 +260,7 @@ export default function PortalJSvsArcGISHub() {
       </div>
 
       {/* Social Proof Section */}
-      <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
-        <h2 className="text-base font-semibold text-theme-orange uppercase tracking-wide opacity-75">
-          Trusted by leading organizations worldwide
-        </h2>
-        <div className="max-w-8xl flex justify-center mt-5" tabIndex={0}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
-            {socialProofLogos.map((logo) => (
-              <Link
-                className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
-                key={logo.name}
-                title={logo.name}
-                href={logo.url}
-              >
-                <Image
-                  className={`h-auto grayscale`}
-                  src={logo.src}
-                  alt={`${logo.name} Logo`}
-                  title={logo.name}
-                  height={100}
-                  width={logo.width}
-                />
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SocialProofStrip logos={socialProofLogos} />
 
       {/* Testimonials Section */}
       <div className="w-full bg-slate-50 dark:bg-slate-900">

--- a/site/pages/compare/ckan.tsx
+++ b/site/pages/compare/ckan.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout'
+import SocialProofStrip from '@/components/SocialProofStrip'
 import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
@@ -259,32 +260,7 @@ export default function PortalJSvsCKAN() {
       </div>
 
       {/* Social Proof Section */}
-      <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
-        <h2 className="text-base font-semibold text-theme-orange uppercase tracking-wide opacity-75">
-          Trusted by leading organizations worldwide
-        </h2>
-        <div className="max-w-8xl flex justify-center mt-5" tabIndex={0}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
-            {socialProofLogos.map((logo) => (
-              <Link
-                className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
-                key={logo.name}
-                title={logo.name}
-                href={logo.url}
-              >
-                <Image
-                  className={`h-auto grayscale`}
-                  src={logo.src}
-                  alt={`${logo.name} Logo`}
-                  title={logo.name}
-                  height={100}
-                  width={logo.width}
-                />
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SocialProofStrip logos={socialProofLogos} />
 
       {/* Testimonials Section */}
       <div className="w-full bg-slate-50 dark:bg-slate-900">

--- a/site/pages/compare/custom-solution.tsx
+++ b/site/pages/compare/custom-solution.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout'
+import SocialProofStrip from '@/components/SocialProofStrip'
 import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
@@ -259,32 +260,7 @@ export default function PortalJSvsCustomSolution() {
       </div>
 
       {/* Social Proof Section */}
-      <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
-        <h2 className="text-base font-semibold text-theme-orange uppercase tracking-wide opacity-75">
-          Trusted by leading organizations worldwide
-        </h2>
-        <div className="max-w-8xl flex justify-center mt-5" tabIndex={0}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
-            {socialProofLogos.map((logo) => (
-              <Link
-                className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
-                key={logo.name}
-                title={logo.name}
-                href={logo.url}
-              >
-                <Image
-                  className={`h-auto grayscale`}
-                  src={logo.src}
-                  alt={`${logo.name} Logo`}
-                  title={logo.name}
-                  height={100}
-                  width={logo.width}
-                />
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SocialProofStrip logos={socialProofLogos} />
 
       {/* Testimonials Section */}
       <div className="w-full bg-slate-50 dark:bg-slate-900">

--- a/site/pages/compare/dataverse.tsx
+++ b/site/pages/compare/dataverse.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout'
+import SocialProofStrip from '@/components/SocialProofStrip'
 import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
@@ -259,32 +260,7 @@ export default function PortalJSvsDataverse() {
       </div>
 
       {/* Social Proof Section */}
-      <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
-        <h2 className="text-base font-semibold text-theme-orange uppercase tracking-wide opacity-75">
-          Trusted by leading organizations worldwide
-        </h2>
-        <div className="max-w-8xl flex justify-center mt-5" tabIndex={0}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
-            {socialProofLogos.map((logo) => (
-              <Link
-                className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
-                key={logo.name}
-                title={logo.name}
-                href={logo.url}
-              >
-                <Image
-                  className={`h-auto grayscale`}
-                  src={logo.src}
-                  alt={`${logo.name} Logo`}
-                  title={logo.name}
-                  height={100}
-                  width={logo.width}
-                />
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SocialProofStrip logos={socialProofLogos} />
 
       {/* Testimonials Section */}
       <div className="w-full bg-slate-50 dark:bg-slate-900">

--- a/site/pages/compare/dkan.tsx
+++ b/site/pages/compare/dkan.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout'
+import SocialProofStrip from '@/components/SocialProofStrip'
 import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
@@ -259,32 +260,7 @@ export default function PortalJSvsDKAN() {
       </div>
 
       {/* Social Proof Section */}
-      <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
-        <h2 className="text-base font-semibold text-theme-orange uppercase tracking-wide opacity-75">
-          Trusted by leading organizations worldwide
-        </h2>
-        <div className="max-w-8xl flex justify-center mt-5" tabIndex={0}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
-            {socialProofLogos.map((logo) => (
-              <Link
-                className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
-                key={logo.name}
-                title={logo.name}
-                href={logo.url}
-              >
-                <Image
-                  className={`h-auto grayscale`}
-                  src={logo.src}
-                  alt={`${logo.name} Logo`}
-                  title={logo.name}
-                  height={100}
-                  width={logo.width}
-                />
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SocialProofStrip logos={socialProofLogos} />
 
       {/* Testimonials Section */}
       <div className="w-full bg-slate-50 dark:bg-slate-900">

--- a/site/pages/compare/opendatasoft.tsx
+++ b/site/pages/compare/opendatasoft.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout'
+import SocialProofStrip from '@/components/SocialProofStrip'
 import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
@@ -234,32 +235,7 @@ export default function PortalJSvsOpenDataSoft() {
       </div>
 
       {/* Social Proof Section */}
-      <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
-        <h2 className="text-base font-semibold text-theme-orange uppercase tracking-wide opacity-75">
-          Trusted by leading organizations worldwide
-        </h2>
-        <div className="max-w-8xl flex justify-center mt-5" tabIndex={0}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
-            {socialProofLogos.map((logo) => (
-              <Link
-                className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
-                key={logo.name}
-                title={logo.name}
-                href={logo.url}
-              >
-                <Image
-                  className={`h-auto grayscale`}
-                  src={logo.src}
-                  alt={`${logo.name} Logo`}
-                  title={logo.name}
-                  height={100}
-                  width={logo.width}
-                />
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SocialProofStrip logos={socialProofLogos} />
 
       {/* Testimonials Section */}
       <div className="w-full bg-slate-50 dark:bg-slate-900">

--- a/site/pages/compare/socrata.tsx
+++ b/site/pages/compare/socrata.tsx
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout'
+import SocialProofStrip from '@/components/SocialProofStrip'
 import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
@@ -259,32 +260,7 @@ export default function PortalJSvsSocrata() {
       </div>
 
       {/* Social Proof Section */}
-      <div className="text-center max-w-full mx-auto py-24 px-4 sm:px-6 lg:px-8 w-full">
-        <h2 className="text-base font-semibold text-theme-orange uppercase tracking-wide opacity-75">
-          Trusted by leading organizations worldwide
-        </h2>
-        <div className="max-w-8xl flex justify-center mt-5" tabIndex={0}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 justify-center items-center gap-x-4 gap-y-5 w-full mt-6">
-            {socialProofLogos.map((logo) => (
-              <Link
-                className="flex items-center justify-center w-full h-full max-h-24 p-2 opacity-75 hover:opacity-100 transition-all duration-300"
-                key={logo.name}
-                title={logo.name}
-                href={logo.url}
-              >
-                <Image
-                  className={`h-auto grayscale`}
-                  src={logo.src}
-                  alt={`${logo.name} Logo`}
-                  title={logo.name}
-                  height={100}
-                  width={logo.width}
-                />
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SocialProofStrip logos={socialProofLogos} />
 
       {/* Testimonials Section */}
       <div className="w-full bg-slate-50 dark:bg-slate-900">


### PR DESCRIPTION
Follow-up to #1553 (which merged with only the font + light-bg + lazy-load fixes). These are the remaining site-design-consistency changes that hadn't landed yet — verified on the #1553 branch preview before that PR merged early.

## What's here
- **Logos match the home grayscale treatment** (Yoana's "pale logos"): the `/ckan` `SocialProof` strip and all **7 `compare/*` pages** now use grayscale + a single `opacity-70` (hover→full), not the old stacked `opacity-75` double-fade. White-on-transparent logos (SSE, Sigma2, Hounslow, USYD) are `invert`ed so grayscale doesn't render them invisible.
  - Extracted a shared **`SocialProofStrip`** component and replaced the 7 inline compare strips with it (auto-inverts white assets).
- **`/data-portals` cards use the home "Real portals" design** — rewrote `ShowcasesItem` as the home light card (rounded-2xl, white, 16:9 cover, title + subtitle, hover-lift; GitHub link kept as a subtle badge) and unified `Showcases` to one responsive card.
- **"Ready to Launch" CTA recolored** sky→teal (the shared `Schedule`, ~10 pages) — removes the off-brand indigo gradient.

## Verified
On the #1553 branch preview before merge: brand font, grayscale logos (computed `grayscale(1)` + `invert(1)` on white assets, none broken), home-style `/data-portals` cards (`bg-white`, 16px radius), and the sky→teal CTA. Net diff is −239/+103 (mostly deleting the duplicated inline strips).

Context: `/ckan` layout left as-is (confirmed fine). Remaining legacy pages tracked in po-86y.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Unified showcase card layout across all devices with redesigned styling
  * Refactored "Trusted by" social proof section across comparison pages for visual consistency
  * Enhanced showcase image rendering with improved responsive behavior
  * Updated gradient styling in decorative elements for refreshed appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->