### PR TITLE
fix(skills): address PortalJS skills QA findings (closes #1556)

### DIFF
--- a/.claude/commands/connect-ckan.md
+++ b/.claude/commands/connect-ckan.md
@@ -15,6 +15,12 @@ framework wiring.
 Use this for the "decoupled / any backend" path: the user has a CKAN data management
 system (their own or a public one) and wants a browseable portal in front of it.
 
+**You can run this right after `/new-portal`.** A fresh portal ships with a few sample
+datasets so it builds and renders immediately — you do NOT need to hand-author a static
+dataset list first. If the user says up front they want a CKAN backend, scaffold with the
+sample data, then run `/connect-ckan` to swap the source over to CKAN. Only a CKAN base
+URL is required.
+
 The generated pages fetch CKAN **server-side** in `getStaticProps`/`getStaticPaths`, so
 the `@portaljs/ckan` bundle never reaches the browser — the client stays lean and the
 site can be statically deployed.

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,5 +1,5 @@
 ---
-description: One-shot deploy of a PortalJS portal to Vercel or static hosting. Detects the target, builds, and publishes — with a live URL at the end.
+description: One-shot deploy of a PortalJS portal to Cloudflare Pages (recommended), Vercel, or any static host. Detects the target, builds, and publishes — with a live URL at the end.
 allowed-tools: Read, Write, Edit, Bash
 ---
 
@@ -7,8 +7,10 @@ allowed-tools: Read, Write, Edit, Bash
 
 Deploy an existing PortalJS portal in one shot. Two targets:
 
-- **`vercel`** — push to Vercel via the `vercel` CLI. Handles SSR/ISR natively, gives a live `*.vercel.app` URL (or your custom domain). Best default for portals that may grow server-side features.
-- **`static`** — build a fully static site (`next export` → `out/`) suitable for any static host: GitHub Pages, Netlify drop, S3 + CloudFront, Cloudflare Pages, plain nginx. No server required.
+- **`vercel`** — push to Vercel via the `vercel` CLI. Handles SSR/ISR natively, gives a live `*.vercel.app` URL (or your custom domain). Zero-config if the user already has the Vercel CLI, so the skill may auto-detect it.
+- **`static`** — build a fully static site (`next export` → `out/`) for any static host: **Cloudflare Pages** (`npx wrangler pages deploy out`), GitHub Pages, Netlify, S3 + CloudFront, plain nginx. No server required.
+
+> **Recommended host: Cloudflare Pages** (the `static` target). PortalJS's architecture docs default to a static-first, S3-compatible, no-lock-in stack on Cloudflare (Pages for static; Workers for the opt-in runtime). Vercel is offered as a convenient SSR option, not the recommended production default — if the skill auto-detects Vercel (because the CLI is installed) it will say so before proceeding, and you can choose `static` + Cloudflare instead. A first-class managed/bring-your-own Cloudflare deploy flow is on the roadmap.
 
 This skill builds, verifies the build passes, and either publishes (Vercel) or produces a ready-to-upload `out/` directory (static). It never reports success on a failing build.
 

--- a/.claude/commands/new-portal.md
+++ b/.claude/commands/new-portal.md
@@ -104,21 +104,33 @@ Derive `PROJECT_SLUG` from `PROJECT_NAME` (lowercase, hyphenated, no special cha
 ### 3. Resolve the template source
 
 This skill works **both inside a clone of the portaljs repo and from any other project**.
-It prefers a local checkout (fast, offline, matches your working tree) and otherwise
-fetches the template remotely from GitHub. The default — and currently only — variant is
-`examples/portaljs-catalog`.
+**Default to fetching the template remotely (always the latest).** Use a local checkout
+only when you are genuinely inside an up-to-date portaljs repo AND not scaffolding into it.
+The default — and currently only — variant is `examples/portaljs-catalog`.
 
 ```bash
 TEMPLATE_VARIANT="examples/portaljs-catalog"
 
-# Prefer a local checkout; fall back to remote fetch from GitHub.
-if GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && [ -d "$GIT_ROOT/$TEMPLATE_VARIANT" ]; then
-  TEMPLATE_MODE="local"
-  TEMPLATE_DIR="$GIT_ROOT/$TEMPLATE_VARIANT"
-else
-  TEMPLATE_MODE="remote"
-  # Override the ref (branch, tag, or commit) with PORTALJS_TEMPLATE_REF; defaults to main.
-  PORTALJS_TEMPLATE_REF="${PORTALJS_TEMPLATE_REF:-main}"
+# Default: fetch the latest template from GitHub. Override the ref with
+# PORTALJS_TEMPLATE_REF (branch, tag, or commit); defaults to main.
+TEMPLATE_MODE="remote"
+PORTALJS_TEMPLATE_REF="${PORTALJS_TEMPLATE_REF:-main}"
+
+# Use a LOCAL checkout only when BOTH hold (otherwise stay remote):
+#  1. the resolved repo has the CURRENT template — verified by the @-namespaced
+#     route file pages/[owner]/[slug].tsx. An old clone without it would scaffold a
+#     stale, non-namespaced portal (pages/datasets/[slug].tsx) — issue #1556.
+#  2. we are NOT scaffolding inside that repo (never create a portal inside the
+#     framework repo itself).
+if GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
+   && [ -f "$GIT_ROOT/$TEMPLATE_VARIANT/pages/[owner]/[slug].tsx" ]; then
+  case "$(pwd)/" in
+    "$GIT_ROOT/"*)
+      echo "Inside the portaljs repo — fetching the template remotely instead of copying in place." ;;
+    *)
+      TEMPLATE_MODE="local"
+      TEMPLATE_DIR="$GIT_ROOT/$TEMPLATE_VARIANT" ;;
+  esac
 fi
 ```
 
@@ -157,8 +169,9 @@ fi
 If the remote fetch fails (bad ref, network, or tiged unavailable), tell the user plainly
 and ask how to proceed (retry / different ref / check network). The scaffolded portal
 (Next.js) requires **Node.js >=18**; `npx tiged` itself runs on older Node, but use >=18
-to match the template. If running locally and the variant directory is missing, tell the
-user the local checkout is out of date and offer to fetch remotely instead.
+to match the template. (The resolver already defaults to remote when no current local
+template is found, so a missing or stale local checkout falls through to the latest
+template automatically.)
 
 ### 5. Substitute placeholder tokens
 

--- a/README.md
+++ b/README.md
@@ -23,19 +23,26 @@
 
 ## Quickstart
 
-**Build one with your AI assistant** — the PortalJS way. In a [Claude Code](https://claude.com/claude-code) session:
+**Build one with your AI assistant** — the recommended path. Install the skills once,
+then create portals from **any directory** (not inside this repo):
 
 ```bash
-git clone https://github.com/datopian/portaljs && cd portaljs && claude
-# then, in the session:
-/new-portal   "Auckland Council open data portal"
+# 1. Install the PortalJS skills (once) — into ~/.claude/commands
+curl -fsSL https://raw.githubusercontent.com/datopian/portaljs/main/scripts/install-portaljs-skills.sh | bash
 ```
 
-`/new-portal` scaffolds the three surfaces; `/add-dataset` loads your data; `/architect`
-picks an architecture first if you're unsure. No install step — Claude Code auto-discovers
-the skills. ([Install them anywhere →](.claude/INSTALL.md))
+Then, from a fresh working directory, in a [Claude Code](https://claude.com/claude-code) session:
 
-**Or run the template directly** — plain Next.js, no account, no lock-in:
+```text
+/new-portal   "Auckland Council open data portal"
+/add-dataset  ./data/air-quality.csv
+```
+
+`/new-portal` fetches the latest template and scaffolds the three surfaces; `/add-dataset`
+loads your data; `/architect` picks an architecture first if you're unsure; `/connect-ckan`
+points it at a CKAN backend. ([Install details + all skills →](.claude/INSTALL.md))
+
+**Or build by hand** — plain Next.js, no AI, no lock-in:
 
 ```bash
 npx tiged datopian/portaljs/examples/portaljs-catalog my-portal

--- a/scripts/install-portaljs-skills.sh
+++ b/scripts/install-portaljs-skills.sh
@@ -20,7 +20,8 @@ DEST="${CLAUDE_COMMANDS_DIR:-$HOME/.claude/commands}"
 RAW_BASE="https://raw.githubusercontent.com/datopian/portaljs/${REF}/.claude/commands"
 
 # OSS skills only — excludes Gas Town internal commands (done/handoff/review).
-SKILLS="new-portal add-dataset add-chart add-map deploy"
+# Keep in sync with the `commands` list in .claude-plugin/plugin.json.
+SKILLS="architect new-portal add-dataset add-chart add-map connect-ckan define-schema deploy check-data-quality"
 
 # Detect a local checkout: this script lives in <repo>/scripts/, so the commands
 # dir is ../.claude/commands relative to the script.

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -18,9 +18,10 @@ instead.
 
 ## 1. Install the skills
 
-The skills are Claude Code commands — `/new-portal`, `/add-dataset`, `/add-chart`,
-`/add-map`, `/connect-ckan`, `/deploy`. Install them once into your personal scope
-so they're available in every project:
+The skills are Claude Code commands — `/architect`, `/new-portal`, `/add-dataset`,
+`/add-chart`, `/add-map`, `/connect-ckan`, `/define-schema`, `/deploy`, and
+`/check-data-quality`. Install them all once into your personal scope so they're
+available in every project:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/datopian/portaljs/main/scripts/install-portaljs-skills.sh | bash
@@ -42,7 +43,7 @@ In Claude Code, describe the portal you want:
 /new-portal Auckland Council Open Data Portal — public datasets for the Auckland region
 ```
 
-`/new-portal` copies the canonical lightweight template, substitutes your project
+`/new-portal` fetches the latest canonical catalog template, substitutes your project
 name and description, installs dependencies, and verifies the build. You get a
 real Next.js project — plain, editable code you own.
 


### PR DESCRIPTION
Addresses the QA findings in #1556 (testing the AI skills end-to-end: install → new-portal → add-dataset → visualize → deploy).

| # | Finding | Fix |
|---|---------|-----|
| 3, 5 | Installer only installed 5 skills — `/connect-ckan`, `/architect`, `/define-schema`, `/check-data-quality` missing after install | `scripts/install-portaljs-skills.sh` now installs all **9** OSS skills (synced with `plugin.json`) |
| 4 | `/new-portal` scaffolded from a **stale / in-repo local template** (`pages/datasets/[slug].tsx`, no namespace) near an old clone | Resolver **defaults to remote (latest)**; uses local only when it has the current `@`-namespaced `pages/[owner]/[slug].tsx` AND not scaffolding inside the repo |
| 1 | README gave two confusing starts (clone → scaffolds *inside* repo; template → no skills) | README recommends **one path**: install skills once, then `/new-portal` from your own dir. Docs skill list completed + wording fixed |
| 6 | `/deploy` defaulted to Vercel while docs recommend Cloudflare Pages | `/deploy` surfaces **Cloudflare Pages as recommended** (static target); Vercel framed as SSR convenience |
| 2 | CKAN flow confusing — AI insisted on a static list first | `/connect-ckan` states it can run **right after `/new-portal`** (sample data ships; no static list needed first) |

Bash blocks syntax-checked. Deeper `/deploy`→Cloudflare/managed rework tracked separately.

Closes #1556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified command workflows for portal scaffolding and dataset connection
  * Expanded available Claude Code skills in installation instructions
  * Added Cloudflare Pages as the recommended static hosting option
  * Improved guidance on template fetching and CLI command flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->