### PR TITLE
feat(catalog): multi-resource datasets + /add-resource skill (po-647)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,6 +14,7 @@
     "./.claude/commands/architect.md",
     "./.claude/commands/new-portal.md",
     "./.claude/commands/add-dataset.md",
+    "./.claude/commands/add-resource.md",
     "./.claude/commands/add-chart.md",
     "./.claude/commands/add-map.md",
     "./.claude/commands/connect-ckan.md",

--- a/.claude/commands/add-resource.md
+++ b/.claude/commands/add-resource.md
@@ -1,0 +1,139 @@
+---
+description: Add another file (resource) to an EXISTING dataset in a PortalJS portal — a data dictionary, methodology, or an additional data file. Turns a single-file dataset into a multi-resource one; the showcase renders a section per resource.
+allowed-tools: Read, Write, Edit, Bash, WebFetch
+---
+
+# /add-resource
+
+Add a **resource** (an additional file) to a dataset that already exists in a
+`portaljs-catalog` portal. Use this when a dataset is more than one file — data + a data
+dictionary + a methodology doc, or quarterly/yearly files under one dataset. Where
+[`/add-dataset`](/docs/skills/add-dataset) creates a **new** dataset (one file), this adds
+a file to an **existing** one.
+
+Mirrors the Frictionless Data Package model: a dataset holds a `resources[]` array, and the
+showcase at `/@<namespace>/<slug>` renders **one section per resource** (preview, schema,
+download). A single-file dataset is migrated to `resources[]` automatically the first time
+you add a second file — no data is lost.
+
+## Required input — ask, don't error
+
+- **Target dataset** — which dataset to add to, by `slug` (or `namespace/slug`).
+- **Source** — a local file path or a public URL for the new resource.
+- **Portal directory** — defaults to the current directory.
+- **Resource name/title** (optional) — a short id + human title for the resource.
+
+Supported formats: **CSV, TSV, JSON (array), GeoJSON** (same as `/add-dataset`).
+
+**If the target dataset or source is missing, ask — never dead-end.** When the user
+doesn't know the slug, read `datasets.json` and list the datasets so they can pick.
+
+## Steps
+
+### 1. Gather input from `$ARGUMENTS` (interview if thin)
+
+Extract:
+- `DATASET` — target dataset slug (or `namespace/slug`).
+- `SOURCE` — file path or URL of the new resource.
+- `PORTAL_DIR` — portal directory (default: `.`).
+- `RESOURCE_NAME` — short id within the dataset (default: lowercase-hyphenated filename stem; must be unique among the dataset's resources).
+- `RESOURCE_TITLE` — human title (default: derived from the filename).
+- `DESCRIPTION` — optional one-line description of the resource.
+
+If `DATASET` or `SOURCE` is missing, ask (listing existing datasets from `datasets.json`
+when the slug is unknown) and wait.
+
+### 2. Validate the portal + locate the dataset
+
+Confirm `PORTAL_DIR/datasets.json`, `PORTAL_DIR/package.json`, and
+`PORTAL_DIR/pages/[owner]/[slug].tsx` exist (the catalog template). Find the dataset entry
+by `slug` (and `namespace` if given). If it doesn't exist, tell the user and offer to
+create it with `/add-dataset` instead.
+
+### 3. Detect format and copy/fetch the file
+
+Same as `/add-dataset` step 3: detect format from extension/Content-Type
+(`csv`/`tsv`/`json`/`geojson`), fetch a URL (check HTTP status) or check a local path
+exists, then copy into the portal:
+
+```bash
+mkdir -p PORTAL_DIR/public/data
+cp SOURCE PORTAL_DIR/public/data/RESOURCE_NAME.EXT
+# or for URLs: curl -L SOURCE -o PORTAL_DIR/public/data/RESOURCE_NAME.EXT
+```
+
+Pick a filename that won't collide with an existing file in `/public/data`.
+
+### 4. Add the resource to the dataset entry
+
+Open `PORTAL_DIR/datasets.json` and update the target dataset, matching the `Dataset` /
+`Resource` shape in `lib/providers/types.ts`:
+
+- **If the dataset has no `resources` yet** (it's a single-file dataset with top-level
+  `file`/`format`/`schema`), **migrate it first**: move the existing file into a
+  `resources` array as the first resource, then remove the now-redundant top-level
+  `file`/`format` (and top-level `schema`, which becomes that resource's schema). Preserve
+  the existing data — this is a lossless transform:
+
+  ```json
+  // before
+  { "slug": "orders", "name": "Orders", "file": "orders.csv", "format": "csv", "schema": { ... } }
+  // after (migrated) + new resource appended
+  {
+    "slug": "orders", "name": "Orders",
+    "resources": [
+      { "name": "data", "path": "orders.csv", "format": "csv", "title": "Orders", "schema": { ... } },
+      { "name": "RESOURCE_NAME", "path": "RESOURCE_NAME.EXT", "format": "<detected>", "title": "RESOURCE_TITLE", "description": "DESCRIPTION" }
+    ]
+  }
+  ```
+
+- **If the dataset already has `resources`**, just append the new resource object. Ensure
+  `name` is unique within the array (the showcase uses it as the section key/anchor).
+
+Keep all package-level fields (`description`, `keywords`, `licenses`, `sources`, `version`,
+…) on the dataset. Drop `description` on the resource only if there genuinely is none.
+
+That is the entire registration — `getResources()` (`lib/datasets.ts`) reads the
+`resources` array and the showcase renders a section per resource automatically.
+
+### 5. Verify the build
+
+```bash
+cd PORTAL_DIR
+npx next build > /tmp/add-resource-build.log 2>&1
+BUILD_EXIT=$?
+tail -20 /tmp/add-resource-build.log
+```
+The common failure is malformed JSON in `datasets.json`. Fix and rebuild before reporting
+success.
+
+### 6. Report
+
+```
+✓ Resource added to DATASET: RESOURCE_TITLE (RESOURCE_NAME.EXT)
+  - Data file: public/data/RESOURCE_NAME.EXT
+  - Manifest:  datasets.json (dataset now has <n> resources)
+  - Showcase:  /@<namespace>/<slug> renders a section per resource
+```
+
+If this was the first migration to multi-resource, note that the dataset's single `file`
+was moved into `resources[]` (no data lost).
+
+## Notes
+
+- **One source of truth.** Resources live on the dataset's `datasets.json` entry. No page
+  edits — the showcase loops `getResources(dataset)`.
+- **Per-resource schema.** Describe a resource's fields with [`/define-schema`](/docs/skills/define-schema)
+  — its Frictionless Table Schema renders under that resource's section.
+- **Single-file stays simple.** Datasets with one file keep the plain `file`/`format`
+  shape; migration to `resources[]` only happens when a second file is added.
+
+## Example
+
+```
+/add-resource orders ./data/orders-data-dictionary.csv  (title: "Data dictionary")
+```
+Adds a data dictionary to the existing `orders` dataset: if `orders` was a single CSV, it's
+migrated to a two-resource dataset (the data + the dictionary), and its showcase now shows
+a section for each. With no arguments, the skill lists your datasets and asks which one.

--- a/examples/portaljs-catalog/.gitignore
+++ b/examples/portaljs-catalog/.gitignore
@@ -6,3 +6,6 @@ out/
 
 # Generated DCAT harvest document (npm run generate:dcat → predev/prebuild)
 public/catalog.jsonld
+
+# TypeScript incremental build cache
+*.tsbuildinfo

--- a/examples/portaljs-catalog/components/DataExplorer.tsx
+++ b/examples/portaljs-catalog/components/DataExplorer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import LoadingSpinner from './ui/LoadingSpinner'
 import { DuckDbQuery } from '../lib/query/duckdb'
-import type { Dataset } from '../lib/datasets'
+import type { Resource } from '../lib/datasets'
 
-// A DuckDB-Wasm-backed data view for a dataset's showcase. Loads the file into an
+// A DuckDB-Wasm-backed data view for a single resource. Loads the file into an
 // in-browser DuckDB, previews it, and lets the visitor run SQL against the table
 // `data` — all client-side, no server. Rendered in place of the flat <Table />
 // when the portal's DATA_QUERY engine is 'duckdb' (see lib/datasets.ts). Import it
@@ -11,8 +11,8 @@ import type { Dataset } from '../lib/datasets'
 
 const PREVIEW_LIMIT = 50
 
-export default function DataExplorer({ dataset }: { dataset: Dataset }) {
-  const url = `/data/${dataset.file}`
+export default function DataExplorer({ resource }: { resource: Resource }) {
+  const url = `/data/${resource.path}`
   const defaultSql = `SELECT * FROM data LIMIT ${PREVIEW_LIMIT}`
 
   // One engine instance per source file.
@@ -32,7 +32,7 @@ export default function DataExplorer({ dataset }: { dataset: Dataset }) {
     setError(null)
     ;(async () => {
       try {
-        await engine.open({ url, format: dataset.format })
+        await engine.open({ url, format: resource.format })
         const count = await engine.query('SELECT count(*) AS n FROM data')
         const res = await engine.query(defaultSql)
         if (cancelled) return
@@ -49,7 +49,7 @@ export default function DataExplorer({ dataset }: { dataset: Dataset }) {
       cancelled = true
       void engine.close()
     }
-  }, [engine, url, dataset.format, defaultSql])
+  }, [engine, url, resource.format, defaultSql])
 
   const run = async () => {
     setLoading(true)

--- a/examples/portaljs-catalog/datasets.json
+++ b/examples/portaljs-catalog/datasets.json
@@ -64,5 +64,35 @@
     "description": "Tonnes of CO₂ emitted per person for a sample of countries.",
     "file": "co2-emissions.csv",
     "format": "csv"
+  },
+  {
+    "slug": "country-indicators",
+    "namespace": "reference",
+    "name": "Country Indicators (bundle)",
+    "description": "A multi-resource dataset: reference codes plus population and CO₂ indicators for a sample of countries.",
+    "keywords": ["countries", "reference", "indicators"],
+    "resources": [
+      {
+        "name": "codes",
+        "path": "country-codes.csv",
+        "format": "csv",
+        "title": "Country codes",
+        "description": "ISO 3166-1 names with alpha-2 and alpha-3 codes."
+      },
+      {
+        "name": "population",
+        "path": "population-2022.csv",
+        "format": "csv",
+        "title": "Population 2022",
+        "description": "Estimated mid-year population."
+      },
+      {
+        "name": "co2",
+        "path": "co2-emissions.csv",
+        "format": "csv",
+        "title": "CO₂ emissions per capita",
+        "description": "Tonnes of CO₂ emitted per person."
+      }
+    ]
   }
 ]

--- a/examples/portaljs-catalog/lib/datasets.ts
+++ b/examples/portaljs-catalog/lib/datasets.ts
@@ -5,9 +5,9 @@
 // holds only the provider-independent bits: the Dataset shape, the namespace
 // mode, and the canonical URL helper.
 
-import type { Dataset } from './providers'
+import type { Dataset, Resource } from './providers'
 
-export type { Dataset } from './providers'
+export type { Dataset, Resource } from './providers'
 
 // A portal uses exactly ONE namespace mode. Set to 'theme' for a single-publisher
 // portal (datasets grouped by subject) or 'owner' for a multi-publisher portal
@@ -29,4 +29,29 @@ export const DATA_QUERY: 'flat' | 'duckdb' = 'flat'
 // with `@`). See README for the routing rationale.
 export function datasetHref(d: Dataset): string {
   return `/@${d.namespace}/${d.slug}`
+}
+
+// Normalize a dataset to its resource list. A multi-resource dataset returns its
+// `resources` as-is; a single-file dataset is presented as one synthesized
+// resource (from `file`/`format`/`schema`) so every surface renders datasets
+// uniformly — there's no single-vs-multi branching at the call site.
+export function getResources(d: Dataset): Resource[] {
+  if (d.resources && d.resources.length > 0) return d.resources
+  if (d.file) {
+    return [
+      {
+        name: 'data',
+        path: d.file,
+        format: d.format ?? 'csv',
+        title: d.name,
+        schema: d.schema,
+      },
+    ]
+  }
+  return []
+}
+
+// Public URL of a resource's raw file (served statically from /public/data).
+export function resourceUrl(r: Resource): string {
+  return `/data/${r.path}`
 }

--- a/examples/portaljs-catalog/lib/providers/index.ts
+++ b/examples/portaljs-catalog/lib/providers/index.ts
@@ -4,6 +4,8 @@ import type { DataProvider } from './types'
 export type {
   DataProvider,
   Dataset,
+  DataFormat,
+  Resource,
   DatasetQuery,
   ProviderCapabilities,
 } from './types'

--- a/examples/portaljs-catalog/lib/providers/types.ts
+++ b/examples/portaljs-catalog/lib/providers/types.ts
@@ -8,13 +8,36 @@
 
 import type { License, Source, TableSchema } from '../metadata/types'
 
+export type DataFormat = 'csv' | 'tsv' | 'json' | 'geojson'
+
+// A single file within a dataset (a Frictionless "resource"). A dataset can hold
+// several — data + a data dictionary + methodology, or quarterly files, etc.
+export type Resource = {
+  // Stable id within the dataset (e.g. "data", "dictionary"). Used in anchors.
+  name: string
+  // Bare filename served from /public/data (e.g. "orders-2024.csv").
+  path: string
+  format: DataFormat
+  title?: string
+  description?: string
+  // Per-resource Frictionless Table Schema.
+  schema?: TableSchema
+}
+
 export type Dataset = {
   slug: string
   namespace: string
   name: string
   description?: string
-  file: string
-  format: 'csv' | 'tsv' | 'json' | 'geojson'
+  // Single-resource sugar — a one-file dataset sets `file`/`format` (+ optional
+  // `schema`) directly. For multiple files, use `resources` below. Read either
+  // shape through getResources() (lib/datasets.ts), which normalizes to a
+  // Resource[]; surfaces consume that, not `file` directly.
+  file?: string
+  format?: DataFormat
+  // Multiple files in one dataset (Frictionless Data Package resources). When
+  // present, takes precedence over the single `file`/`format` above.
+  resources?: Resource[]
 
   // --- metadata-profile contract (lib/metadata) ---
   // How this dataset's schema + descriptive metadata are authored and surfaced.
@@ -24,8 +47,8 @@ export type Dataset = {
   // MetadataProfile id (defaults to the L0 'frictionless-tabular'); surfaces
   // resolve it via getProfile().
   profile?: string
-  // Frictionless Table Schema — the field-level contract, rendered as a
-  // column/type/description table on the showcase.
+  // Frictionless Table Schema — for a single-resource dataset, the schema of
+  // that file. (Per-file schemas for multi-resource live on each Resource.)
   schema?: TableSchema
   // Data Package descriptor fields a catalog surfaces.
   licenses?: License[]

--- a/examples/portaljs-catalog/pages/[owner]/[slug].tsx
+++ b/examples/portaljs-catalog/pages/[owner]/[slug].tsx
@@ -3,7 +3,14 @@ import Link from 'next/link'
 import dynamic from 'next/dynamic'
 import type { GetStaticPaths, GetStaticProps } from 'next'
 import { Table } from '../../components/Table'
-import { DATA_QUERY, NAMESPACE_TYPE, type Dataset } from '../../lib/datasets'
+import {
+  DATA_QUERY,
+  NAMESPACE_TYPE,
+  getResources,
+  resourceUrl,
+  type Dataset,
+  type Resource,
+} from '../../lib/datasets'
 import { provider } from '../../lib/providers'
 
 // DuckDB only runs in the browser, so load the query view client-side. The chunk
@@ -36,8 +43,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 }
 
 export default function DatasetPage({ dataset }: { dataset: Dataset }) {
-  const url = `/data/${dataset.file}`
-  const tabular = dataset.format === 'csv' || dataset.format === 'tsv'
+  const resources = getResources(dataset)
   const namespaceLabel = NAMESPACE_TYPE === 'owner' ? 'Owner' : 'Theme'
 
   return (
@@ -74,15 +80,11 @@ export default function DatasetPage({ dataset }: { dataset: Dataset }) {
           </div>
           <div>
             <dt className="text-xs font-semibold uppercase tracking-wide text-gray-400">
-              Format
+              Resources
             </dt>
-            <dd className="mt-1 text-sm text-gray-800">{dataset.format}</dd>
-          </div>
-          <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-gray-400">
-              File
-            </dt>
-            <dd className="mt-1 text-sm text-gray-800">{dataset.file}</dd>
+            <dd className="mt-1 text-sm text-gray-800">
+              {resources.length} file{resources.length === 1 ? '' : 's'}
+            </dd>
           </div>
           {dataset.version && (
             <div>
@@ -116,80 +118,15 @@ export default function DatasetPage({ dataset }: { dataset: Dataset }) {
           </div>
         )}
 
-        {/* Data preview — flat <Table /> by default, or a DuckDB-Wasm SQL
-            query view when the portal's DATA_QUERY engine is 'duckdb'. */}
-        {tabular && DATA_QUERY === 'duckdb' ? (
-          <DataExplorer dataset={dataset} />
-        ) : tabular ? (
-          <Table url={url} fullWidth />
-        ) : (
-          <p className="text-gray-500">
-            Preview not available for {dataset.format} files.{' '}
-            <a href={url} className="underline">
-              Download the file
-            </a>
-            .
-          </p>
-        )}
-
-        {/* Schema — the dataset's Frictionless Table Schema (metadata-profile
-            contract). Rendered when declared; the page degrades cleanly without it. */}
-        {dataset.schema?.fields && dataset.schema.fields.length > 0 && (
-          <section className="mt-10 border-t border-gray-200 pt-6">
-            <h2 className="text-lg font-semibold text-gray-900">Schema</h2>
-            <div className="mt-3 overflow-x-auto">
-              <table className="min-w-full text-sm">
-                <thead>
-                  <tr className="border-b border-gray-200 text-left text-xs uppercase tracking-wide text-gray-400">
-                    <th className="py-2 pr-4 font-semibold">Field</th>
-                    <th className="py-2 pr-4 font-semibold">Type</th>
-                    <th className="py-2 pr-4 font-semibold">Description</th>
-                    <th className="py-2 font-semibold">Constraints</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {dataset.schema.fields.map((f) => {
-                    const c = f.constraints
-                    const tags = [
-                      c?.required && 'required',
-                      c?.unique && 'unique',
-                      c?.enum && `enum(${c.enum.length})`,
-                    ].filter(Boolean) as string[]
-                    return (
-                      <tr
-                        key={f.name}
-                        className="border-b border-gray-100 align-top"
-                      >
-                        <td className="py-2 pr-4 font-mono text-gray-800">
-                          {f.name}
-                        </td>
-                        <td className="py-2 pr-4 text-gray-600">
-                          {f.type ?? '—'}
-                        </td>
-                        <td className="py-2 pr-4 text-gray-600">
-                          {f.description ?? f.title ?? ''}
-                        </td>
-                        <td className="py-2 text-gray-500">
-                          {tags.join(', ')}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-            {dataset.schema.primaryKey && (
-              <p className="mt-2 text-xs text-gray-400">
-                Primary key:{' '}
-                <code className="rounded bg-gray-100 px-1">
-                  {Array.isArray(dataset.schema.primaryKey)
-                    ? dataset.schema.primaryKey.join(', ')
-                    : dataset.schema.primaryKey}
-                </code>
-              </p>
-            )}
-          </section>
-        )}
+        {/* Data — one section per resource (a single-file dataset has exactly
+            one; multi-resource datasets render a section for each file). */}
+        {resources.map((r, i) => (
+          <ResourceSection
+            key={r.name + i}
+            resource={r}
+            showHeading={resources.length > 1}
+          />
+        ))}
 
         {/* Sources & license — Data Package descriptor fields. */}
         {((dataset.licenses && dataset.licenses.length > 0) ||
@@ -247,30 +184,6 @@ export default function DatasetPage({ dataset }: { dataset: Dataset }) {
           </section>
         )}
 
-        {/* Download + API */}
-        <section className="mt-10 border-t border-gray-200 pt-6">
-          <h2 className="text-lg font-semibold text-gray-900">
-            Download &amp; API
-          </h2>
-          <p className="mt-2 text-sm">
-            <a
-              href={url}
-              className="text-blue-600 underline hover:text-blue-700"
-            >
-              Download {dataset.file}
-            </a>
-          </p>
-          <p className="mt-2 text-sm text-gray-500">
-            The raw file is served statically at{' '}
-            <code className="bg-gray-100 px-1 rounded">{url}</code> — fetch it
-            directly for programmatic / API access (e.g.{' '}
-            <code className="bg-gray-100 px-1 rounded">
-              fetch(&apos;{url}&apos;)
-            </code>
-            ).
-          </p>
-        </section>
-
         {/* Views placeholder — charts and maps are added here by the
             /add-chart and /add-map skills. */}
         <section className="mt-10 border-t border-gray-200 pt-6">
@@ -281,5 +194,115 @@ export default function DatasetPage({ dataset }: { dataset: Dataset }) {
         </section>
       </main>
     </>
+  )
+}
+
+// One resource within a dataset: preview (flat <Table /> or the DuckDB SQL view),
+// its Frictionless Table Schema, and a download / API line. A single-file dataset
+// renders exactly one of these (getResources synthesizes it); multi-resource
+// datasets render one per file, each with its own heading.
+function ResourceSection({
+  resource,
+  showHeading,
+}: {
+  resource: Resource
+  showHeading: boolean
+}) {
+  const url = resourceUrl(resource)
+  const tabular = resource.format === 'csv' || resource.format === 'tsv'
+  return (
+    <section className="mt-10 border-t border-gray-200 pt-6 first:mt-2 first:border-t-0 first:pt-0">
+      {showHeading && (
+        <div className="mb-3 flex items-baseline gap-3">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {resource.title ?? resource.name}
+          </h2>
+          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs uppercase tracking-wide text-gray-500">
+            {resource.format}
+          </span>
+        </div>
+      )}
+      {showHeading && resource.description && (
+        <p className="mb-3 text-sm text-gray-500">{resource.description}</p>
+      )}
+
+      {tabular && DATA_QUERY === 'duckdb' ? (
+        <DataExplorer resource={resource} />
+      ) : tabular ? (
+        <Table url={url} fullWidth />
+      ) : (
+        <p className="text-gray-500">
+          Preview not available for {resource.format} files.{' '}
+          <a href={url} className="underline">
+            Download the file
+          </a>
+          .
+        </p>
+      )}
+
+      {/* Per-resource Frictionless Table Schema (degrades cleanly when absent). */}
+      {resource.schema?.fields && resource.schema.fields.length > 0 && (
+        <div className="mt-6">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            Schema
+          </h3>
+          <div className="mt-2 overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-left text-xs uppercase tracking-wide text-gray-400">
+                  <th className="py-2 pr-4 font-semibold">Field</th>
+                  <th className="py-2 pr-4 font-semibold">Type</th>
+                  <th className="py-2 pr-4 font-semibold">Description</th>
+                  <th className="py-2 font-semibold">Constraints</th>
+                </tr>
+              </thead>
+              <tbody>
+                {resource.schema.fields.map((f) => {
+                  const c = f.constraints
+                  const tags = [
+                    c?.required && 'required',
+                    c?.unique && 'unique',
+                    c?.enum && `enum(${c.enum.length})`,
+                  ].filter(Boolean) as string[]
+                  return (
+                    <tr key={f.name} className="border-b border-gray-100 align-top">
+                      <td className="py-2 pr-4 font-mono text-gray-800">{f.name}</td>
+                      <td className="py-2 pr-4 text-gray-600">{f.type ?? '—'}</td>
+                      <td className="py-2 pr-4 text-gray-600">
+                        {f.description ?? f.title ?? ''}
+                      </td>
+                      <td className="py-2 text-gray-500">{tags.join(', ')}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+          {resource.schema.primaryKey && (
+            <p className="mt-2 text-xs text-gray-400">
+              Primary key:{' '}
+              <code className="rounded bg-gray-100 px-1">
+                {Array.isArray(resource.schema.primaryKey)
+                  ? resource.schema.primaryKey.join(', ')
+                  : resource.schema.primaryKey}
+              </code>
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Download + API for this resource. */}
+      <p className="mt-4 text-sm">
+        <a href={url} className="text-blue-600 underline hover:text-blue-700">
+          Download {resource.path}
+        </a>
+        <span className="text-gray-500">
+          {' '}
+          — served statically at{' '}
+          <code className="bg-gray-100 px-1 rounded">{url}</code> for programmatic
+          access.
+        </span>
+      </p>
+    </section>
   )
 }

--- a/scripts/install-portaljs-skills.sh
+++ b/scripts/install-portaljs-skills.sh
@@ -21,7 +21,7 @@ RAW_BASE="https://raw.githubusercontent.com/datopian/portaljs/${REF}/.claude/com
 
 # OSS skills only — excludes Gas Town internal commands (done/handoff/review).
 # Keep in sync with the `commands` list in .claude-plugin/plugin.json.
-SKILLS="architect new-portal add-dataset add-chart add-map connect-ckan define-schema deploy check-data-quality"
+SKILLS="architect new-portal add-dataset add-resource add-chart add-map connect-ckan define-schema deploy check-data-quality"
 
 # Detect a local checkout: this script lives in <repo>/scripts/, so the commands
 # dir is ../.claude/commands relative to the script.

--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -49,6 +49,10 @@
         "href": "/docs/skills/add-dataset"
       },
       {
+        "title": "/add-resource",
+        "href": "/docs/skills/add-resource"
+      },
+      {
         "title": "/add-chart",
         "href": "/docs/skills/add-chart"
       },

--- a/site/content/docs/skills.md
+++ b/site/content/docs/skills.md
@@ -32,6 +32,7 @@ portal. You describe intent; the skill writes the code.
 | ----- | ------------ |
 | [`/new-portal`](/docs/skills/new-portal) | Scaffold a new portal from a brief — copies the template, substitutes your project name and description, installs deps, verifies the build. |
 | [`/add-dataset`](/docs/skills/add-dataset) | Add a CSV, TSV, JSON, or GeoJSON dataset — copies the data in, generates a dataset page, and registers it on the home page catalog. |
+| [`/add-resource`](/docs/skills/add-resource) | Attach another file (data dictionary, methodology, extra data) to an existing dataset — it becomes multi-resource and the showcase renders a section per file. |
 | [`/add-chart`](/docs/skills/add-chart) | Add a line, bar, area, pie, or scatter chart to a dataset page using `recharts`. |
 | [`/add-map`](/docs/skills/add-map) | Render a GeoJSON dataset on an interactive Leaflet map and register it on the home page. |
 | [`/connect-ckan`](/docs/skills/connect-ckan) | Wire the portal to a [CKAN](/ckan) backend over its API instead of static files. |

--- a/site/content/docs/skills/add-chart.md
+++ b/site/content/docs/skills/add-chart.md
@@ -71,4 +71,4 @@ finishes:
 - **[`/add-map`](/docs/skills/add-map)** — render geographic data on a map instead.
 - **[`/deploy`](/docs/skills/deploy)** — publish the portal once it looks right.
 
-<DocsPagination prev="/docs/skills/add-dataset" next="/docs/skills/add-map" />
+<DocsPagination prev="/docs/skills/add-resource" next="/docs/skills/add-map" />

--- a/site/content/docs/skills/add-dataset.md
+++ b/site/content/docs/skills/add-dataset.md
@@ -73,4 +73,4 @@ When it finishes:
 - **[`/add-chart`](/docs/skills/add-chart)** — add a chart to the dataset's showcase.
 - **[`/add-map`](/docs/skills/add-map)** — show geographic data on a map.
 
-<DocsPagination prev="/docs/skills/new-portal" next="/docs/skills/add-chart" />
+<DocsPagination prev="/docs/skills/new-portal" next="/docs/skills/add-resource" />

--- a/site/content/docs/skills/add-resource.md
+++ b/site/content/docs/skills/add-resource.md
@@ -1,0 +1,58 @@
+---
+metatitle: /add-resource – Add Another File to a PortalJS Dataset
+metadescription: The /add-resource skill attaches an extra file (data dictionary, methodology, additional data) to an existing dataset. The dataset becomes multi-resource and its showcase renders a section per file.
+title: /add-resource
+description: Attach another file to an existing dataset — a data dictionary, methodology, or additional data. The showcase then renders one section per resource.
+---
+
+`/add-resource` adds a **resource** (an additional file) to a dataset that already exists in
+your portal. Where [`/add-dataset`](/docs/skills/add-dataset) creates a *new* dataset from
+one file, `/add-resource` attaches a file to an *existing* one — for datasets that are more
+than a single file: data + a data dictionary + methodology, or quarterly/yearly files under
+one dataset.
+
+It follows the Frictionless **Data Package** model: a dataset holds a `resources[]` array,
+and the showcase at `/@<namespace>/<slug>` renders **one section per resource** (preview,
+schema, download). A single-file dataset is migrated to `resources[]` automatically the
+first time you add a second file — no data is lost.
+
+## When to use it
+
+When a dataset is conceptually one thing but ships as several files. Keep them as one
+dataset (one showcase page, shared metadata) rather than splitting into separate datasets.
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Target dataset | No | Which dataset, by `slug` (or `namespace/slug`). Asked — with a list — if missing. |
+| Source | No | Local file path or public URL for the new file. Asked if missing. |
+| Portal directory | No | Defaults to the current directory. |
+| Resource name / title | No | Short id + human title; defaults derived from the filename. |
+
+Supported formats: **CSV, TSV, JSON (array), GeoJSON**.
+
+## What it produces
+
+- The file copied into `/public/data/`.
+- The dataset's `datasets.json` entry updated: the new resource appended to `resources[]`
+  (migrating a single-file dataset to `resources[]` on the first add, losslessly).
+- A new **section on the showcase** for that resource — preview, its Frictionless schema
+  (if defined via [`/define-schema`](/docs/skills/define-schema)), and a download link.
+
+## Example
+
+```
+/add-resource orders ./data/orders-data-dictionary.csv
+```
+
+Attaches a data dictionary to the existing `orders` dataset. If `orders` was a single CSV,
+it becomes a two-resource dataset (the data + the dictionary) and its showcase renders a
+section for each. With no arguments, the skill lists your datasets and asks which one.
+
+## Where to go next
+
+- **[`/define-schema`](/docs/skills/define-schema)** — describe a resource's fields.
+- **[`/add-chart`](/docs/skills/add-chart)** / **[`/add-map`](/docs/skills/add-map)** — add a view.
+
+<DocsPagination prev="/docs/skills/add-dataset" next="/docs/skills/add-chart" />

--- a/tests/skill-triggering/prompts/add-resource.txt
+++ b/tests/skill-triggering/prompts/add-resource.txt
@@ -1,0 +1,1 @@
+My "orders" dataset already has the main CSV, but I also have a separate data dictionary file and a methodology document that belong to the same dataset. I don't want them as separate datasets — they're part of the orders dataset. How do I attach these extra files to it so they show up on the same page?

--- a/tests/skill-triggering/run-all.sh
+++ b/tests/skill-triggering/run-all.sh
@@ -11,6 +11,7 @@ SKILLS=(
   architect
   new-portal
   add-dataset
+  add-resource
   add-chart
   add-map
   connect-ckan


### PR DESCRIPTION
Adds multi-resource dataset support — a dataset can hold several files (data + a data dictionary + methodology, or quarterly files) under one showcase. Previously a dataset was strictly one file. Closes **po-647** (the suggestion from the #1556 QA review).

## Model (backward-compatible, Frictionless-style)
- `Resource` type + optional `resources[]` on `Dataset` (`lib/providers/types.ts`). A single-file dataset keeps its plain `file`/`format` shape; **`getResources()`** (`lib/datasets.ts`) normalizes either shape to a `Resource[]`, so surfaces never branch on single-vs-multi.
- The **showcase renders one section per resource** — preview (flat `<Table>` or the DuckDB SQL view), the resource's Frictionless Table Schema, and a per-resource download/API line. Single-file datasets render exactly one section (UX unchanged).
- `DataExplorer` now takes a `Resource`, so each tabular resource gets its own in-browser DuckDB view.
- Sample: a `country-indicators` bundle (3 resources) added to `datasets.json` to exercise it.

## `/add-resource` skill
Attaches a file to an **existing** dataset (vs `/add-dataset` which creates a new one). Losslessly **migrates** a single-file dataset to `resources[]` on the first add. Registered in `plugin.json`, the install script, the skill-triggering test, and docs (page + sidebar + index).

## Verified
`tsc --noEmit` clean; `npm run build` passes — the multi-resource page (`/@reference/country-indicators`) and the single-file pages all generate, and the DCAT prebuild runs.

> Note: per-resource → DCAT distribution mapping (so a multi-resource dataset emits multiple `dcat:Distribution`s in `/catalog.jsonld`) is a small follow-up; the generator currently handles multi-resource datasets without error (no distribution emitted for them yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/add-resource` skill enabling users to attach additional files to existing datasets
  * Datasets now support multiple resources with per-resource preview sections, metadata, and download options

* **Documentation**
  * Added comprehensive `/add-resource` skill documentation with usage examples
  * Updated skills reference and navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->