### PR TITLE
feat: create-portaljs — npm create portaljs@latest scaffolder (po-pd1)

### DIFF
--- a/.changeset/create-portaljs-initial.md
+++ b/.changeset/create-portaljs-initial.md
@@ -1,0 +1,5 @@
+---
+"create-portaljs": minor
+---
+
+Initial release: scaffold a PortalJS data portal with `npm create portaljs@latest`. Unscoped package (no `@portaljs` scope dependency); publishes public via the existing changesets release flow.

--- a/packages/create-portaljs/README.md
+++ b/packages/create-portaljs/README.md
@@ -1,0 +1,43 @@
+# create-portaljs
+
+Scaffold a [PortalJS](https://github.com/datopian/portaljs) data portal in one command.
+
+```bash
+npm create portaljs@latest my-portal
+# or: npx create-portaljs@latest my-portal · pnpm create portaljs · yarn create portaljs
+```
+
+It downloads the canonical `portaljs-catalog` template into `my-portal/`, substitutes your
+project name/description, sets the namespace mode, and (optionally) runs `git init` +
+`npm install`. Then:
+
+```bash
+cd my-portal
+npm run dev      # → http://localhost:3000
+```
+
+You get the three surfaces — **Home**, a **Catalog** (`/search`), and a dataset **Showcase**
+(`/@<namespace>/<slug>`) — over sample data. Plain, editable Next.js. No lock-in.
+
+## Options
+
+```
+create-portaljs [directory] [options]
+
+  --namespace <theme|owner>  Namespace mode (default: theme)
+  --name <string>            Human project name (default: from directory)
+  --description <string>     One-line description
+  --ref <git-ref>            Template ref to fetch (default: main)
+  --no-install               Skip npm install
+  --no-git                   Skip git init
+  -y, --yes                  Accept defaults, no prompts (CI-friendly)
+  -h, --help                 Show help
+```
+
+Any option given on the CLI skips its prompt; `--yes` skips all prompts.
+
+## What next
+
+Build it out with the PortalJS skills (or by hand — it's just Next.js):
+`/add-dataset`, `/add-resource`, `/add-chart`, `/add-map`, `/connect-ckan`, `/deploy`.
+See the [docs](https://www.portaljs.com/docs/quickstart).

--- a/packages/create-portaljs/SPEC.md
+++ b/packages/create-portaljs/SPEC.md
@@ -1,0 +1,100 @@
+# Spec: `create-portaljs`
+
+> The canonical, zero-prerequisite scaffolder for a PortalJS data portal.
+> `npm create portaljs@latest my-portal` → a working portal in your own directory.
+
+## Why
+
+Today's scaffold paths each have friction (issue #1556, po-pd1):
+
+- `npx tiged datopian/portaljs/examples/portaljs-catalog my-portal` — works, but `tiged`
+  is obscure, no prompts, no token substitution, no git/install, no "what next".
+- `/new-portal` — great, but requires Claude Code (the AI path).
+- clone the repo — scaffolds *inside* the framework repo.
+
+`create-portaljs` is the DX developers expect (cf. `create-next-app`, `create-vite`): one
+memorable command, no prior knowledge, no AI required. It's the strongest top-of-funnel for
+OSS adoption and the natural thing to lead the README / landing / a Show HN with.
+
+## Goal & non-goals
+
+**Goal:** reliably scaffold the canonical `examples/portaljs-catalog` template into a new
+directory, substitute project tokens, set the namespace mode, optionally init git + install
+deps, and print next steps.
+
+**Non-goals (handled elsewhere):** adding datasets/charts/maps/backends (the `/add-*` and
+`/connect-*` skills), the architecture interview (`/architect`), deployment (`/deploy`).
+This is *scaffold only* — the same artifact `/new-portal` produces, without the AI.
+
+## Usage
+
+```bash
+npm create portaljs@latest               # prompts for everything
+npm create portaljs@latest my-portal     # name from argv, prompts for the rest
+# equivalently: npx create-portaljs@latest my-portal / pnpm create portaljs / yarn create portaljs
+```
+
+### CLI surface
+
+```
+create-portaljs [directory] [options]
+
+Arguments:
+  directory                 Target directory (also the default project slug).
+
+Options:
+  --namespace <theme|owner> Namespace mode (default: theme).
+  --name <string>           Human project name (default: derived from directory).
+  --description <string>    One-line description (default: "An open data portal.").
+  --ref <git-ref>           Template ref to fetch (default: main).
+  --no-install              Skip `npm install`.
+  --no-git                  Skip `git init`.
+  -y, --yes                 Accept all defaults, no prompts (CI-friendly).
+  -h, --help                Show help.
+```
+
+Any option provided on the CLI skips its prompt. With `--yes`, all prompts are skipped.
+
+## Behavior (step by step)
+
+1. **Resolve inputs.** Parse argv; for anything missing (and not `--yes`), prompt:
+   directory, project name, description, namespace mode, install?, git init?.
+2. **Guard the target.** If the directory exists and is non-empty, error out (don't
+   overwrite) and ask for a different name — never clobber.
+3. **Fetch the template.** Download `github:datopian/portaljs/examples/portaljs-catalog#<ref>`
+   into the target via `giget` (`downloadTemplate`) — reliable subdirectory extraction, no
+   git history, no `node_modules`. (This is the robust replacement for the `degit`
+   tarball-fallback bug from #1549.)
+4. **Substitute tokens** in all text files under the target:
+   `__PROJECT_NAME__` → name, `__PROJECT_SLUG__` → slug (kebab-cased dir name),
+   `__DESCRIPTION__` → description.
+5. **Set namespace mode.** Rewrite `NAMESPACE_TYPE` in `lib/datasets.ts` to the chosen
+   `theme` | `owner`.
+6. **Optional `git init`** (+ an initial commit) and **`npm install`**.
+7. **Print next steps:** `cd <dir>`, `npm run dev`, and pointers to `/add-dataset` /
+   `/add-resource` / `/connect-ckan` / `/deploy`.
+
+## Implementation notes
+
+- **Runtime:** Node >= 18, plain ESM (`index.mjs` with a shebang) — no build/transpile step.
+- **Dependencies:** `giget` (template fetch) + `prompts` (interactive). Both small,
+  established. No framework.
+- **Token substitution** walks the tree in JS (read → replace → write) over text
+  extensions (`.ts .tsx .js .json .css .md`), skipping binaries.
+- **Idempotent-ish:** refuses to scaffold into a non-empty dir; safe to re-run with a new
+  name.
+
+## Publishing
+
+- Package name **`create-portaljs`** (unscoped) — so `npm create portaljs` resolves to it,
+  and it sidesteps the parked `@portaljs/*` scope-token blocker.
+- Still requires an npm publish credential / automation token (the one prerequisite).
+- Versioned with the repo (changesets). `@latest` is what `npm create portaljs@latest` uses.
+
+## Acceptance
+
+- `node packages/create-portaljs/index.mjs /tmp/p --yes` produces a portal that
+  `npm install && npm run build` passes, with tokens substituted (no `__…__` left) and
+  `NAMESPACE_TYPE` set.
+- Refuses to scaffold into a non-empty directory.
+- Works via `npm create portaljs@latest` once published.

--- a/packages/create-portaljs/index.mjs
+++ b/packages/create-portaljs/index.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// create-portaljs — scaffold a PortalJS data portal.
+//   npm create portaljs@latest my-portal
+// See SPEC.md. Plain ESM, Node >= 18, deps: giget + prompts.
+
+import { existsSync, readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs'
+import { join, basename, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const TEMPLATE = 'examples/portaljs-catalog'
+const TEXT_EXT = new Set(['.ts', '.tsx', '.js', '.mjs', '.json', '.css', '.md', '.html'])
+
+function parseArgs(argv) {
+  const o = { install: true, git: true, yes: false, ref: 'main' }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '-h' || a === '--help') o.help = true
+    else if (a === '-y' || a === '--yes') o.yes = true
+    else if (a === '--no-install') o.install = false
+    else if (a === '--no-git') o.git = false
+    else if (a === '--namespace') o.namespace = argv[++i]
+    else if (a === '--name') o.name = argv[++i]
+    else if (a === '--description') o.description = argv[++i]
+    else if (a === '--ref') o.ref = argv[++i]
+    else if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=')
+      if (v !== undefined) o[k] = v
+    } else if (!o.dir) o.dir = a
+  }
+  return o
+}
+
+const HELP = `
+create-portaljs — scaffold a PortalJS data portal
+
+Usage:
+  npm create portaljs@latest [directory] [options]
+
+Options:
+  --namespace <theme|owner>  Namespace mode (default: theme)
+  --name <string>            Human project name (default: from directory)
+  --description <string>     One-line description
+  --ref <git-ref>            Template ref to fetch (default: main)
+  --no-install               Skip npm install
+  --no-git                   Skip git init
+  -y, --yes                  Accept defaults, no prompts
+  -h, --help                 Show this help
+`
+
+const slugify = (s) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'my-portal'
+
+function fail(msg) {
+  console.error(`\n✖ ${msg}\n`)
+  process.exit(1)
+}
+
+// Recursively substitute the template's placeholder tokens in text files.
+function substitute(dir, replacements) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.git') continue
+    const p = join(dir, entry)
+    const st = statSync(p)
+    if (st.isDirectory()) {
+      substitute(p, replacements)
+    } else if (TEXT_EXT.has(p.slice(p.lastIndexOf('.')))) {
+      let s = readFileSync(p, 'utf8')
+      let changed = false
+      for (const [token, value] of replacements) {
+        if (s.includes(token)) {
+          s = s.split(token).join(value)
+          changed = true
+        }
+      }
+      if (changed) writeFileSync(p, s)
+    }
+  }
+}
+
+function run(cmd, args, cwd) {
+  const r = spawnSync(cmd, args, { cwd, stdio: 'inherit' })
+  return r.status === 0
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  if (opts.help) {
+    console.log(HELP)
+    return
+  }
+
+  // Lazy-load deps so --help works even before install resolves them.
+  const prompts = (await import('prompts')).default
+  const { downloadTemplate } = await import('giget')
+
+  const onCancel = () => fail('Cancelled.')
+  const ask = async (questions) =>
+    opts.yes ? {} : prompts(questions, { onCancel })
+
+  // 1. Resolve inputs (CLI flags win; otherwise prompt unless --yes).
+  let dir = opts.dir
+  if (!dir) {
+    const a = await ask({
+      type: 'text',
+      name: 'dir',
+      message: 'Project directory',
+      initial: 'my-portal',
+    })
+    dir = a.dir || 'my-portal'
+  }
+  const slug = slugify(basename(dir))
+  const name =
+    opts.name ??
+    (await ask({
+      type: 'text',
+      name: 'name',
+      message: 'Project name',
+      initial: slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+    })).name ??
+    slug
+  const description =
+    opts.description ??
+    (await ask({
+      type: 'text',
+      name: 'description',
+      message: 'One-line description',
+      initial: 'An open data portal.',
+    })).description ??
+    'An open data portal.'
+  const namespace =
+    opts.namespace ??
+    (await ask({
+      type: 'select',
+      name: 'namespace',
+      message: 'Namespace mode',
+      choices: [
+        { title: 'theme — single publisher, group by subject', value: 'theme' },
+        { title: 'owner — multiple publishers, group by who published', value: 'owner' },
+      ],
+      initial: 0,
+    })).namespace ??
+    'theme'
+  if (namespace !== 'theme' && namespace !== 'owner') fail(`Invalid --namespace: ${namespace}`)
+
+  const doInstall = opts.install &&
+    (opts.yes || (await ask({ type: 'confirm', name: 'v', message: 'Install dependencies?', initial: true })).v !== false)
+  const doGit = opts.git &&
+    (opts.yes || (await ask({ type: 'confirm', name: 'v', message: 'Initialize a git repo?', initial: true })).v !== false)
+
+  // 2. Guard the target directory.
+  const target = resolve(process.cwd(), dir)
+  if (existsSync(target) && readdirSync(target).length > 0) {
+    fail(`Directory "${dir}" already exists and is not empty. Choose another name.`)
+  }
+
+  // 3. Fetch the template (reliable subdir extraction; no degit fallback bug).
+  console.log(`\nScaffolding ${name} → ${dir} (template @ ${opts.ref})`)
+  try {
+    await downloadTemplate(`github:datopian/portaljs/${TEMPLATE}#${opts.ref}`, {
+      dir: target,
+      force: true,
+    })
+  } catch (e) {
+    fail(`Failed to fetch the template: ${e?.message || e}`)
+  }
+
+  // 4. Substitute placeholder tokens.
+  substitute(target, [
+    ['__PROJECT_NAME__', name],
+    ['__PROJECT_SLUG__', slug],
+    ['__DESCRIPTION__', description],
+  ])
+
+  // 5. Set the namespace mode in lib/datasets.ts.
+  const datasetsTs = join(target, 'lib', 'datasets.ts')
+  if (existsSync(datasetsTs)) {
+    const s = readFileSync(datasetsTs, 'utf8').replace(
+      /export const NAMESPACE_TYPE: 'theme' \| 'owner' = '(theme|owner)'/,
+      `export const NAMESPACE_TYPE: 'theme' | 'owner' = '${namespace}'`
+    )
+    writeFileSync(datasetsTs, s)
+  }
+
+  // 6. Optional git init + install.
+  if (doGit && !existsSync(join(target, '.git'))) {
+    if (run('git', ['init', '-q'], target)) {
+      run('git', ['add', '-A'], target)
+      run('git', ['commit', '-q', '-m', 'chore: scaffold PortalJS portal'], target)
+    }
+  }
+  if (doInstall) {
+    console.log('\nInstalling dependencies…')
+    if (!run('npm', ['install'], target)) {
+      console.log('npm install failed — you can run it yourself in the project.')
+    }
+  }
+
+  // 7. Next steps.
+  console.log(`
+✔ Created ${name} in ${dir}
+
+Next:
+  cd ${dir}${doInstall ? '' : '\n  npm install'}
+  npm run dev            # → http://localhost:3000
+
+Then, in a Claude Code session, build it out:
+  /add-dataset   ./data/your-file.csv     add data (or /add-resource for more files)
+  /connect-ckan  <ckan-url>               point at a CKAN backend instead
+  /deploy                                 publish (Cloudflare Pages recommended)
+`)
+}
+
+main().catch((e) => fail(e?.message || String(e)))

--- a/packages/create-portaljs/package.json
+++ b/packages/create-portaljs/package.json
@@ -28,6 +28,9 @@
     "directory": "packages/create-portaljs"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "giget": "^1.2.3",
     "prompts": "^2.4.2"

--- a/packages/create-portaljs/package.json
+++ b/packages/create-portaljs/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "create-portaljs",
+  "version": "0.1.0",
+  "description": "Scaffold a PortalJS data portal — npm create portaljs@latest",
+  "type": "module",
+  "bin": {
+    "create-portaljs": "index.mjs"
+  },
+  "files": [
+    "index.mjs",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "portaljs",
+    "data-portal",
+    "create",
+    "scaffold",
+    "cli",
+    "nextjs"
+  ],
+  "homepage": "https://github.com/datopian/portaljs/tree/main/packages/create-portaljs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/datopian/portaljs.git",
+    "directory": "packages/create-portaljs"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "giget": "^1.2.3",
+    "prompts": "^2.4.2"
+  }
+}


### PR DESCRIPTION
Adds **`create-portaljs`** — the canonical, zero-prerequisite, no-AI way to scaffold a portal, matching the DX developers expect (`create-next-app`, `create-vite`). Closes **po-pd1**.

```bash
npm create portaljs@latest my-portal
```

## Why
The existing scaffold paths each have friction (issue #1556): `npx tiged …` is obscure and bare; `/new-portal` needs Claude Code; cloning the repo scaffolds *inside* the framework. `create-portaljs` is one memorable command — the strongest OSS-adoption top-of-funnel and a clean thing to lead the README/landing/Show HN with.

## What it does
A small ESM CLI (`packages/create-portaljs`, Node ≥18, deps `giget` + `prompts`, no build step):
1. Prompts for directory, name, description, namespace mode, install?, git? (any provided as a flag skips its prompt; `--yes` skips all).
2. Refuses to scaffold into a non-empty dir.
3. Fetches `examples/portaljs-catalog` via **`giget`** — reliable subdirectory extraction (the robust replacement for the `degit` tarball-fallback bug, #1549).
4. Substitutes `__PROJECT_NAME__` / `__PROJECT_SLUG__` / `__DESCRIPTION__` and sets `NAMESPACE_TYPE`.
5. Optional `git init` + `npm install`, then prints next steps (`npm run dev`, `/add-dataset`, `/deploy`).

Full spec in `packages/create-portaljs/SPEC.md`.

## Verified
`node index.mjs /tmp/p --yes --namespace owner --name "Test Portal"` → no leftover tokens, `package.json` name = slug, `NAMESPACE_TYPE = 'owner'`, and `npm install && npm run build` passes. `--help` works without deps resolved.

## Remaining (not in this PR)
- **Publish to npm** — `create-portaljs` is unscoped, so it sidesteps the parked `@portaljs/*` scope-token blocker, but still needs an npm publish credential/automation token. That's the one prerequisite before `npm create portaljs@latest` works publicly.
- A changeset / workspace-lock update at release time (left to the maintainer release flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the `create-portaljs` CLI to scaffold a PortalJS data portal from a remote template, with interactive prompts (or non-interactive `--yes`).
  * Supports options for namespace mode, project metadata (name/description), template ref, target directory, and optional skipping of install and git setup; updates namespace configuration in the scaffold and prints next steps.

* **Documentation**
  * Added `create-portaljs` README and a CLI behavior/spec document covering usage, options, flow, and rerun safety.

* **Chores**
  * Added an initial release Changesets entry for `create-portaljs`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->