### PR TITLE
chore(release): scope publishing to create-portaljs (unblock npm release)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@portaljs/core", "@portaljs/ckan", "@portaljs/ckan-api-client-js"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11073,7 +11073,7 @@
     },
     "packages/core": {
       "name": "@portaljs/core",
-      "version": "1.0.10",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.3.3",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @portaljs/core
 
-## 1.0.10
-
-### Patch Changes
-
-- [#1532](https://github.com/datopian/portaljs/pull/1532) [`8bb5c310440fee6e68a8af98367085ee6f546db6`](https://github.com/datopian/portaljs/commit/8bb5c310440fee6e68a8af98367085ee6f546db6) Thanks [@anuveyatsu](https://github.com/anuveyatsu)! - Widen peer dependencies so the package installs on the modern stack without `--legacy-peer-deps`: `react`/`react-dom` now allow `^19` (in addition to `^18`), and `next` is `>=13.2.1` (allowing Next 14–16).
-
 ## 1.0.8
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@portaljs/core",
-  "version": "1.0.10",
+  "version": "1.0.9",
   "description": "Core Portal.JS components, configs and utils.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Unblocks the `create-portaljs` publish (po-pd1) while the `@portaljs` scope stays token-blocked.

## Problem
The Release workflow runs `changeset publish`, which attempts **every** unpublished public package. `@portaljs/core` is at **1.0.10** locally (peer-deps widening, #1532) but **never published** — the NPM_TOKEN can't publish to the `@portaljs` scope. So when the Version Packages PR (#1562) merges, the publish would try `@portaljs/core@1.0.10` and **fail**, turning Release red on every push.

Note: `changeset publish` honors **only `private`**, *not* the `ignore` config — so "ignore @portaljs/core" alone can't exclude it from publish.

## Fix (scoped, reversible)
- **Revert `@portaljs/core` 1.0.10 → 1.0.9** so it matches npm and `changeset publish` skips it. Only the *unpublished release metadata* is reverted; the peer-deps widening **code** stays in `core`'s `peerDependencies`. → **Re-release `@portaljs/core` (re-add a changeset) once the `@portaljs` scope token is available.**
- Add `@portaljs/*` to changesets `ignore` so future version PRs don't re-bump them ahead of npm while the scope is blocked.
- Resync `package-lock.json` for `core@1.0.9` (**`npm ci` verified**).

`create-portaljs` is unscoped → publishes with the current token.

## After this lands
1. Merge **#1562** (Version Packages, create-portaljs → 0.2.0) → `changeset publish` publishes **create-portaljs@0.2.0**, skips `@portaljs/*` → green run.
2. `npm create portaljs@latest` is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Core package version downgraded to 1.0.9

* **Chores**
  * Updated release configuration to adjust package versioning behavior
  * Removed associated changelog entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->