### PR TITLE
ci(release): Discord notification on npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # - name: Send a Discord notification if a publish happens
-      #   if: steps.changesets.outputs.published == 'true'
-      #   uses: Ilshidur/action-discord@0.3.2
-      #   with:
-      #     args: 'The project {{ EVENT_PAYLOAD.repository.full_name }} has been deployed.'
+      - name: Send a Discord notification if a publish happens
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true # a missing/broken webhook must never fail a good release
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: '📦 {{ EVENT_PAYLOAD.repository.full_name }} published a new release to npm.'


### PR DESCRIPTION
Enables the (previously commented-out) Discord notification in the Release workflow.

- Fires **only on an actual publish** (`steps.changesets.outputs.published == 'true'`), not on Version-PR runs.
- Reads the **`DISCORD_WEBHOOK`** repo secret.
- `continue-on-error: true` — a missing or broken webhook will **never fail an otherwise-successful release**.

**Requires:** add a repo secret **`DISCORD_WEBHOOK`** = a Discord channel webhook URL. Until that's set, the step is a harmless no-op (continue-on-error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release notification system to improve notification of new package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->