### PR TITLE
docs: recommend 'npm create portaljs@latest' across README + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,37 @@
 
 ## Quickstart
 
-**Build one with your AI assistant** — the recommended path. Install the skills once,
-then create portals from **any directory** (not inside this repo):
+**Create a portal** — one command, nothing to install beyond Node 18+:
 
 ```bash
-# 1. Install the PortalJS skills (once) — into ~/.claude/commands
+npm create portaljs@latest my-portal
+cd my-portal
+npm run dev      # → http://localhost:3000
+```
+
+You get the three surfaces — Home, a Catalog (`/search`), and a dataset Showcase
+(`/@<namespace>/<slug>`) — over sample data. Plain, editable Next.js, no lock-in. Add your
+own CSV/JSON to `datasets.json` and it renders automatically.
+
+**Build it with your AI assistant** — PortalJS ships [Claude Code](https://claude.com/claude-code)
+skills that do the assembly. Install them once (into `~/.claude/commands`):
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/datopian/portaljs/main/scripts/install-portaljs-skills.sh | bash
 ```
 
-Then, from a fresh working directory, in a [Claude Code](https://claude.com/claude-code) session:
+Then, in a Claude Code session from any directory:
 
 ```text
+/architect    not sure what stack you need? start here
 /new-portal   "Auckland Council open data portal"
 /add-dataset  ./data/air-quality.csv
 ```
 
-`/new-portal` fetches the latest template and scaffolds the three surfaces; `/add-dataset`
-loads your data; `/architect` picks an architecture first if you're unsure; `/connect-ckan`
-points it at a CKAN backend. ([Install details + all skills →](.claude/INSTALL.md))
+`/new-portal` scaffolds the three surfaces; `/add-dataset` (or `/add-resource`) loads data;
+`/connect-ckan` points it at a CKAN backend; `/deploy` ships it. ([All skills + install →](.claude/INSTALL.md))
 
-**Or build by hand** — plain Next.js, no AI, no lock-in:
+**Prefer the bare template** — plain Next.js, no AI, no lock-in:
 
 ```bash
 npx tiged datopian/portaljs/examples/portaljs-catalog my-portal
@@ -126,21 +137,16 @@ a working portal.
 
 ### Setup
 
-The skills live in this repo under [`.claude/commands/`](.claude/commands/). The quickest
-way to try them is from a clone:
+Install the skills once into your personal scope so they're available from **any**
+directory:
 
 ```bash
-git clone https://github.com/datopian/portaljs
-cd portaljs
-claude
+curl -fsSL https://raw.githubusercontent.com/datopian/portaljs/main/scripts/install-portaljs-skills.sh | bash
 ```
 
-Claude Code auto-discovers the slash commands from `.claude/commands/` — no install step.
-Type `/` in the session to see them.
-
-> **Install anywhere:** the skills and template are also packaged as a Claude Code plugin
-> and can be installed into `~/.claude/commands/` so you can run them from any project. See
-> [`.claude/INSTALL.md`](.claude/INSTALL.md).
+Restart Claude Code (or open a new session) and type `/` to see them. See
+[`.claude/INSTALL.md`](.claude/INSTALL.md) for other install options (versioned plugin, or
+running straight from a clone of this repo).
 
 ### Use
 
@@ -159,12 +165,14 @@ scaffolds the three surfaces; `/add-dataset` appends to the `datasets.json` mani
 the showcase renders automatically at `/@<namespace>/<slug>`. Run `npm run dev` and you
 have a portal.
 
-**Prefer to build by hand?** Clone the canonical template — the skills are a convenience,
-not a requirement:
+**Prefer to build by hand?** The skills are a convenience, not a requirement — scaffold the
+template directly with the CLI:
 
 ```bash
-npx tiged datopian/portaljs/examples/portaljs-catalog my-portal
+npm create portaljs@latest my-portal
 ```
+
+(Or grab the bare template with no prompts: `npx tiged datopian/portaljs/examples/portaljs-catalog my-portal`.)
 
 ### Available skills
 

--- a/site/content/docs/manual-setup.md
+++ b/site/content/docs/manual-setup.md
@@ -16,19 +16,24 @@ the same project by hand. This page shows how.
 
 ## 1. Get the template
 
-Grab the canonical catalog template with [tiged](https://github.com/tiged/tiged)
-(a maintained `degit` fork that reliably extracts the subdirectory — no git history, just the files):
+Scaffold the canonical catalog template with the `create-portaljs` CLI — it copies the
+template, substitutes your project name, and sets the namespace mode:
 
 ```bash
-npx tiged datopian/portaljs/examples/portaljs-catalog my-portal
+npm create portaljs@latest my-portal
 cd my-portal
-npm install
+npm install   # (the CLI offers to do this for you)
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000). You now have a running portal —
 a home page (`/`), a search catalog at `/search`, and per-dataset showcase pages — with
 a few sample datasets.
+
+> [!note] Bare copy, no prompts
+> To grab just the files with no scaffolding prompts, use
+> [tiged](https://github.com/tiged/tiged) (a maintained `degit` fork that reliably
+> extracts the subdirectory): `npx tiged datopian/portaljs/examples/portaljs-catalog my-portal`.
 
 > [!note] Just a landing page?
 > If you only want a single home page with no catalog or dataset pages, use the

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -5,9 +5,20 @@ title: Quickstart — the AI path
 description: Install the PortalJS skills, scaffold a portal, add your data, and go live in minutes — your AI assistant does the assembly.
 ---
 
-This is the fast path. You'll install the PortalJS skills into
+> [!tip] One-command start
+> The fastest way to a working portal — no AI, nothing to install beyond Node 18+:
+>
+> ```bash
+> npm create portaljs@latest my-portal
+> cd my-portal && npm run dev
+> ```
+>
+> That scaffolds the full template. The rest of this page is the **AI-assisted** path:
+> install the skills and drive the whole build (and ongoing changes) from chat.
+
+This page is the AI path. You'll install the PortalJS skills into
 [Claude Code](https://docs.claude.com/en/docs/claude-code), then drive the whole
-build from chat. Prefer to build by hand? See [Manual setup](/docs/manual-setup)
+build from chat. Prefer to build entirely by hand? See [Manual setup](/docs/manual-setup)
 instead.
 
 > [!info] Prerequisites

--- a/site/content/docs/templates.md
+++ b/site/content/docs/templates.md
@@ -42,7 +42,13 @@ the URL is always `/@<namespace>/<slug>`. See [Core concepts](/docs/core-concept
 the rationale. [`/add-dataset`](/docs/skills/add-dataset) appends a manifest entry
 against this template.
 
-Clone it by hand with [tiged](https://github.com/tiged/tiged) (a maintained `degit` fork that reliably extracts a subdirectory):
+Scaffold it with the CLI (recommended):
+
+```bash
+npm create portaljs@latest my-portal
+```
+
+Or grab the bare files with [tiged](https://github.com/tiged/tiged) (a maintained `degit` fork that reliably extracts a subdirectory):
 
 ```bash
 npx tiged datopian/portaljs/examples/portaljs-catalog my-portal


### PR DESCRIPTION
`create-portaljs` is now live on npm, so the docs should lead with it. This updates the recommended usage everywhere.

## Changes
- **README Quickstart** now leads with **`npm create portaljs@latest my-portal`** (one command, no prereqs), then the AI-skills path (install script → `/new-portal`/`/add-dataset`/…), then the bare `tiged` template.
- **Fixed a stale README "Setup" section** that still recommended `git clone … && claude` — i.e. scaffolding *inside* the framework repo (the #1556 friction). Now: install the skills, run them from any dir.
- **docs/quickstart** — added a one-command `npm create portaljs` tip at the top of the AI-path page.
- **docs/manual-setup + docs/templates** — scaffold via the CLI (recommended); `tiged` kept as the bare, no-prompts alternative.

Verified `npm create portaljs@latest` end-to-end from the registry before writing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined setup instructions across documentation to highlight the `npm create portaljs@latest` command as the primary starting point
  * Added a direct non-AI scaffolding path option in Quickstart documentation
  * Reorganized AI-assisted setup workflow guidance
  * Updated template setup instructions with modern CLI approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->