### PR TITLE
fix(template): showcase breadcrumb 'Datasets' → 'Search'

### DIFF
--- a/examples/portaljs-catalog/pages/[owner]/[slug].tsx
+++ b/examples/portaljs-catalog/pages/[owner]/[slug].tsx
@@ -58,7 +58,7 @@ export default function DatasetPage({ dataset }: { dataset: Dataset }) {
           </Link>
           <span className="mx-2">/</span>
           <Link href="/search" className="hover:text-gray-700">
-            Datasets
+            Search
           </Link>
           <span className="mx-2">/</span>
           <span>{dataset.name}</span>


### PR DESCRIPTION
The dataset showcase breadcrumb linked to `/search` but read "Home / Datasets / <name>". Label it **Search** to match the destination (the Search/Catalog surface). Reported from a fresh `npm create portaljs` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded "cyclone" animation with gradient effects and elapsed timer during installation; automatically falls back to simple text in CI and non-interactive environments.
  * Enhanced install process with improved error handling and diagnostic feedback.

* **UI Improvements**
  * Updated breadcrumb navigation text from "Datasets" to "Search" for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->