### PR TITLE
feat(create-portaljs): bundle agentic skills into scaffold

### DIFF
--- a/.changeset/create-portaljs-bundle-skills.md
+++ b/.changeset/create-portaljs-bundle-skills.md
@@ -1,0 +1,5 @@
+---
+'create-portaljs': minor
+---
+
+Bundle the PortalJS agentic skills into the scaffolded project's `.claude/commands/`. The skills now travel with the new portal — running `claude` in the project directory picks up `/add-dataset`, `/connect-ckan`, `/deploy`, etc. immediately, with no separate global install. Skills are fetched at the same template ref as the scaffold (so they match) and pruned to the OSS allowlist; a fetch failure is non-fatal and prints the manual install one-liner.

--- a/packages/create-portaljs/README.md
+++ b/packages/create-portaljs/README.md
@@ -38,6 +38,8 @@ Any option given on the CLI skips its prompt; `--yes` skips all prompts.
 
 ## What next
 
-Build it out with the PortalJS skills (or by hand — it's just Next.js):
+The PortalJS agentic skills are bundled into the new project's `.claude/commands/`,
+so they work the moment you run `claude` in the portal directory — no separate
+install. Build it out with them (or by hand — it's just Next.js):
 `/add-dataset`, `/add-resource`, `/add-chart`, `/add-map`, `/connect-ckan`, `/deploy`.
 See the [docs](https://www.portaljs.com/docs/quickstart).

--- a/packages/create-portaljs/index.mjs
+++ b/packages/create-portaljs/index.mjs
@@ -3,12 +3,30 @@
 //   npm create portaljs@latest my-portal
 // See SPEC.md. Plain ESM, Node >= 18, deps: giget + prompts.
 
-import { existsSync, readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, writeFileSync, statSync, rmSync } from 'node:fs'
 import { join, basename, resolve } from 'node:path'
 import { spawn, spawnSync } from 'node:child_process'
 
 const TEMPLATE = 'examples/portaljs-catalog'
 const TEXT_EXT = new Set(['.ts', '.tsx', '.js', '.mjs', '.json', '.css', '.md', '.html'])
+
+// Where the agentic skills live in the repo, and the OSS allowlist we bundle into
+// the scaffold's project-local .claude/commands/ (so `claude` in the new portal
+// sees /add-dataset, /connect-ckan, … with no separate install step). Kept in sync
+// with .claude-plugin/plugin.json and scripts/install-portaljs-skills.sh.
+const SKILLS_SRC = '.claude/commands'
+const SKILLS = [
+  'architect',
+  'new-portal',
+  'add-dataset',
+  'add-resource',
+  'add-chart',
+  'add-map',
+  'connect-ckan',
+  'define-schema',
+  'deploy',
+  'check-data-quality',
+]
 
 function parseArgs(argv) {
   const o = { install: true, git: true, yes: false, ref: 'main' }
@@ -280,6 +298,30 @@ async function main() {
     writeFileSync(datasetsTs, s)
   }
 
+  // 5b. Bundle the agentic skills into the project's .claude/commands/ so they
+  // work the instant the user runs `claude` in the new portal — no global
+  // install. Pinned to the same template ref, so skills match the scaffold.
+  // The repo's .claude/commands holds only OSS skills today; we still prune to
+  // the allowlist so a future internal command never leaks into a scaffold.
+  // Non-fatal: a fetch failure just prints the manual install one-liner.
+  const skillsDir = join(target, '.claude', 'commands')
+  try {
+    await downloadTemplate(`github:datopian/portaljs/${SKILLS_SRC}#${opts.ref}`, {
+      dir: skillsDir,
+      force: true,
+    })
+    for (const entry of readdirSync(skillsDir)) {
+      const keep = entry.endsWith('.md') && SKILLS.includes(entry.slice(0, -3))
+      if (!keep) rmSync(join(skillsDir, entry), { recursive: true, force: true })
+    }
+    console.log(`Bundled ${SKILLS.length} PortalJS skills into .claude/commands/`)
+  } catch (e) {
+    console.log(
+      `\x1b[33m⚠\x1b[0m  Could not bundle skills (${e?.message || e}). Install them with:\n` +
+        '   curl -fsSL https://raw.githubusercontent.com/datopian/portaljs/main/scripts/install-portaljs-skills.sh | bash'
+    )
+  }
+
   // 6. Optional git init + install.
   if (doGit && !existsSync(join(target, '.git'))) {
     if (run('git', ['init', '-q'], target)) {
@@ -307,7 +349,8 @@ Next:
   cd ${dir}${doInstall ? '' : '\n  npm install'}
   npm run dev            # → http://localhost:3000
 
-Then, in a Claude Code session, build it out:
+Then run \`claude\` in the project — the PortalJS skills are bundled in
+.claude/commands/, so these work right away:
   /add-dataset   ./data/your-file.csv     add data (or /add-resource for more files)
   /connect-ckan  <ckan-url>               point at a CKAN backend instead
   /deploy                                 publish (Cloudflare Pages recommended)


### PR DESCRIPTION
## Problem

After `npm create portaljs@latest`, running `claude` in the new portal showed **no PortalJS skills**. The template subdir (`examples/portaljs-catalog`) ships no `.claude/`, so giget pulls zero skills; the skills live at repo-root `.claude/commands/` and only install globally via `install-portaljs-skills.sh`. The CLI never told the user that — dead end.

## Fix

create-portaljs now bundles the skills into the scaffold's project-local `.claude/commands/`:
- Fetched at the **same template ref** as the scaffold, so skills match the template version.
- Pruned to the OSS allowlist (kept in sync with `plugin.json` / `install-portaljs-skills.sh`) so a future internal command can't leak into a scaffold.
- **Non-fatal**: a fetch failure prints the manual install one-liner instead of erroring.
- Runs before git init, so the skills are part of the scaffold commit.
- "Next steps" output + package README updated to say the skills are bundled.

## Verification

Scaffolded `--no-install --no-git --ref main` → all **10 skills** land in `.claude/commands/` (`add-chart, add-dataset, add-map, add-resource, architect, check-data-quality, connect-ckan, define-schema, deploy, new-portal`). `node --check` passes.

Changeset: minor → create-portaljs 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PortalJS agentic skills are now pre-bundled in scaffolded projects, making commands like `/add-dataset`, `/connect-ckan`, and `/deploy` immediately available without separate installation.

* **Documentation**
  * Updated scaffolding instructions to reflect that skills are now bundled by default and ready to use when running the CLI tool in your project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->