### PR TITLE
fix(connect-ckan): drop @portaljs/ckan, use a server-side fetch wrapper (po-0m8)

### DIFF
--- a/.claude/commands/connect-ckan.md
+++ b/.claude/commands/connect-ckan.md
@@ -1,5 +1,5 @@
 ---
-description: Wire a scaffolded PortalJS portal to a CKAN backend over its API. Installs @portaljs/ckan and feeds the /search catalog and /@<namespace>/<slug> showcases from CKAN instead of datasets.json.
+description: Wire a scaffolded PortalJS portal to a CKAN backend over its API. Generates a tiny server-side fetch client (no runtime dependency) and feeds the /search catalog and /@<namespace>/<slug> showcases from CKAN instead of datasets.json.
 allowed-tools: Read, Write, Edit, Bash, WebFetch
 ---
 
@@ -9,8 +9,15 @@ Connect an existing `portaljs-catalog` portal to a live CKAN backend. The portal
 reading the static `datasets.json` manifest (and files in `/public/data/`) and instead
 feeds its two data surfaces — the **`/search` catalog** and the **`/@<namespace>/<slug>`
 showcases** — straight from a CKAN instance's REST API (`package_search` / `package_show`)
-using the `@portaljs/ckan` client. Output is plain, editable Next.js code — no opaque
-framework wiring.
+through a tiny generated fetch client. Output is plain, editable Next.js code with **no
+runtime dependency** — no opaque framework wiring.
+
+> **Why a fetch client, not `@portaljs/ckan`?** That package's bundle wires React UI
+> components to React 18 internals (`ReactCurrentDispatcher`) and crashes at import under
+> the template's React 19 — even server-side, where this skill imports it. The CKAN client
+> class is locked inside that same module, so it can't be used in isolation. A ~40-line
+> `fetch` wrapper covers the two REST actions this skill needs (`package_search`,
+> `package_show`), is server-side only, ships zero client bytes, and has no React coupling.
 
 Use this for the "decoupled / any backend" path: the user has a CKAN data management
 system (their own or a public one) and wants a browseable portal in front of it.
@@ -21,9 +28,8 @@ dataset list first. If the user says up front they want a CKAN backend, scaffold
 sample data, then run `/connect-ckan` to swap the source over to CKAN. Only a CKAN base
 URL is required.
 
-The generated pages fetch CKAN **server-side** in `getStaticProps`/`getStaticPaths`, so
-the `@portaljs/ckan` bundle never reaches the browser — the client stays lean and the
-site can be statically deployed.
+The generated pages fetch CKAN **server-side** in `getStaticProps`/`getStaticPaths`, so the
+catalog is pre-rendered at build time and the site can be statically deployed.
 
 ## Required input — ask, don't error
 
@@ -82,42 +88,17 @@ If any returns `success: false`, tell the user that org wasn't found, list the v
 from `organization_list`, and ask which one they meant (or to drop the filter) before
 continuing.
 
-### 4. Install `@portaljs/ckan` (once)
+### 4. Generate the CKAN client module (a tiny fetch wrapper)
 
-Tell the user first: `Installing @portaljs/ckan...`
-
-```bash
-cd PORTAL_DIR && npm install @portaljs/ckan@^0.1.0
-```
-
-If install fails, tell the user (check Node.js >=18 and network access) and retry.
-
-### 5. Patch `tsconfig.json` so TypeScript resolves the CKAN types
-
-`@portaljs/ckan` ships its `index.d.ts` but its `package.json` `exports` field has no
-`types` condition, so under the template's `moduleResolution: "bundler"` the build fails
-with *"Could not find a declaration file for module '@portaljs/ckan'"*. Fix it by adding a
-`paths` mapping to the declaration file.
-
-Open `PORTAL_DIR/tsconfig.json` and add the `@portaljs/ckan` key to `compilerOptions.paths`
-(keep any existing entries such as `"@/*"`):
-```jsonc
-"paths": {
-  "@/*": ["./*"],
-  "@portaljs/ckan": ["./node_modules/@portaljs/ckan/dist/index.d.ts"]
-}
-```
-If there is no `paths` object yet, create one with both keys. This step is mandatory — the
-build will not type-check without it.
-
-### 6. Generate the CKAN client module
-
-Write `PORTAL_DIR/lib/ckan.ts`. The provided URL becomes the default, overridable at deploy
-time via the `DMS` env var. Org/group filters and the build-time page cap live here as
-plain editable constants.
+Write `PORTAL_DIR/lib/ckan.ts` — a self-contained server-side client over the CKAN REST
+API. **No package install, no `tsconfig` changes**: it uses the built-in `fetch`, so there
+is nothing to add to `package.json` and no `paths` entry to maintain. The provided URL
+becomes the default, overridable at deploy time via the `DMS` env var. Org/group filters
+and the build-time page cap live here as plain editable constants.
 
 ```ts
-import { CKAN } from '@portaljs/ckan'
+// Minimal server-side CKAN client — plain fetch, no dependency, no React coupling.
+// Used ONLY in getStaticProps/getStaticPaths, so it never reaches the browser bundle.
 
 // CKAN backend base URL. Override at deploy time with the DMS env var.
 export const DMS = (process.env.DMS || 'CKAN_URL').replace(/\/+$/, '')
@@ -130,12 +111,65 @@ export const GROUP_FILTER: string[] = [/* GROUP_FILTER */]
 // note every dataset becomes one statically generated page.
 export const MAX_DATASETS = 200
 
-// Shared client. Used ONLY in getStaticProps/getStaticPaths (server side),
-// so the @portaljs/ckan bundle never reaches the browser.
-export const ckan = new CKAN(DMS)
+// CKAN REST shapes — only the fields the pages read.
+type CkanResource = { id: string; name?: string; format?: string; url?: string }
+type CkanOrganization = { name?: string; title?: string }
+export type CkanPackage = {
+  name: string
+  title?: string
+  notes?: string
+  organization?: CkanOrganization
+  resources?: CkanResource[]
+}
+
+export type SearchArgs = {
+  offset?: number
+  limit?: number
+  tags?: string[]
+  orgs?: string[]
+  groups?: string[]
+}
+
+// Build a CKAN `fq` filter-query from org/group/tag lists (OR within a field).
+function buildFq({ orgs = [], groups = [], tags = [] }: SearchArgs): string {
+  const clause = (field: string, vals: string[]) =>
+    vals.length ? `${field}:(${vals.map((v) => `"${v}"`).join(' OR ')})` : ''
+  return [clause('organization', orgs), clause('groups', groups), clause('tags', tags)]
+    .filter(Boolean)
+    .join(' ')
+}
+
+async function ckanAction(action: string, params: Record<string, string>): Promise<any> {
+  const qs = new URLSearchParams(params).toString()
+  const res = await fetch(`${DMS}/api/3/action/${action}?${qs}`)
+  if (!res.ok) throw new Error(`CKAN ${action} failed: ${res.status} ${res.statusText}`)
+  const body = await res.json()
+  if (!body?.success) throw new Error(`CKAN ${action} returned success=false`)
+  return body.result
+}
+
+// The two-method surface the pages use. Add more actions (organization_list,
+// datastore_search, …) here as you extend the portal.
+export const ckan = {
+  async packageSearch(
+    args: SearchArgs = {}
+  ): Promise<{ datasets: CkanPackage[]; count: number }> {
+    const params: Record<string, string> = {
+      start: String(args.offset ?? 0),
+      rows: String(args.limit ?? MAX_DATASETS),
+    }
+    const fq = buildFq(args)
+    if (fq) params.fq = fq
+    const result = await ckanAction('package_search', params)
+    return { datasets: result.results ?? [], count: result.count ?? 0 }
+  },
+  async getDatasetDetails(slug: string): Promise<CkanPackage> {
+    return ckanAction('package_show', { id: slug })
+  },
+}
 
 // A card is the serializable shape passed to client components from the
-// server-side data functions (never pass the raw CKAN client across this seam).
+// server-side data functions (never pass the raw CKAN responses around unfiltered).
 export type DatasetCard = {
   slug: string
   namespace: string
@@ -154,12 +188,12 @@ export function datasetHref(d: { namespace: string; slug: string }): string {
 Substitute `CKAN_URL` with the real URL and fill `ORG_FILTER`/`GROUP_FILTER` with quoted
 org/group names (e.g. `['my-org']`), or leave them as `[]` if no filter was given.
 
-> **Keep CKAN calls server-side.** Only reference `ckan`, `DMS`, and the filters inside
-> `getStaticProps`/`getStaticPaths`. If a React component body imports them, Next.js bundles
-> the whole `@portaljs/ckan` package into the client. Pass plain serializable props to
-> components instead.
+> **Keep CKAN calls server-side.** Reference `ckan`, `DMS`, and the filters only inside
+> `getStaticProps`/`getStaticPaths`, and pass plain serializable props to components. The
+> fetch wrapper has no client cost, but keeping data-fetching server-side preserves the SSG
+> model (everything pre-rendered, statically hostable).
 
-### 7. Generate the CKAN-backed catalog at `/search`
+### 5. Generate the CKAN-backed catalog at `/search`
 
 The home page (`pages/index.tsx`) stays the search-first landing — its search box and chips
 already navigate to `/search`. Wire the **catalog list** at `PORTAL_DIR/pages/search.tsx`
@@ -238,7 +272,7 @@ you want live text filtering over the CKAN results, keep a client-side filter ov
 `package_search?q=` later. Leave `pages/index.tsx` as-is (it's the static search landing);
 only swap the catalog's data source. Tell the user what you changed.
 
-### 8. Generate the CKAN-backed showcase at `/@<namespace>/<slug>`
+### 6. Generate the CKAN-backed showcase at `/@<namespace>/<slug>`
 
 Overwrite `PORTAL_DIR/pages/[owner]/[slug].tsx` (the template's showcase route). It
 pre-renders one page per dataset via `getStaticPaths` and fetches full details with
@@ -361,7 +395,7 @@ export default function DatasetPage({ dataset }: { dataset: DatasetView }) {
 > `/add-map` skills target the static showcase's Views section, so they don't apply to the
 > CKAN-backed route as-is.
 
-### 9. Verify the build
+### 7. Verify the build
 
 ```bash
 cd PORTAL_DIR
@@ -371,19 +405,20 @@ tail -30 /tmp/connect-ckan-build.log
 ```
 
 If `BUILD_EXIT` is non-zero, print the log and fix the error before reporting success. Do
-not report success while the build is failing. Common cause: missing tsconfig `paths` entry
-(step 5).
+not report success while the build is failing. Common causes: a typo in the substituted
+`CKAN_URL`, or an org/group filter name that doesn't exist on the instance (the catalog
+comes back empty).
 
 > **Build time scales with dataset count.** Each dataset is one `package_show` request and
 > one static page. On large instances the build can be slow — `MAX_DATASETS` in `lib/ckan.ts`
 > caps it. If the cap is hit, tell the user how many datasets were rendered vs. the catalog
 > total and that they can raise `MAX_DATASETS`.
 
-### 10. Report success
+### 8. Report success
 
 ```
 ✓ Connected to CKAN: CKAN_URL
-  - Client:    lib/ckan.ts (DMS overridable via env var)
+  - Client:    lib/ckan.ts (fetch wrapper, no dependency; DMS overridable via env var)
   - Home:      pages/index.tsx → unchanged search landing (search box → /search)
   - Catalog:   pages/search.tsx → lists datasets from package_search, links to /@<ns>/<slug>
   - Showcase:  pages/[owner]/[slug].tsx → package_show, CSV/TSV preview via <Table>
@@ -399,9 +434,10 @@ Next: run `npm run dev` and visit http://localhost:3000, or run /deploy to publi
   fast, statically hostable, but data is fixed at build time — rebuild to pick up new CKAN
   datasets. For always-live data, deploy to a Node host and either switch the pages to
   `getServerSideProps` or set `getStaticPaths` `fallback: 'blocking'`.
-- **Client bundle stays clean.** `@portaljs/ckan` (which bundles React UI components) is
-  imported only in server-side data functions, so it is tree-shaken out of the browser
-  bundle. Keep it that way — never reference `ckan`/`DMS` in component bodies.
+- **No runtime dependency.** `lib/ckan.ts` is a plain `fetch` wrapper — nothing is added to
+  `package.json`, so there's no version to track and nothing to bundle. Keep CKAN calls in
+  server-side data functions (never reference `ckan`/`DMS` in component bodies) to preserve
+  the pre-rendered SSG model.
 - **DMS env var.** `lib/ckan.ts` reads `process.env.DMS` first, falling back to the URL you
   provided. Set `DMS` in the deploy environment to point at a different CKAN instance without
   editing code.
@@ -411,7 +447,8 @@ Next: run `npm run dev` and visit http://localhost:3000, or run /deploy to publi
 - **CORS for resource previews.** The `<Table>` preview fetches resource URLs from the
   browser. If a CKAN resource host blocks cross-origin requests, the table shows a load
   error while the Download link still works. Datastore-backed resources are the most reliable.
-- **CKAN client API.** `lib/ckan.ts` exposes a `@portaljs/ckan` `CKAN` instance. Other useful
-  methods for extending the portal: `getOrgsWithDetails()`, `getGroupsWithDetails()`,
-  `getAllTags()` (build filter UIs), and `datastoreSearch(resourceId)` (query the datastore).
+- **Extending the client.** `lib/ckan.ts` wraps two REST actions (`package_search`,
+  `package_show`). To build filter UIs or query the datastore, add more actions the same way
+  via the `ckanAction` helper — e.g. `organization_list`, `group_list`, `tag_list`,
+  `datastore_search?resource_id=…`. Each is one `ckanAction('<name>', { … })` call.
 ```

--- a/site/content/docs/backends.md
+++ b/site/content/docs/backends.md
@@ -20,9 +20,10 @@ frontend. See [Core concepts](/docs/core-concepts) for the model.
 ## CKAN
 
 The first-class, skill-supported path. [`/connect-ckan`](/docs/guides/connect-a-ckan-backend)
-installs `@portaljs/ckan`, lists datasets from `package_search`, and renders each from
-`package_show`, with CSV/TSV resources previewed through the template's `<Table />`.
-Calls run server-side so the CKAN bundle never reaches the browser. See the
+generates a tiny server-side `fetch` client (no dependency), lists datasets from
+`package_search`, and renders each from `package_show`, with CSV/TSV resources previewed
+through the template's `<Table />`. Calls run server-side, so the catalog is pre-rendered
+and statically deployable. See the
 [CKAN integration page](/ckan) and the
 [`examples/ckan`](https://github.com/datopian/portaljs/tree/main/examples/ckan) and
 [`examples/ckan-ssg`](https://github.com/datopian/portaljs/tree/main/examples/ckan-ssg)
@@ -30,10 +31,10 @@ examples.
 
 ## DKAN
 
-DKAN exposes a **CKAN-compatible API** (`/api/3/action/...`). Point the same
-`@portaljs/ckan` client (or plain `fetch`) at a DKAN instance's API root and the
-catalog/dataset pattern carries over. Confirm `package_search`/`package_show`
-availability on your DKAN version first.
+DKAN exposes a **CKAN-compatible API** (`/api/3/action/...`). Point the same `fetch`
+client `/connect-ckan` generates at a DKAN instance's API root and the catalog/dataset
+pattern carries over. Confirm `package_search`/`package_show` availability on your DKAN
+version first.
 
 ## OpenMetadata
 

--- a/site/content/docs/guides/connect-a-ckan-backend.md
+++ b/site/content/docs/guides/connect-a-ckan-backend.md
@@ -27,7 +27,7 @@ Optionally restrict the catalog to one or more organizations or groups:
 ```
 
 [`/connect-ckan`](/docs/skills/connect-ckan) verifies the CKAN API is reachable,
-installs `@portaljs/ckan`, generates a `lib/ckan.ts` client module, and rewrites the
+generates a tiny `lib/ckan.ts` fetch client (no runtime dependency), and rewrites the
 catalog (`/search`) and the dataset showcase route to fetch from CKAN. It runs a full
 `next build` and reports how many dataset pages were generated.
 
@@ -35,15 +35,14 @@ catalog (`/search`) and the dataset showcase route to fetch from CKAN. It runs a
 
 The frontend is **independent from the backend** and talks to it over the API
 (`package_search` for the catalog, `package_show` for each dataset). The generated
-pages fetch CKAN **server-side** in `getStaticProps`/`getStaticPaths`, so the
-`@portaljs/ckan` bundle never reaches the browser — the client stays lean and the site
-can still deploy statically.
+pages fetch CKAN **server-side** in `getStaticProps`/`getStaticPaths`, so the catalog is
+pre-rendered at build time and the site can still deploy statically.
 
 It writes plain, editable code:
 
-- `lib/ckan.ts` — a shared `CKAN` client. The base URL defaults to what you passed and
-  is overridable at deploy time via the `DMS` env var; org/group filters and a
-  build-time `MAX_DATASETS` cap live here as plain constants.
+- `lib/ckan.ts` — a tiny `fetch`-based CKAN client (no dependency). The base URL defaults
+  to what you passed and is overridable at deploy time via the `DMS` env var; org/group
+  filters and a build-time `MAX_DATASETS` cap live here as plain constants.
 - `pages/search.tsx` — the catalog at `/search`, listing datasets from `package_search`.
 - `pages/[owner]/[slug].tsx` — the dataset showcase at `/@<namespace>/<slug>`, one
   statically generated page per dataset, with CSV/TSV resources previewed through the
@@ -51,32 +50,42 @@ It writes plain, editable code:
 
 > [!note] Keep CKAN calls server-side
 > Reference `ckan`, `DMS`, and the filters **only** inside
-> `getStaticProps`/`getStaticPaths`. If a component body imports them, Next.js bundles
-> the whole `@portaljs/ckan` package into the client. Pass plain serializable props to
-> components instead.
+> `getStaticProps`/`getStaticPaths`, and pass plain serializable props to components. The
+> fetch wrapper has no client cost, but keeping data-fetching server-side preserves the
+> pre-rendered SSG model.
 
 ## The by-hand path
 
-Install the client and create `lib/ckan.ts`:
-
-```bash
-npm install @portaljs/ckan@^0.1.0
-```
+Create `lib/ckan.ts` — a small server-side `fetch` wrapper over the CKAN REST API. No
+package to install, no `tsconfig` changes; it uses the built-in `fetch`:
 
 ```ts
-import { CKAN } from '@portaljs/ckan';
-export const ckan = new CKAN((process.env.DMS || 'https://demo.dev.datopian.com').replace(/\/+$/, ''));
+export const DMS = (process.env.DMS || 'https://demo.dev.datopian.com').replace(/\/+$/, '');
+
+async function ckanAction(action: string, params: Record<string, string>) {
+  const res = await fetch(`${DMS}/api/3/action/${action}?${new URLSearchParams(params)}`);
+  if (!res.ok) throw new Error(`CKAN ${action} failed: ${res.status}`);
+  const body = await res.json();
+  if (!body?.success) throw new Error(`CKAN ${action} returned success=false`);
+  return body.result;
+}
+
+export const ckan = {
+  packageSearch: (rows = 200) =>
+    ckanAction('package_search', { rows: String(rows) }).then((r) => ({ datasets: r.results, count: r.count })),
+  getDatasetDetails: (slug: string) => ckanAction('package_show', { id: slug }),
+};
 ```
 
 Then call `ckan.packageSearch(...)` from `getStaticProps` on the catalog
 (`pages/search.tsx`) and `ckan.getDatasetDetails(slug)` from the dynamic showcase route
 `pages/[owner]/[slug].tsx`, passing the results as props.
 
-> [!note] TypeScript types for @portaljs/ckan
-> Under the template's `moduleResolution: "bundler"`, add a `paths` entry in
-> `tsconfig.json` so TypeScript finds the declarations:
-> `"@portaljs/ckan": ["./node_modules/@portaljs/ckan/dist/index.d.ts"]`. Without it the
-> build fails to type-check.
+> [!note] Why not `@portaljs/ckan`?
+> That package's bundle wires React UI components to React 18 internals
+> (`ReactCurrentDispatcher`) and crashes at import under the template's React 19 — even
+> server-side. The fetch wrapper above covers the two REST actions the portal needs with
+> no React coupling and zero client bytes.
 
 ## Notes
 

--- a/site/content/docs/manual-setup.md
+++ b/site/content/docs/manual-setup.md
@@ -83,8 +83,9 @@ Everything the skills do, you can do by hand:
   showcase (`pages/[owner]/[slug].tsx`).
 - **Maps** — `npm install react-leaflet leaflet` and render a GeoJSON file as a view
   in the showcase.
-- **CKAN** — `npm install @portaljs/ckan` and pass a `datastoreConfig` to `Table`,
-  or build a catalog against the CKAN API. See [CKAN integration](/ckan).
+- **CKAN** — build a catalog against the CKAN REST API with a tiny server-side `fetch`
+  client (no dependency); `/connect-ckan` generates it for you. See
+  [CKAN integration](/ckan).
 
 For the conventions these follow — import paths, data loading, page structure —
 read the [`CLAUDE.md`](https://github.com/datopian/portaljs/blob/main/CLAUDE.md)

--- a/site/content/docs/skills/connect-ckan.md
+++ b/site/content/docs/skills/connect-ckan.md
@@ -1,6 +1,6 @@
 ---
 metatitle: /connect-ckan – Wire a PortalJS Portal to a CKAN Backend over its API
-metadescription: The /connect-ckan skill installs @portaljs/ckan, feeds the catalog at /search and dataset showcases at /@<namespace>/<slug> from CKAN as plain editable code, and verifies the build — the decoupled, any-backend path.
+metadescription: The /connect-ckan skill generates a tiny server-side fetch client (no runtime dependency), feeds the catalog at /search and dataset showcases at /@<namespace>/<slug> from CKAN as plain editable code, and verifies the build — the decoupled, any-backend path.
 title: /connect-ckan
 description: Wire a portal to a CKAN backend over its API instead of static files — the decoupled, any-backend path.
 ---
@@ -9,16 +9,16 @@ description: Wire a portal to a CKAN backend over its API instead of static file
 backend. The portal stops reading the static `datasets.json` manifest and
 `/public/data/` files, and instead feeds both surfaces — the catalog at `/search`
 and the dataset showcases at `/@<namespace>/<slug>` — straight from a CKAN
-instance's REST API (`package_search` / `package_show`) using the `@portaljs/ckan`
-client. The output is plain, editable Next.js code — no opaque framework wiring.
+instance's REST API (`package_search` / `package_show`) through a tiny generated
+`fetch` client. The output is plain, editable Next.js code with **no runtime
+dependency** — no opaque framework wiring.
 
 ## When to use it
 
 Use it for the **decoupled / any-backend** path: you have a CKAN data management
 system (your own or a public one) and want a browseable portal in front of it.
 CKAN calls run **server-side** in `getStaticProps` / `getStaticPaths`, so the
-`@portaljs/ckan` bundle never reaches the browser and the site can still be
-statically deployed.
+catalog is pre-rendered at build time and the site can still be statically deployed.
 
 ## Inputs
 
@@ -46,11 +46,10 @@ Restricted to specific organizations:
 
 ## What it produces
 
-- `@portaljs/ckan` added to `package.json`, plus a `tsconfig.json` `paths` entry so
-  TypeScript resolves the client's types.
-- `lib/ckan.ts` — a small, editable client module. The CKAN URL is the default,
-  overridable at deploy time via the `DMS` env var; org/group filters and a
-  build-time page cap (`MAX_DATASETS`) are plain constants you can edit.
+- `lib/ckan.ts` — a small, editable `fetch`-based client (no package added to
+  `package.json`, no `tsconfig` changes). The CKAN URL is the default, overridable at
+  deploy time via the `DMS` env var; org/group filters and a build-time page cap
+  (`MAX_DATASETS`) are plain constants you can edit.
 - `pages/search.tsx` rewritten so the catalog lists datasets from `package_search`.
 - `pages/[owner]/[slug].tsx` — the showcase route, repointed to pre-render one
   showcase per dataset at `/@<namespace>/<slug>` via `package_show`, previewing


### PR DESCRIPTION
## Problem (po-0m8)

`/connect-ckan` installed and imported `@portaljs/ckan`. That package's bundle wires React UI components to React 18 internals (`ReactCurrentDispatcher`) and **crashes at import under React 19 — even server-side**, where the skill imports the client in `getStaticProps`/`getStaticPaths`. The usable `CKAN` client class is locked inside that same broken module. Since the template now ships **React 19** (#1566), the skill produced a portal that wouldn't build.

## Fix

Replace `@portaljs/ckan` with a **~40-line server-side `fetch` wrapper** in `lib/ckan.ts`, keeping the exact method surface the generated pages already call (`ckan.packageSearch` / `ckan.getDatasetDetails`):
- No `npm install`, no `tsconfig` `paths` entry.
- Server-side only, zero client bundle, no React coupling.
- `buildFq` for org/group/tag filters; `ckanAction` helper to extend with more REST actions.

The two generated pages (`search.tsx`, `[owner]/[slug].tsx`) are unchanged — they consume the same surface.

## Verification

Wired a **React-19 catalog scaffold** to `https://demo.ckan.org` via the new `lib/ckan.ts` and ran `next build`:
- **EXIT=0** — no `ReactCurrentDispatcher` / React-internals crash.
- All **13 datasets** pre-rendered as `/@<org>/<slug>` SSG pages; `/search` built.
- No `@portaljs/ckan` in `package.json`.

## Docs

Updated to drop the install/tsconfig steps and add the rationale: skill page, `connect-a-ckan-backend` guide (incl. by-hand path), `manual-setup`, `backends`.

No npm release — this is skill + docs content; it reaches scaffolds via the bundled-skill fetch at `main`. (Part 1 of the connect-ckan + /migrate batch; the `/migrate` skill that follows shares this fetch-reader pattern.)

Closes po-0m8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CKAN backend integration guides to reflect simplified setup using a generated server-side fetch wrapper instead of an external package dependency.
  * Clarified that the `/connect-ckan` command now generates a lightweight, editable client for pre-rendering dataset catalogs at build time.
  * Updated backend setup instructions to emphasize the dependency-free approach for CKAN and DKAN integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->