### PR TITLE
feat(migrate): /migrate skill — harvest CKAN/DCAT into a static catalog (v1)

### DIFF
--- a/.changeset/create-portaljs-migrate-skill.md
+++ b/.changeset/create-portaljs-migrate-skill.md
@@ -1,0 +1,5 @@
+---
+'create-portaljs': minor
+---
+
+Bundle the new `/migrate` skill into scaffolds. `/migrate` harvests datasets from a CKAN instance or a DCAT-US `/data.json` catalog (DKAN, ArcGIS Hub, data.gov) into the static PortalJS catalog — link-by-URL by default, or download the files. Added to the skills allowlist so it ships in every scaffolded portal's `.claude/commands/` alongside the other skills.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,7 @@
     "./.claude/commands/add-chart.md",
     "./.claude/commands/add-map.md",
     "./.claude/commands/connect-ckan.md",
+    "./.claude/commands/migrate.md",
     "./.claude/commands/define-schema.md",
     "./.claude/commands/deploy.md",
     "./.claude/commands/check-data-quality.md"

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -1,0 +1,244 @@
+---
+description: Migrate (harvest) datasets from an external open-data platform into a static PortalJS catalog. Reads a CKAN instance or a DCAT-US /data.json catalog and writes datasets.json entries — link-by-URL by default, or download the files. The DKAN / ArcGIS Hub / data.gov path goes through the DCAT reader.
+allowed-tools: Read, Write, Edit, Bash, WebFetch
+---
+
+# /migrate
+
+Harvest datasets from an external open-data platform into an existing
+`portaljs-catalog` portal. The source's datasets are read over its API, mapped to the
+portal's canonical dataset shape, and written into `datasets.json` (the static catalog's
+single source of truth) — so the `/search` catalog and the `/@<namespace>/<slug>`
+showcases render them like any hand-added dataset.
+
+This is the **copy-into-the-portal** path. It is the inverse of
+[`/connect-ckan`](connect-ckan.md): connect-ckan keeps the source authoritative and reads
+it live at build time; `/migrate` takes a one-time (re-runnable) snapshot into the static
+catalog, so the portal stands alone and needs no backend.
+
+## Hub-and-spoke model
+
+Every source is read into one **canonical** shape (the template's `Dataset`/`Resource`
+type — a Frictionless-aligned `{ slug, namespace, name, description, resources[] }`), then
+written to the target from that canonical form. Add a source once and it migrates to every
+target. v1 ships two readers and one writer.
+
+**Sources (v1):**
+
+| Source | How it's read | Covers |
+| ------ | ------------- | ------ |
+| **CKAN** | REST API (`package_search` / `package_show`) | any CKAN instance |
+| **DCAT-US `/data.json`** | one catalog document | **DKAN, ArcGIS Hub, data.gov**, and other DCAT-US publishers |
+
+> DKAN, ArcGIS Hub, and data.gov all expose a DCAT-US `/data.json` — use the **dcat**
+> source for those. (Socrata, OpenDataSoft, and ArcGIS FeatureServer are planned; for now,
+> if they expose a `/data.json`, the dcat reader works.)
+
+**Target (v1):** the static `portaljs-catalog` (`datasets.json` + optional files in
+`/public/data/`).
+
+## Required input — ask, don't error
+
+- **Source type** — `ckan` or `dcat` (auto-detected from the URL if omitted; see step 3).
+- **Source URL** (required) — a CKAN base URL (e.g. `https://demo.dev.datopian.com`) or a
+  DCAT `/data.json` URL (e.g. `https://hub.arcgis.com/data.json`).
+- **Portal directory** (optional) — the target portal (default: current directory).
+- **Filters** (optional, CKAN only) — org / group names to restrict the harvest.
+- **Copy mode** (optional) — `link` (default) or `download` (see step 5).
+- **`--dry-run`** (optional) — preview what would be written without touching `datasets.json`.
+- **`--replace`** (optional) — clear existing `datasets.json` entries first (default: upsert
+  alongside what's already there, e.g. the sample datasets).
+
+**If the source URL is missing, ask for it (and the source type if unclear) — never
+dead-end with a missing-input error.**
+
+## Steps
+
+### 1. Gather input from `$ARGUMENTS` (interview if thin)
+
+Extract:
+- `SOURCE_TYPE` — `ckan` | `dcat` (default: auto-detect in step 3).
+- `SOURCE_URL` — required; strip any trailing slash.
+- `PORTAL_DIR` — default `.`.
+- `ORG_FILTER` / `GROUP_FILTER` — lists (CKAN only; default empty).
+- `COPY_MODE` — `link` | `download` (default `link`).
+- `DRY_RUN` — boolean (default false).
+- `REPLACE` — boolean (default false).
+
+If `SOURCE_URL` is missing, ask and wait:
+```
+To migrate datasets I need:
+1. Source URL — a CKAN base URL, or a DCAT /data.json URL (required)
+2. Source type — ckan or dcat (Enter to auto-detect)
+3. Portal directory (Enter for current directory)
+4. Copy mode — link (reference source URLs, default) or download (copy files in)
+```
+
+### 2. Validate the target portal
+
+The target must be a `portaljs-catalog` portal. Confirm `PORTAL_DIR/datasets.json`,
+`PORTAL_DIR/package.json`, and `PORTAL_DIR/pages/[owner]/[slug].tsx` exist. If
+`datasets.json` is missing, tell the user this isn't the catalog template (it may be the
+minimal single-page template) and ask how to proceed rather than failing silently.
+
+Read `NAMESPACE_TYPE` from `PORTAL_DIR/lib/datasets.ts` — it doesn't change the harvest
+(every dataset still carries a `namespace`), but it tells you whether namespaces read as
+subjects (`theme`) or publishers (`owner`) so you can explain the result.
+
+### 3. Detect the source type and verify it's reachable
+
+If `SOURCE_TYPE` is unset, auto-detect:
+- If the URL ends in `.json` (or contains `/data.json`), treat as **dcat**.
+- Otherwise probe CKAN: `curl -s -m 20 "SOURCE_URL/api/3/action/package_search?rows=1"` →
+  if JSON with `"success": true`, it's **ckan**.
+- If neither, try fetching `SOURCE_URL/data.json` as a DCAT catalog.
+- If still nothing resolves, tell the user the URL didn't look like a CKAN API or a DCAT
+  catalog, and ask them to confirm the URL / pick the type — don't dead-end.
+
+For **ckan** with an `ORG_FILTER`, validate each org exists via
+`organization_show?id=ORG`; if one is missing, list valid orgs (`organization_list`) and
+ask which they meant or to drop the filter.
+
+### 4. Read the source into canonical datasets
+
+Use `WebFetch` or `curl` for requests. Build an in-memory list of **canonical** entries
+shaped like the template's `Dataset`:
+
+```jsonc
+{
+  "slug": "...",            // URL-safe, unique within a namespace
+  "namespace": "...",       // groups the dataset (CKAN org / DCAT publisher or theme)
+  "name": "...",            // human title
+  "description": "...",     // one paragraph (optional)
+  "keywords": ["..."],      // optional
+  "resources": [
+    { "name": "...", "path": "<url-or-filename>", "format": "csv", "title": "..." }
+  ]
+}
+```
+
+A single-file dataset may instead use the `file`/`format` sugar, but prefer `resources[]`
+so multi-file datasets are uniform.
+
+**CKAN mapping** (`package_search` paginated by `rows`/`start`, then per dataset the
+search result already carries `resources`, so a second `package_show` is only needed if a
+field is missing):
+
+| Canonical | CKAN field |
+| --------- | ---------- |
+| `slug` | `name` (already URL-safe) |
+| `namespace` | `organization.name` (fallback `dataset`) |
+| `name` | `title` \|\| `name` |
+| `description` | `notes` |
+| `keywords` | `tags[].name` |
+| `resources[].name` | resource `name` \|\| `id` |
+| `resources[].path` | resource `url` (link mode) |
+| `resources[].format` | resource `format` lowercased |
+
+Page with `rows=200` until you've read `count` (or a sane cap — tell the user if you cap).
+Apply `ORG_FILTER`/`GROUP_FILTER` via the `fq` query
+(`organization:("a" OR "b") groups:("c")`).
+
+**DCAT-US mapping** (one GET of the `/data.json`; datasets live under `dataset[]`):
+
+| Canonical | DCAT field |
+| --------- | ---------- |
+| `slug` | slugified `identifier` \|\| slugified `title` |
+| `namespace` | slugified `publisher.name` (fallback first `theme`, else `dataset`) |
+| `name` | `title` |
+| `description` | `description` |
+| `keywords` | `keyword[]` |
+| `resources[].name` | distribution `title` \|\| derived from URL |
+| `resources[].path` | distribution `downloadURL` \|\| `accessURL` (link mode) |
+| `resources[].format` | distribution `format` \|\| `mediaType` → normalized (below) |
+
+**Format normalization.** Lowercase and map to the formats the showcase can preview
+(`csv`, `tsv`, `json`, `geojson`); keep any other format string as-is (the showcase shows a
+download link instead of a preview for non-tabular formats). Map common media types:
+`text/csv→csv`, `application/json→json`, `application/geo+json→geojson`,
+`text/tab-separated-values→tsv`. Drop distributions with no usable URL.
+
+Ensure `slug` is unique within its `namespace` (suffix `-2`, `-3`, … on collision).
+
+### 5. Resolve resource paths by copy mode
+
+- **`link` (default):** set each `resources[].path` to the **source file URL** as-is. The
+  template's `resourceUrl()` returns absolute paths unchanged, so no files are copied —
+  fast, light, and the catalog stays in sync with the source's hosting. Trade-off: previews
+  and downloads depend on the source staying up and allowing cross-origin reads.
+- **`download`:** for each resource, download the file into
+  `PORTAL_DIR/public/data/<namespace>/<slug>/<filename>` and set `path` to the **relative**
+  `"<namespace>/<slug>/<filename>"`. Self-contained portal, no runtime dependency on the
+  source — but a large catalog balloons the repo. Skip (with a logged warning) any file
+  that fails to download rather than aborting the whole run.
+
+### 6. Dry-run preview
+
+Always print a summary before writing:
+```
+Source:   <type> <url>   (<N> datasets, <R> resources)
+Target:   PORTAL_DIR/datasets.json   (mode: link|download, replace|upsert)
+Sample:
+  @<ns>/<slug>  "<name>"  — <k> resource(s): csv, json
+  …(up to 5)
+```
+If `DRY_RUN` is set, stop here — write nothing.
+
+### 7. Write `datasets.json`
+
+Read the existing `PORTAL_DIR/datasets.json` (a JSON array). Then:
+- If `REPLACE`: start from an empty array (tell the user the samples were removed).
+- Otherwise **upsert**: replace any existing entry with the same `(namespace, slug)`, append
+  the rest. This keeps the sample datasets and makes re-runs idempotent.
+
+Write the merged array back as formatted JSON (2-space indent). For `download` mode, the
+files are already in `/public/data/` from step 5.
+
+### 8. Verify the build
+
+```bash
+cd PORTAL_DIR
+npm run build > /tmp/migrate-build.log 2>&1
+BUILD_EXIT=$?
+tail -30 /tmp/migrate-build.log
+```
+If `BUILD_EXIT` is non-zero, print the log and fix before reporting success — do not report
+success on a failing build. A common cause is a malformed `datasets.json` entry (missing
+`slug`/`namespace`/`name`).
+
+### 9. Report success
+
+```
+✓ Migrated <N> datasets from <type>: <url>
+  - Target:   PORTAL_DIR/datasets.json  (<total> entries now, <N> new/updated)
+  - Mode:     link  (resources reference source URLs)   | download (files in /public/data)
+  - Namespaces: @ns-a (12), @ns-b (3), …
+  - Build:    <pages> static pages generated
+
+Next:
+  npm run dev                     # browse the imported catalog
+  /check-data-quality             # validate the harvested data
+  /deploy                         # publish it
+```
+
+## Notes
+
+- **link vs download.** `link` is the default because it's instant and keeps the repo small;
+  the catalog references the source's file URLs. Switch to `download` when you want a fully
+  self-contained portal (the source may disappear, or you're archiving). Both write the same
+  `datasets.json` — only `resources[].path` differs (remote URL vs local relative path).
+- **Re-running is safe.** Upsert keys on `(namespace, slug)`, so re-running the same
+  migration refreshes changed datasets without duplicating them. Use `--replace` to start
+  clean.
+- **Schemas aren't inferred here.** Sources rarely ship Frictionless Table Schemas. After
+  migrating, run [`/check-data-quality`](check-data-quality.md) to validate and
+  [`/define-schema`](define-schema.md) to add schemas to the resources you care about.
+- **Charts/maps.** [`/add-chart`](add-chart.md) and [`/add-map`](add-map.md) work on the
+  migrated datasets exactly as on hand-added ones — they target the static showcase.
+- **Large catalogs.** Harvesting thousands of datasets makes thousands of static pages and
+  a slow build. Use the CKAN org/group filters (or a DCAT source already scoped to a site)
+  to migrate a subset, and tell the user how many were imported vs. available.
+- **DKAN / ArcGIS Hub / data.gov.** These are DCAT-US publishers — point `/migrate` at their
+  `/data.json` with `--source dcat`. A native Socrata/OpenDataSoft/ArcGIS-FeatureServer
+  reader is planned for richer metadata.
+```

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -167,10 +167,15 @@ Ensure `slug` is unique within its `namespace` (suffix `-2`, `-3`, … on collis
   fast, light, and the catalog stays in sync with the source's hosting. Trade-off: previews
   and downloads depend on the source staying up and allowing cross-origin reads.
 - **`download`:** for each resource, download the file into
-  `PORTAL_DIR/public/data/<namespace>/<slug>/<filename>` and set `path` to the **relative**
-  `"<namespace>/<slug>/<filename>"`. Self-contained portal, no runtime dependency on the
-  source — but a large catalog balloons the repo. Skip (with a logged warning) any file
-  that fails to download rather than aborting the whole run.
+  `PORTAL_DIR/public/data/<namespace>/<slug>/<NN>-<safe-filename>` and set `path` to the
+  matching **relative** `"<namespace>/<slug>/<NN>-<safe-filename>"`. `<NN>` is the resource's
+  zero-padded index within the dataset and `<safe-filename>` is the URL basename sanitized to
+  `[a-zA-Z0-9._-]` (default `data.<format>` when the URL has no usable basename). The index
+  prefix is **required** — harvested datasets routinely expose several distributions sharing a
+  basename (e.g. two `download.csv`s), and a bare `<filename>` would let later files overwrite
+  earlier ones. Self-contained portal, no runtime dependency on the source — but a large
+  catalog balloons the repo. Skip (with a logged warning) any file that fails to download
+  rather than aborting the whole run.
 
 ### 6. Dry-run preview
 

--- a/examples/portaljs-catalog/lib/datasets.ts
+++ b/examples/portaljs-catalog/lib/datasets.ts
@@ -51,7 +51,11 @@ export function getResources(d: Dataset): Resource[] {
   return []
 }
 
-// Public URL of a resource's raw file (served statically from /public/data).
+// Public URL of a resource's raw file. A relative `path` is served statically from
+// /public/data; an absolute path is returned as-is, so a resource can point at a remote
+// file (e.g. a CKAN/DCAT download URL harvested by /migrate) or a site-root path without
+// copying bytes into the repo.
 export function resourceUrl(r: Resource): string {
+  if (/^(https?:)?\/\//.test(r.path) || r.path.startsWith('/')) return r.path
   return `/data/${r.path}`
 }

--- a/packages/create-portaljs/index.mjs
+++ b/packages/create-portaljs/index.mjs
@@ -23,6 +23,7 @@ const SKILLS = [
   'add-chart',
   'add-map',
   'connect-ckan',
+  'migrate',
   'define-schema',
   'deploy',
   'check-data-quality',

--- a/scripts/install-portaljs-skills.sh
+++ b/scripts/install-portaljs-skills.sh
@@ -21,7 +21,7 @@ RAW_BASE="https://raw.githubusercontent.com/datopian/portaljs/${REF}/.claude/com
 
 # OSS skills only — excludes Gas Town internal commands (done/handoff/review).
 # Keep in sync with the `commands` list in .claude-plugin/plugin.json.
-SKILLS="architect new-portal add-dataset add-resource add-chart add-map connect-ckan define-schema deploy check-data-quality"
+SKILLS="architect new-portal add-dataset add-resource add-chart add-map connect-ckan migrate define-schema deploy check-data-quality"
 
 # Detect a local checkout: this script lives in <repo>/scripts/, so the commands
 # dir is ../.claude/commands relative to the script.

--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -65,6 +65,10 @@
         "href": "/docs/skills/connect-ckan"
       },
       {
+        "title": "/migrate",
+        "href": "/docs/skills/migrate"
+      },
+      {
         "title": "/define-schema",
         "href": "/docs/skills/define-schema"
       },

--- a/site/content/docs/skills/connect-ckan.md
+++ b/site/content/docs/skills/connect-ckan.md
@@ -74,4 +74,4 @@ It verifies the build before reporting success. When it finishes:
   backend.
 - **[`/deploy`](/docs/skills/deploy)** — publish the connected portal.
 
-<DocsPagination prev="/docs/skills/add-map" next="/docs/skills/define-schema" />
+<DocsPagination prev="/docs/skills/add-map" next="/docs/skills/migrate" />

--- a/site/content/docs/skills/define-schema.md
+++ b/site/content/docs/skills/define-schema.md
@@ -83,4 +83,4 @@ describe.
 - **[`/architect`](/docs/skills/architect)** — decide the metadata strategy (Frictionless,
   extended, custom, or multi-profile + DCAT) before authoring.
 
-<DocsPagination prev="/docs/skills/connect-ckan" next="/docs/skills/deploy" />
+<DocsPagination prev="/docs/skills/migrate" next="/docs/skills/deploy" />

--- a/site/content/docs/skills/migrate.md
+++ b/site/content/docs/skills/migrate.md
@@ -1,0 +1,113 @@
+---
+metatitle: /migrate – Harvest Datasets from CKAN or DCAT into a PortalJS Catalog
+metadescription: The /migrate skill harvests datasets from a CKAN instance or a DCAT-US /data.json catalog (DKAN, ArcGIS Hub, data.gov) into a static PortalJS catalog — link by URL or download the files, as plain editable datasets.json entries.
+title: /migrate
+description: Harvest datasets from a CKAN instance or a DCAT /data.json catalog into the static PortalJS catalog — the copy-into-the-portal path.
+---
+
+`/migrate` harvests datasets from an external open-data platform **into** an existing
+`portaljs-catalog` portal. It reads the source over its API, maps each dataset to the
+template's canonical shape, and writes the results into `datasets.json` — so the `/search`
+catalog and the `/@<namespace>/<slug>` showcases render them like any hand-added dataset.
+
+It's the inverse of [`/connect-ckan`](/docs/skills/connect-ckan): connect-ckan keeps the
+source authoritative and reads it live at build time; `/migrate` takes a one-time
+(re-runnable) **snapshot** into the static catalog, so the portal stands alone with no
+backend.
+
+## Hub-and-spoke
+
+Every source is read into one **canonical** shape (the Frictionless-aligned
+`Dataset`/`Resource` type), then written to the target from that form — so a source is
+added once and works with every target.
+
+**Sources (v1):**
+
+| Source | Read via | Covers |
+| ------ | -------- | ------ |
+| **CKAN** | `package_search` / `package_show` | any CKAN instance |
+| **DCAT-US `/data.json`** | one catalog document | **DKAN, ArcGIS Hub, data.gov**, other DCAT-US publishers |
+
+> DKAN, ArcGIS Hub, and data.gov publish a DCAT-US `/data.json` — use the **dcat** source
+> for those. Native Socrata, OpenDataSoft, and ArcGIS FeatureServer readers are planned.
+
+**Target (v1):** the static `portaljs-catalog` (`datasets.json` + optional files in
+`/public/data/`).
+
+## Inputs
+
+| Input | Required | Notes |
+| ----- | -------- | ----- |
+| Source URL | Yes | A CKAN base URL, or a DCAT `/data.json` URL. |
+| Source type | No | `ckan` or `dcat`; auto-detected from the URL if omitted. |
+| Portal directory | No | The target portal. Defaults to the current directory. |
+| Org / group filter | No | CKAN only — restrict the harvest. |
+| Copy mode | No | `link` (default) or `download` — see below. |
+| `--dry-run` | No | Preview what would be written without changing `datasets.json`. |
+| `--replace` | No | Clear existing entries first (default: upsert alongside them). |
+
+## Examples
+
+Harvest a whole CKAN instance:
+
+```
+/migrate https://demo.dev.datopian.com
+```
+
+Harvest one CKAN organization, downloading the files into the repo:
+
+```
+/migrate https://demo.dev.datopian.com --org transport --download
+```
+
+Harvest a DCAT catalog (DKAN / ArcGIS Hub / data.gov):
+
+```
+/migrate https://hub.arcgis.com/data.json --source dcat
+```
+
+## Copy modes
+
+- **`link` (default)** — each resource's `path` is set to the **source file URL**. No files
+  are copied; the catalog references the source's hosting. Fast and light, but previews and
+  downloads depend on the source staying up and allowing cross-origin reads.
+- **`download`** — files are pulled into `/public/data/<namespace>/<slug>/` and `path` is set
+  to the local relative path. The portal is fully self-contained, at the cost of repo size.
+
+Both produce the same `datasets.json`; only `resources[].path` differs. The template's
+`resourceUrl()` returns absolute paths unchanged, which is what makes link mode work.
+
+## What it produces
+
+- **`datasets.json`** — the harvested datasets, upserted by `(namespace, slug)` (re-running
+  refreshes changed datasets without duplicating them). Existing entries — including the
+  template's samples — are kept unless you pass `--replace`.
+- **`/public/data/…`** (download mode only) — the copied resource files.
+
+It runs a full `npm run build` and reports how many datasets were imported and pages
+generated before declaring success.
+
+## After migrating
+
+- [`/check-data-quality`](/docs/skills/check-data-quality) — validate the harvested data.
+- [`/define-schema`](/docs/skills/define-schema) — add Frictionless schemas (sources rarely
+  ship them).
+- [`/add-chart`](/docs/skills/add-chart) / [`/add-map`](/docs/skills/add-map) — they work on
+  migrated datasets exactly as on hand-added ones.
+- [`/deploy`](/docs/skills/deploy) — publish the catalog.
+
+## Notes
+
+- **Large catalogs** make many static pages and a slow build. Use the CKAN org/group filters
+  (or a DCAT source already scoped to a site) to migrate a subset; the skill reports how many
+  were imported vs. available.
+- **Schemas** aren't inferred during the harvest — add them afterward with `/define-schema`.
+- **Formats.** CSV/TSV/JSON/GeoJSON preview in the showcase; any other format is kept and
+  shown as a download link.
+
+## Where to go next
+
+- **[`/connect-ckan`](/docs/skills/connect-ckan)** — the live read-through alternative.
+- **[Backends](/docs/backends)** — integration notes per platform.
+
+<DocsPagination prev="/docs/skills/connect-ckan" next="/docs/skills/define-schema" />


### PR DESCRIPTION
Implements the **v1 dataset-migration** epic ([po-kdo](#)): a single `/migrate` skill that harvests datasets from an external open-data platform into a static `portaljs-catalog`.

## Hub-and-spoke (po-62c)

Sources are read into one canonical `Dataset`/`Resource` shape, then written to the target — add a source once, it works with every target.

**Readers (v1):**
- **CKAN** (po-9uk) — `package_search`/`package_show`, org/group filters. Same fetch pattern as the po-0m8 `/connect-ckan` rewrite.
- **DCAT-US `/data.json`** (po-3nt) — one document; covers **DKAN, ArcGIS Hub, data.gov**.

**Writer (v1):** static catalog (po-w3i) — upserts `datasets.json` by `(namespace, slug)`.

## Copy modes
- **`link` (default)** — resource `path` = source file URL, no copy.
- **`download`** — files pulled into `/public/data/<ns>/<slug>/`, self-contained.

One small **backwards-compatible** template change makes link mode work: `resourceUrl()` now returns absolute paths (`http(s)://` or leading `/`) unchanged; relative paths still serve from `/public/data`.

## Skill behavior
Auto-detects source type, validates the target portal, `--dry-run` preview, `--replace` to clear samples, idempotent re-runs, build-verify, post-migrate pointers to `/check-data-quality` + `/define-schema`.

## Wiring
- `migrate` added to scaffold allowlist (`create-portaljs`), `plugin.json`, `install-portaljs-skills.sh`.
- Docs: `skills/migrate.md` + sidebar + pagination.
- Changeset: **create-portaljs minor** → this is the release that also delivers the po-0m8 connect-ckan fix to scaffolds.

## Verification (React 19 template)
- **CKAN** harvest from `demo.ckan.org` (13 datasets, 35 resources) → upserted into samples → `npm run build` **EXIT=0**, 17 showcase pages + `/search`.
- **DCAT** harvest from a `/data.json` (format normalization csv/json/geojson, publisher→namespace, identifier→slug) → build **EXIT=0**.
- Link-by-URL resources resolve via the `resourceUrl` passthrough.

Closes po-3nt, po-9uk, po-w3i, po-ocm (and the po-62c canonical model). Builds on po-0m8 (#1572, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/migrate` skill to PortalJS to harvest datasets from CKAN or DCAT-US `/data.json` catalogs into static PortalJS catalogs, supporting both link-by-URL and download modes.
  * Bundled the new `migrate` skill into newly scaffolded portal projects.

* **Documentation**
  * Added detailed docs for the `/migrate` skill, including inputs, dry-run, replace/upsert behavior, and operational guidance.
  * Updated docs navigation/pagination for the skills flow, and refreshed command/skill listings to include `/migrate`.

* **Bug Fixes**
  * Improved resource URL handling to allow absolute/remote paths without unwanted prefixing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->