### PR TITLE
feat(migrate): v2 — CKAN write target + Socrata/ODS/ArcGIS readers

### DIFF
--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -1,5 +1,5 @@
 ---
-description: Migrate (harvest) datasets between open-data platforms. Reads a CKAN instance or a DCAT-US /data.json catalog (DKAN, ArcGIS Hub, data.gov) and writes them to a static PortalJS catalog (datasets.json, link-by-URL or download) or pushes them into a CKAN instance over its API.
+description: Migrate (harvest) datasets between open-data platforms. Reads CKAN, a DCAT-US /data.json catalog (DKAN, ArcGIS Hub, data.gov), Socrata, OpenDataSoft, or an ArcGIS FeatureServer, and writes them to a static PortalJS catalog (datasets.json, link-by-URL or download) or pushes them into a CKAN instance over its API.
 allowed-tools: Read, Write, Edit, Bash, WebFetch
 ---
 
@@ -25,14 +25,17 @@ target. v1 ships two readers and one writer.
 
 **Sources (v1):**
 
-| Source | How it's read | Covers |
-| ------ | ------------- | ------ |
-| **CKAN** | REST API (`package_search` / `package_show`) | any CKAN instance |
-| **DCAT-US `/data.json`** | one catalog document | **DKAN, ArcGIS Hub, data.gov**, and other DCAT-US publishers |
+| Source | `--source` | How it's read | Covers |
+| ------ | ---------- | ------------- | ------ |
+| **CKAN** | `ckan` | REST API (`package_search` / `package_show`) | any CKAN instance |
+| **DCAT-US `/data.json`** | `dcat` | one catalog document | **DKAN, ArcGIS Hub, data.gov**, other DCAT-US publishers |
+| **Socrata** | `socrata` | Discovery API + per-dataset resource exports | Socrata-powered open-data sites |
+| **OpenDataSoft** | `ods` | Explore API v2 catalog + exports | ODS-powered portals |
+| **ArcGIS FeatureServer / MapServer** | `arcgis` | layer metadata + GeoJSON query | individual ArcGIS map/feature services |
 
-> DKAN, ArcGIS Hub, and data.gov all expose a DCAT-US `/data.json` — use the **dcat**
-> source for those. (Socrata, OpenDataSoft, and ArcGIS FeatureServer are planned; for now,
-> if they expose a `/data.json`, the dcat reader works.)
+> DKAN, ArcGIS Hub, and data.gov publish a DCAT-US `/data.json` — use the **dcat** source for
+> those whole catalogs. Use **arcgis** for an individual FeatureServer/MapServer (each layer
+> becomes a GeoJSON dataset, which `/data.json` doesn't expose).
 
 **Targets:**
 
@@ -47,10 +50,12 @@ since any reader can feed any writer through the canonical shape.
 ## Required input — ask, don't error
 
 **Source:**
-- **Source type** — `ckan` or `dcat` (auto-detected from the URL if omitted; see step 3).
-- **Source URL** (required) — a CKAN base URL (e.g. `https://demo.dev.datopian.com`) or a
-  DCAT `/data.json` URL (e.g. `https://hub.arcgis.com/data.json`).
-- **Filters** (optional, CKAN only) — org / group names to restrict the harvest.
+- **Source type** — `ckan`, `dcat`, `socrata`, `ods`, or `arcgis` (auto-detected from the
+  URL if omitted; see step 3).
+- **Source URL** (required) — e.g. a CKAN base URL, a DCAT `/data.json` URL, a Socrata or
+  OpenDataSoft site root, or an ArcGIS `…/FeatureServer` (or `…/MapServer`) URL.
+- **Filters** (optional) — CKAN: org / group names. Socrata/ODS: pass a search term or
+  category to scope large catalogs.
 
 **Target** — `--target static` (default) or `--target ckan`:
 - **static**: **Portal directory** (optional, default current dir); **copy mode** `link`
@@ -116,12 +121,17 @@ write without a confirmed key. If `OWNER_ORG` is set, confirm it exists
 ### 3. Detect the source type and verify it's reachable
 
 If `SOURCE_TYPE` is unset, auto-detect:
-- If the URL ends in `.json` (or contains `/data.json`), treat as **dcat**.
+- URL contains `/FeatureServer` or `/MapServer` → **arcgis**.
+- URL ends in `.json` or contains `/data.json` → **dcat**.
+- URL contains `/api/explore/` → **ods**; `/api/catalog/` → **socrata**.
 - Otherwise probe CKAN: `curl -s -m 20 "SOURCE_URL/api/3/action/package_search?rows=1"` →
   if JSON with `"success": true`, it's **ckan**.
-- If neither, try fetching `SOURCE_URL/data.json` as a DCAT catalog.
-- If still nothing resolves, tell the user the URL didn't look like a CKAN API or a DCAT
-  catalog, and ask them to confirm the URL / pick the type — don't dead-end.
+- Else probe in turn: `SOURCE_URL/api/explore/v2.1/catalog/datasets?limit=1` (ods),
+  `SOURCE_URL/data.json` (dcat).
+- If still nothing resolves, tell the user the URL didn't look like a supported source and
+  ask them to confirm the URL / pick the `--source` type — don't dead-end. (Socrata is read
+  through the central Discovery API, so for a Socrata site pass `--source socrata` with the
+  site root, e.g. `https://data.cityofnewyork.us`.)
 
 For **ckan** with an `ORG_FILTER`, validate each org exists via
 `organization_show?id=ORG`; if one is missing, list valid orgs (`organization_list`) and
@@ -180,11 +190,56 @@ Apply `ORG_FILTER`/`GROUP_FILTER` via the `fq` query
 | `resources[].path` | distribution `downloadURL` \|\| `accessURL` (link mode) |
 | `resources[].format` | distribution `format` \|\| `mediaType` → normalized (below) |
 
+**Socrata mapping** (Discovery API at the central host, then per-dataset file exports):
+
+Page the catalog: `https://api.us.socrata.com/api/catalog/v1?domains=<host>&limit=100&offset=…`
+(`<host>` is the site root's hostname, e.g. `data.cityofnewyork.us`). Use `&q=<term>` or
+`&categories=<cat>` for the optional filter. Each `results[]` item has a `resource` object:
+
+| Canonical | Socrata field |
+| --------- | ------------- |
+| `slug` | `resource.id` (the 4x4, e.g. `8wbx-tsch`) |
+| `namespace` | slugified `classification.domain_category` (fallback `dataset`) |
+| `name` | `resource.name` |
+| `description` | `resource.description` |
+| `keywords` | `classification.domain_tags` |
+| `resources[].path` | `https://<host>/resource/<id>.csv` (tabular) or `.geojson` for map data (link mode) |
+| `resources[].format` | `csv` (or `geojson` when the asset is geospatial) |
+
+**OpenDataSoft mapping** (Explore API v2):
+
+Page `https://<host>/api/explore/v2.1/catalog/datasets?limit=100&offset=…` (use `&where=…`
+or `&refine=…` for filters). Each `results[]` item:
+
+| Canonical | ODS field |
+| --------- | --------- |
+| `slug` | slugified `dataset_id` (ODS ids can contain `@`, which is the namespace sentinel) |
+| `namespace` | slugified first `metas.default.theme` (fallback `dataset`) |
+| `name` | `metas.default.title` |
+| `description` | `metas.default.description` |
+| `keywords` | `metas.default.keyword` |
+| `resources[].path` | `https://<host>/api/explore/v2.1/catalog/datasets/<id>/exports/csv` (and `/exports/geojson` if the dataset has geo) (link mode) |
+| `resources[].format` | `csv` (or `geojson`) |
+
+**ArcGIS FeatureServer / MapServer mapping** (one service → many layers; each layer is a
+GeoJSON dataset):
+
+GET `<service-url>?f=json` to list `layers[]` (and `tables[]`). For each layer:
+
+| Canonical | ArcGIS field |
+| --------- | ------------ |
+| `slug` | slugified `name` (fallback `layer-<id>`) |
+| `namespace` | slugified service name (last path segment before `/FeatureServer`) |
+| `name` | layer `name` |
+| `description` | layer `description` (often empty) |
+| `resources[].path` | `<service-url>/<layerId>/query?where=1%3D1&outFields=*&f=geojson` (link mode) |
+| `resources[].format` | `geojson` |
+
 **Format normalization.** Lowercase and map to the formats the showcase can preview
 (`csv`, `tsv`, `json`, `geojson`); keep any other format string as-is (the showcase shows a
 download link instead of a preview for non-tabular formats). Map common media types:
 `text/csv→csv`, `application/json→json`, `application/geo+json→geojson`,
-`text/tab-separated-values→tsv`. Drop distributions with no usable URL.
+`text/tab-separated-values→tsv`. Drop distributions/resources with no usable URL.
 
 Ensure `slug` is unique within its `namespace` (suffix `-2`, `-3`, … on collision).
 
@@ -320,6 +375,6 @@ Next: open <target-url> to review the imported datasets.
   a slow build. Use the CKAN org/group filters (or a DCAT source already scoped to a site)
   to migrate a subset, and tell the user how many were imported vs. available.
 - **DKAN / ArcGIS Hub / data.gov.** These are DCAT-US publishers — point `/migrate` at their
-  `/data.json` with `--source dcat`. A native Socrata/OpenDataSoft/ArcGIS-FeatureServer
-  reader is planned for richer metadata.
+  whole-catalog `/data.json` with `--source dcat`. For one ArcGIS service (not a Hub site),
+  use `--source arcgis` against its `…/FeatureServer` so each layer becomes a GeoJSON dataset.
 ```

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -78,7 +78,7 @@ dead-end with a missing-input error.** For `--target ckan`, if the target URL or
 ### 1. Gather input from `$ARGUMENTS` (interview if thin)
 
 Extract:
-- `SOURCE_TYPE` — `ckan` | `dcat` (default: auto-detect in step 3).
+- `SOURCE_TYPE` — `ckan` | `dcat` | `socrata` | `ods` | `arcgis` (default: auto-detect in step 3).
 - `SOURCE_URL` — required; strip any trailing slash.
 - `ORG_FILTER` / `GROUP_FILTER` — lists (CKAN source only; default empty).
 - `TARGET` — `static` | `ckan` (default `static`).
@@ -334,7 +334,7 @@ success on a failing build. A common cause is a malformed `datasets.json` entry 
 ### 9. Report success
 
 Static target:
-```
+```text
 ✓ Migrated <N> datasets from <type>: <url>
   - Target:   PORTAL_DIR/datasets.json  (<total> entries now, <N> new/updated)
   - Mode:     link  (resources reference source URLs)   | download (files in /public/data)
@@ -348,7 +348,7 @@ Next:
 ```
 
 CKAN target:
-```
+```text
 ✓ Migrated <N> datasets from <type>: <src-url>  →  CKAN: <target-url>
   - Created <c> / updated <u> packages, <R> resources
   - Orgs:    <org-a> (created), <org-b> (existing)

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -1,5 +1,5 @@
 ---
-description: Migrate (harvest) datasets from an external open-data platform into a static PortalJS catalog. Reads a CKAN instance or a DCAT-US /data.json catalog and writes datasets.json entries — link-by-URL by default, or download the files. The DKAN / ArcGIS Hub / data.gov path goes through the DCAT reader.
+description: Migrate (harvest) datasets between open-data platforms. Reads a CKAN instance or a DCAT-US /data.json catalog (DKAN, ArcGIS Hub, data.gov) and writes them to a static PortalJS catalog (datasets.json, link-by-URL or download) or pushes them into a CKAN instance over its API.
 allowed-tools: Read, Write, Edit, Bash, WebFetch
 ---
 
@@ -34,23 +34,39 @@ target. v1 ships two readers and one writer.
 > source for those. (Socrata, OpenDataSoft, and ArcGIS FeatureServer are planned; for now,
 > if they expose a `/data.json`, the dcat reader works.)
 
-**Target (v1):** the static `portaljs-catalog` (`datasets.json` + optional files in
-`/public/data/`).
+**Targets:**
+
+| Target | `--target` | Writes |
+| ------ | ---------- | ------ |
+| **Static PortalJS catalog** (default) | `static` | `datasets.json` (+ optional files in `/public/data/`) in a `portaljs-catalog` portal |
+| **CKAN instance** | `ckan` | datasets/resources into a CKAN backend via `package_create` / `resource_create` (needs a write API key) |
+
+The CKAN target enables platform-to-platform moves — **CKAN→CKAN** and **DKAN→CKAN** —
+since any reader can feed any writer through the canonical shape.
 
 ## Required input — ask, don't error
 
+**Source:**
 - **Source type** — `ckan` or `dcat` (auto-detected from the URL if omitted; see step 3).
 - **Source URL** (required) — a CKAN base URL (e.g. `https://demo.dev.datopian.com`) or a
   DCAT `/data.json` URL (e.g. `https://hub.arcgis.com/data.json`).
-- **Portal directory** (optional) — the target portal (default: current directory).
 - **Filters** (optional, CKAN only) — org / group names to restrict the harvest.
-- **Copy mode** (optional) — `link` (default) or `download` (see step 5).
-- **`--dry-run`** (optional) — preview what would be written without touching `datasets.json`.
-- **`--replace`** (optional) — clear existing `datasets.json` entries first (default: upsert
-  alongside what's already there, e.g. the sample datasets).
+
+**Target** — `--target static` (default) or `--target ckan`:
+- **static**: **Portal directory** (optional, default current dir); **copy mode** `link`
+  (default) or `download` (step 5b).
+- **ckan**: **target CKAN URL** (required) and a **write API key** read from the
+  `CKAN_API_KEY` env var (required — never pass it on the command line or hardcode it); an
+  optional **owner org** to file every dataset under (step 7b).
+
+**Common:**
+- **`--dry-run`** (optional) — preview what would be written, change nothing.
+- **`--replace`** (optional, static target) — clear existing `datasets.json` entries first
+  (default: upsert alongside what's already there, e.g. the sample datasets).
 
 **If the source URL is missing, ask for it (and the source type if unclear) — never
-dead-end with a missing-input error.**
+dead-end with a missing-input error.** For `--target ckan`, if the target URL or
+`CKAN_API_KEY` is missing, ask rather than failing.
 
 ## Steps
 
@@ -59,11 +75,17 @@ dead-end with a missing-input error.**
 Extract:
 - `SOURCE_TYPE` — `ckan` | `dcat` (default: auto-detect in step 3).
 - `SOURCE_URL` — required; strip any trailing slash.
-- `PORTAL_DIR` — default `.`.
-- `ORG_FILTER` / `GROUP_FILTER` — lists (CKAN only; default empty).
-- `COPY_MODE` — `link` | `download` (default `link`).
+- `ORG_FILTER` / `GROUP_FILTER` — lists (CKAN source only; default empty).
+- `TARGET` — `static` | `ckan` (default `static`).
+- `PORTAL_DIR` — default `.` (static target).
+- `COPY_MODE` — `link` | `download` (default `link`; static target).
+- `TARGET_CKAN_URL` — required for `ckan` target; strip any trailing slash.
+- `OWNER_ORG` — optional CKAN org to file datasets under (ckan target).
 - `DRY_RUN` — boolean (default false).
-- `REPLACE` — boolean (default false).
+- `REPLACE` — boolean (default false; static target).
+
+The write API key for a `ckan` target is read from `process.env.CKAN_API_KEY` at run time —
+never from `$ARGUMENTS`.
 
 If `SOURCE_URL` is missing, ask and wait:
 ```
@@ -74,16 +96,22 @@ To migrate datasets I need:
 4. Copy mode — link (reference source URLs, default) or download (copy files in)
 ```
 
-### 2. Validate the target portal
+### 2. Validate the target
 
-The target must be a `portaljs-catalog` portal. Confirm `PORTAL_DIR/datasets.json`,
+**Static target (`--target static`).** Confirm `PORTAL_DIR/datasets.json`,
 `PORTAL_DIR/package.json`, and `PORTAL_DIR/pages/[owner]/[slug].tsx` exist. If
 `datasets.json` is missing, tell the user this isn't the catalog template (it may be the
-minimal single-page template) and ask how to proceed rather than failing silently.
+minimal single-page template) and ask how to proceed rather than failing silently. Read
+`NAMESPACE_TYPE` from `PORTAL_DIR/lib/datasets.ts` — it doesn't change the harvest (every
+dataset still carries a `namespace`), but it tells you whether namespaces read as subjects
+(`theme`) or publishers (`owner`) so you can explain the result.
 
-Read `NAMESPACE_TYPE` from `PORTAL_DIR/lib/datasets.ts` — it doesn't change the harvest
-(every dataset still carries a `namespace`), but it tells you whether namespaces read as
-subjects (`theme`) or publishers (`owner`) so you can explain the result.
+**CKAN target (`--target ckan`).** Confirm `TARGET_CKAN_URL` is a working CKAN API and the
+key authenticates: call `package_search?rows=1` (must be `success: true`), then verify the
+key with an authenticated read such as `organization_list_for_user` (pass the key in the
+`Authorization` header). If the key is missing or rejected, tell the user and stop — never
+write without a confirmed key. If `OWNER_ORG` is set, confirm it exists
+(`organization_show?id=OWNER_ORG`); offer to create it (step 7b) or pick an existing one.
 
 ### 3. Detect the source type and verify it's reachable
 
@@ -160,7 +188,9 @@ download link instead of a preview for non-tabular formats). Map common media ty
 
 Ensure `slug` is unique within its `namespace` (suffix `-2`, `-3`, … on collision).
 
-### 5. Resolve resource paths by copy mode
+### 5. (static target) Resolve resource paths by copy mode
+
+> Steps 5–8 below describe the **static** target. For `--target ckan`, skip to step 7b.
 
 - **`link` (default):** set each `resources[].path` to the **source file URL** as-is. The
   template's `resourceUrl()` returns absolute paths unchanged, so no files are copied —
@@ -182,14 +212,15 @@ Ensure `slug` is unique within its `namespace` (suffix `-2`, `-3`, … on collis
 Always print a summary before writing:
 ```
 Source:   <type> <url>   (<N> datasets, <R> resources)
-Target:   PORTAL_DIR/datasets.json   (mode: link|download, replace|upsert)
+Target:   static → PORTAL_DIR/datasets.json (mode: link|download, replace|upsert)
+          —or— ckan → <TARGET_CKAN_URL> (owner org: <org>)
 Sample:
   @<ns>/<slug>  "<name>"  — <k> resource(s): csv, json
   …(up to 5)
 ```
-If `DRY_RUN` is set, stop here — write nothing.
+If `DRY_RUN` is set, stop here — write nothing (and for the CKAN target, make no POSTs).
 
-### 7. Write `datasets.json`
+### 7. (static target) Write `datasets.json`
 
 Read the existing `PORTAL_DIR/datasets.json` (a JSON array). Then:
 - If `REPLACE`: start from an empty array (tell the user the samples were removed).
@@ -199,7 +230,40 @@ Read the existing `PORTAL_DIR/datasets.json` (a JSON array). Then:
 Write the merged array back as formatted JSON (2-space indent). For `download` mode, the
 files are already in `/public/data/` from step 5.
 
-### 8. Verify the build
+### 7b. (CKAN target) Push to CKAN
+
+For `--target ckan`, write the canonical datasets into the target CKAN over its action API.
+Read the key once: `const key = process.env.CKAN_API_KEY` and send it as the
+`Authorization: <key>` header on every write (POST, `Content-Type: application/json`).
+
+For each canonical dataset:
+
+1. **Organization.** Determine the owner org: `OWNER_ORG` if given, else the dataset's
+   `namespace`. Ensure it exists — `organization_show?id=<org>`; if missing, create it with
+   `organization_create` (`{ name: <org>, title: <org> }`). Cache the orgs you've ensured so
+   you don't re-check each dataset.
+2. **Upsert the package.** Map canonical → CKAN payload:
+
+   | CKAN field | Canonical |
+   | ---------- | --------- |
+   | `name` | `slug` (CKAN's unique key; must be lowercase/`-`) |
+   | `title` | `name` |
+   | `notes` | `description` |
+   | `owner_org` | the org from step 1 |
+   | `tags` | `keywords.map(k => ({ name: k }))` |
+
+   Check `package_show?id=<slug>`: if it exists, `package_update` (merge, preserving the
+   `id`); otherwise `package_create`. Treat the slug as globally unique in CKAN — on a
+   `name` collision with a different org, suffix the slug.
+3. **Resources.** For each canonical resource, `resource_create` (or `resource_update` when
+   re-running) with `{ package_id, name, url: <path>, format }`. In `link` mode `url` is the
+   source file URL (CKAN references it); a `download`-style copy-into-CKAN upload is out of
+   scope for v1 — note that to the user if they ask.
+
+Stop and report the first auth/permission failure (HTTP 403 / `success:false`) rather than
+half-migrating silently; on a per-dataset error, log it, skip that dataset, and continue.
+
+### 8. (static target) Verify the build
 
 ```bash
 cd PORTAL_DIR
@@ -209,10 +273,12 @@ tail -30 /tmp/migrate-build.log
 ```
 If `BUILD_EXIT` is non-zero, print the log and fix before reporting success — do not report
 success on a failing build. A common cause is a malformed `datasets.json` entry (missing
-`slug`/`namespace`/`name`).
+`slug`/`namespace`/`name`). For the **CKAN target**, verify instead with
+`package_search?rows=1&fq=...` (or `package_show` on a few slugs) that the datasets landed.
 
 ### 9. Report success
 
+Static target:
 ```
 ✓ Migrated <N> datasets from <type>: <url>
   - Target:   PORTAL_DIR/datasets.json  (<total> entries now, <N> new/updated)
@@ -224,6 +290,16 @@ Next:
   npm run dev                     # browse the imported catalog
   /check-data-quality             # validate the harvested data
   /deploy                         # publish it
+```
+
+CKAN target:
+```
+✓ Migrated <N> datasets from <type>: <src-url>  →  CKAN: <target-url>
+  - Created <c> / updated <u> packages, <R> resources
+  - Orgs:    <org-a> (created), <org-b> (existing)
+  - Skipped: <s> (see log)
+
+Next: open <target-url> to review the imported datasets.
 ```
 
 ## Notes

--- a/site/content/docs/skills/migrate.md
+++ b/site/content/docs/skills/migrate.md
@@ -31,8 +31,15 @@ added once and works with every target.
 > DKAN, ArcGIS Hub, and data.gov publish a DCAT-US `/data.json` — use the **dcat** source
 > for those. Native Socrata, OpenDataSoft, and ArcGIS FeatureServer readers are planned.
 
-**Target (v1):** the static `portaljs-catalog` (`datasets.json` + optional files in
-`/public/data/`).
+**Targets:**
+
+| Target | `--target` | Writes |
+| ------ | ---------- | ------ |
+| **Static PortalJS catalog** (default) | `static` | `datasets.json` (+ optional files in `/public/data/`) |
+| **CKAN instance** | `ckan` | datasets/resources into a CKAN backend via its action API |
+
+The CKAN target enables platform-to-platform moves — **CKAN→CKAN** and **DKAN→CKAN** — since
+any reader feeds any writer through the canonical shape.
 
 ## Inputs
 
@@ -40,11 +47,14 @@ added once and works with every target.
 | ----- | -------- | ----- |
 | Source URL | Yes | A CKAN base URL, or a DCAT `/data.json` URL. |
 | Source type | No | `ckan` or `dcat`; auto-detected from the URL if omitted. |
-| Portal directory | No | The target portal. Defaults to the current directory. |
-| Org / group filter | No | CKAN only — restrict the harvest. |
-| Copy mode | No | `link` (default) or `download` — see below. |
-| `--dry-run` | No | Preview what would be written without changing `datasets.json`. |
-| `--replace` | No | Clear existing entries first (default: upsert alongside them). |
+| Org / group filter | No | CKAN source only — restrict the harvest. |
+| `--target` | No | `static` (default) or `ckan`. |
+| Portal directory | No | Static target — defaults to the current directory. |
+| Copy mode | No | Static target — `link` (default) or `download`. |
+| Target CKAN URL | For `--target ckan` | The CKAN instance to write into. |
+| `CKAN_API_KEY` (env) | For `--target ckan` | A **write** API key, read from the environment — never passed on the command line. |
+| `--dry-run` | No | Preview what would be written, change nothing. |
+| `--replace` | No | Static target — clear existing entries first (default: upsert). |
 
 ## Examples
 
@@ -66,7 +76,16 @@ Harvest a DCAT catalog (DKAN / ArcGIS Hub / data.gov):
 /migrate https://hub.arcgis.com/data.json --source dcat
 ```
 
-## Copy modes
+Move one CKAN instance's datasets into another CKAN (set the write key first):
+
+```
+export CKAN_API_KEY=…           # write key for the destination
+/migrate https://source-ckan.example --target ckan --target-url https://dest-ckan.example --owner-org my-org
+```
+
+> Copy modes apply to the **static** target. For `--target ckan`, see *CKAN target* below.
+
+## Copy modes (static target)
 
 - **`link` (default)** — each resource's `path` is set to the **source file URL**. No files
   are copied; the catalog references the source's hosting. Fast and light, but previews and
@@ -86,6 +105,16 @@ Both produce the same `datasets.json`; only `resources[].path` differs. The temp
 
 It runs a full `npm run build` and reports how many datasets were imported and pages
 generated before declaring success.
+
+## CKAN target
+
+With `--target ckan`, `/migrate` pushes the canonical datasets into a CKAN instance instead
+of writing `datasets.json`: it ensures the owner organization exists, then `package_create`
+(or `package_update` on re-run) for each dataset and `resource_create` for each resource,
+authenticating with the `CKAN_API_KEY` env var. The slug becomes CKAN's package `name`;
+`name`/`description`/`keywords` map to `title`/`notes`/`tags`. In `link` mode the resource
+`url` references the source file (v1 does not re-upload bytes into CKAN). It stops on the
+first auth/permission error rather than half-migrating.
 
 ## After migrating
 

--- a/site/content/docs/skills/migrate.md
+++ b/site/content/docs/skills/migrate.md
@@ -49,13 +49,14 @@ any reader feeds any writer through the canonical shape.
 | Input | Required | Notes |
 | ----- | -------- | ----- |
 | Source URL | Yes | A CKAN base URL, or a DCAT `/data.json` URL. |
-| Source type | No | `ckan` or `dcat`; auto-detected from the URL if omitted. |
+| Source type | No | `ckan`, `dcat`, `socrata`, `ods`, or `arcgis`; auto-detected from the URL if omitted. |
 | Org / group filter | No | CKAN source only — restrict the harvest. |
 | `--target` | No | `static` (default) or `ckan`. |
 | Portal directory | No | Static target — defaults to the current directory. |
 | Copy mode | No | Static target — `link` (default) or `download`. |
 | Target CKAN URL | For `--target ckan` | The CKAN instance to write into. |
 | `CKAN_API_KEY` (env) | For `--target ckan` | A **write** API key, read from the environment — never passed on the command line. |
+| Owner org | No | CKAN target — file every dataset under this org (created if missing; defaults to each dataset's namespace). |
 | `--dry-run` | No | Preview what would be written, change nothing. |
 | `--replace` | No | Static target — clear existing entries first (default: upsert). |
 

--- a/site/content/docs/skills/migrate.md
+++ b/site/content/docs/skills/migrate.md
@@ -23,13 +23,16 @@ added once and works with every target.
 
 **Sources (v1):**
 
-| Source | Read via | Covers |
-| ------ | -------- | ------ |
-| **CKAN** | `package_search` / `package_show` | any CKAN instance |
-| **DCAT-US `/data.json`** | one catalog document | **DKAN, ArcGIS Hub, data.gov**, other DCAT-US publishers |
+| Source | `--source` | Read via | Covers |
+| ------ | ---------- | -------- | ------ |
+| **CKAN** | `ckan` | `package_search` / `package_show` | any CKAN instance |
+| **DCAT-US `/data.json`** | `dcat` | one catalog document | **DKAN, ArcGIS Hub, data.gov**, other DCAT-US publishers |
+| **Socrata** | `socrata` | Discovery API + resource exports | Socrata-powered sites |
+| **OpenDataSoft** | `ods` | Explore API v2 + exports | ODS-powered portals |
+| **ArcGIS FeatureServer / MapServer** | `arcgis` | layer metadata + GeoJSON query | individual ArcGIS services (each layer → a GeoJSON dataset) |
 
-> DKAN, ArcGIS Hub, and data.gov publish a DCAT-US `/data.json` — use the **dcat** source
-> for those. Native Socrata, OpenDataSoft, and ArcGIS FeatureServer readers are planned.
+> DKAN, ArcGIS Hub, and data.gov publish a DCAT-US `/data.json` — use **dcat** for those whole
+> catalogs; use **arcgis** for an individual FeatureServer/MapServer.
 
 **Targets:**
 
@@ -74,6 +77,14 @@ Harvest a DCAT catalog (DKAN / ArcGIS Hub / data.gov):
 
 ```
 /migrate https://hub.arcgis.com/data.json --source dcat
+```
+
+Harvest a Socrata site, an OpenDataSoft portal, or a single ArcGIS service:
+
+```
+/migrate https://data.cityofnewyork.us --source socrata
+/migrate https://data.opendatasoft.com --source ods
+/migrate https://services.arcgis.com/…/FeatureServer --source arcgis
 ```
 
 Move one CKAN instance's datasets into another CKAN (set the write key first):


### PR DESCRIPTION
Extends `/migrate` (the v2 epic [po-kdo](#) children). All skill + docs content — **no npm release** (the `/migrate` skill is already in the scaffold allowlist from 0.5.0, so new scaffolds fetch the updated `migrate.md` from main).

## po-btf — CKAN write target
`--target ckan` pushes the canonical datasets **into** a CKAN instance via its action API (`organization`/`package`/`resource_create`, `_update` on re-run), authenticating with the `CKAN_API_KEY` env var (never on the CLI). Enables **CKAN→CKAN** and **DKAN→CKAN**. Stops on the first 403/auth failure rather than half-migrating. Canonical→CKAN field mapping verified against a live `package_show` schema (`name`/`title`/`notes`/`owner_org`/`tags[{name}]`/`resources[{name,url,format}]`).

## po-h5y / po-bld / po-5bl — three new source readers
- **`socrata`** — Discovery API (`api.us.socrata.com/api/catalog/v1`) + per-dataset `/resource/<4x4>.csv`; namespace from `domain_category`.
- **`ods`** — OpenDataSoft Explore API v2 catalog + `/exports/csv`; namespace from `theme`; `dataset_id` slugified (ODS ids can contain `@`).
- **`arcgis`** — FeatureServer/MapServer `?f=json` layers → one GeoJSON dataset per layer via `/<id>/query?f=geojson`; namespace from service name.

Auto-detection extended: `/FeatureServer`|`/MapServer`→arcgis, `/api/explore`→ods, `/api/catalog`→socrata.

## Verification (React 19 template)
Harvested all three live sources into one catalog and built:
- Socrata `data.cityofnewyork.us` (5) + ODS `data.opendatasoft.com` (5) + ArcGIS `sampleserver6` USA/MapServer (4 layers) → 18 datasets → `npm run build` **EXIT=0**, 22 pages. (CKAN→CKAN write can't be POST-tested without a write key; mapping validated against the real schema, skill stops on auth failure.)

Closes po-btf, po-h5y, po-bld, po-5bl — completing the v2 readers/writer under epic po-kdo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `/migrate` command docs to cover additional sources (CKAN, DCAT-US, Socrata, OpenDataSoft, ArcGIS) and introduce a **CKAN** backend target alongside the default static catalog.
  * Clarified inputs, including environment-based CKAN credentials, target/static replace and dry-run behavior, and improved validation/error handling (migration halts on auth/permission failures).
  * Expanded ingestion and field-mapping guidance plus added detailed examples for common source-to-target paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->