### PR TITLE
feat(design): replace orange buttons with blue gradient/outline globally

### DIFF
--- a/site/components/ButtonLink.tsx
+++ b/site/components/ButtonLink.tsx
@@ -22,10 +22,10 @@ export default function ButtonLink({
   ...rest
 }: ButtonLinkProps) {
   let _className: string =
-    "inline-flex items-center justify-center px-4 py-2 border-0 text-base font-semibold text-center !rounded-[10px] transition duration-300 ";
+    "inline-flex items-center justify-center px-4 py-2 text-base font-semibold text-center !rounded-[10px] transition duration-300 ";
 
   if (style == "primary") {
-    _className += `bg-gradient-to-br from-sky-400 to-blue-600 text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)] hover:-translate-y-px`;
+    _className += `border-0 bg-gradient-to-br from-sky-400 to-blue-600 text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)] hover:-translate-y-px`;
   } else if (style == "secondary") {
     _className += `border border-slate-300 dark:border-slate-600 bg-transparent text-slate-700 dark:text-slate-300 hover:border-blue-400 hover:text-blue-600 dark:hover:border-blue-400 dark:hover:text-blue-400`;
   } else if (style == "tertiary") {

--- a/site/components/ButtonLink.tsx
+++ b/site/components/ButtonLink.tsx
@@ -22,12 +22,12 @@ export default function ButtonLink({
   ...rest
 }: ButtonLinkProps) {
   let _className: string =
-    "inline-block items-center justify-center px-4 py-2 border text-base font-semibold text-center rounded transition duration-300 ";
+    "inline-flex items-center justify-center px-4 py-2 border-0 text-base font-semibold text-center !rounded-[10px] transition duration-300 ";
 
   if (style == "primary") {
-    _className += `border-transparent bg-secondary hover:bg-secondary-hover text-black`;
+    _className += `bg-gradient-to-br from-sky-400 to-blue-600 text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)] hover:-translate-y-px`;
   } else if (style == "secondary") {
-    _className += `border-secondary hover:bg-secondary-hover hover:text-black text-secondary`;
+    _className += `border border-slate-300 dark:border-slate-600 bg-transparent text-slate-700 dark:text-slate-300 hover:border-blue-400 hover:text-blue-600 dark:hover:border-blue-400 dark:hover:text-blue-400`;
   } else if (style == "tertiary") {
     _className += `border-none hover:bg-slate-700 text-slate-300 bg-slate-800 `;
   }

--- a/site/components/Nav.tsx
+++ b/site/components/Nav.tsx
@@ -144,6 +144,7 @@ export default function Nav() {
           <ButtonLink
             href="https://cloud.portaljs.com"
             title="PortalJS Cloud — fully managed hosting"
+            style="primary"
             className="text-sm !py-2 hidden lg:block"
             trackConversion={true}
           >


### PR DESCRIPTION
## Summary

- `ButtonLink` `primary` style → blue gradient (`from-sky-400 to-blue-600`) replacing orange `bg-secondary`
- `ButtonLink` `secondary` style → blue outline replacing orange `border-secondary`
- Nav CTA (`PortalJS Cloud`) uses explicit `style="primary"` 
- Base class updated: `border-0`, `!rounded-[10px]`, `inline-flex` — no border artefacts, consistent shape across all pages

All existing `<ButtonLink>` usages site-wide automatically get the new design. No per-page changes needed.

## Merge order
Merge this PR **before** `feat/pricing-page-redesign` (#1579), which depends on these button styles.

## Test plan
- [ ] Homepage CTAs — blue gradient primary, blue outline secondary
- [ ] Nav — "PortalJS Cloud" button is blue gradient, correct size
- [ ] Compare pages — any ButtonLink CTAs are blue
- [ ] No orange buttons anywhere on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated `ButtonLink` styling for primary and secondary variants with refreshed base layout and transition behavior.
  * Improved primary buttons with a stronger sky-to-blue gradient, along with refined shadow, hover, and movement effects.
  * Refreshed secondary buttons using updated slate/dark-slate border and text styling for clearer hover states.
  * Updated the navigation “PortalJS Cloud” button to use the primary variant for consistent visual emphasis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->