### PR TITLE
Align case studies and data portals titles with homepage design

### DIFF
--- a/site/components/Showcases.tsx
+++ b/site/components/Showcases.tsx
@@ -207,16 +207,18 @@ export const dataPortals = [
 
 export default function Showcases() {
   return (
-    <div className="max-w-8xl px-4 xl:px-12 mx-auto">
-      <div>
-        {/* <p className="text-sm font-bold text-blue-400">LONG READ</p> */}
-        <div className="flex items-center justify-start gap-2 transition blink">
-          <p className="text-start text-5xl sm:text-7xl sm:my-8 tracking-tight">
-            Discover <br />
-            data portals <br />
-            powered by PortalJS{' '}
-          </p>
-        </div>
+    <div>
+      <div className="py-16 sm:py-20 text-center lg:text-left">
+        <span className="font-mono text-xs font-semibold uppercase tracking-[0.18em] text-blue-600">
+          Data Portals
+        </span>
+        <h1 className="mt-4 text-4xl font-bold leading-[1.08] tracking-tight text-slate-900 dark:text-white sm:text-5xl xl:text-6xl">
+          Discover <br />
+          <span className="bg-gradient-to-r from-sky-400 to-blue-600 bg-clip-text text-transparent">
+            data portals
+          </span> <br />
+          powered by PortalJS
+        </h1>
       </div>
       <div className="not-prose my-12 grid grid-cols-1 gap-[22px] sm:grid-cols-2">
         {dataPortals.map((item) => (

--- a/site/pages/case-studies.tsx
+++ b/site/pages/case-studies.tsx
@@ -11,7 +11,7 @@ import { CaseStudiesStructuredData } from '@/components/schema/CaseStudiesStruct
 
 export default function CaseStudiesPage(casestudies) {
   return (
-    <Layout>
+    <Layout isHomePage={true}>
       <Head>
         {generateNextSeo({
           title: "Case Studies | PortalJS",
@@ -20,13 +20,19 @@ export default function CaseStudiesPage(casestudies) {
         })}
       </Head>
       <CaseStudiesStructuredData casestudies={casestudies.casestudies} />
-      <section className="">
-        <div>
-          <div className="flex items-center gap-2 transition blink">
-            <p className="text-start text-5xl sm:text-7xl max-w-lg sm:my-8 tracking-tight">
-              See our client stories{' '}
-            </p>
-          </div>
+      <div className="flex justify-center">
+        <div className="max-w-8xl px-4 sm:px-8 xl:px-12 w-full">
+      <section className="py-16 sm:py-20">
+        <div className="text-center lg:text-left">
+          <span className="font-mono text-xs font-semibold uppercase tracking-[0.18em] text-blue-600">
+            Case Studies
+          </span>
+          <h1 className="mt-4 text-4xl font-bold leading-[1.08] tracking-tight text-slate-900 dark:text-white sm:text-5xl xl:text-6xl">
+            See our <br />
+            <span className="bg-gradient-to-r from-sky-400 to-blue-600 bg-clip-text text-transparent">
+              client stories
+            </span>
+          </h1>
         </div>
         <div className="grid grid-cols-1 gap-12 min-w-full my-8">
           {casestudies &&
@@ -49,9 +55,9 @@ export default function CaseStudiesPage(casestudies) {
                     />
                   </Link>
                   <div className="">
-                    <p className="text-sm font-bold text-blue-400 mb-1">
-                      CASE STUDY
-                    </p>
+                    <span className="font-mono text-xs font-semibold uppercase tracking-[0.18em] text-blue-600">
+                      Case Study
+                    </span>
                     <div className="">
                       <Link
                         className="line-clamp-3 text-[#2A3342]  group-hover:text-[#60a5fa] dark:text-[#f3f4f6] dark:hover:text-[#60a5fa] text-2xl font-bold transition ease-in-out capitalize max-w-3xl"
@@ -69,6 +75,8 @@ export default function CaseStudiesPage(casestudies) {
             ))}
         </div>
       </section>
+        </div>
+      </div>
     </Layout>
   )
 }

--- a/site/pages/data-portals.tsx
+++ b/site/pages/data-portals.tsx
@@ -6,7 +6,7 @@ import { DataPortalsStructuredData } from '@/components/schema/DataPortalStructu
 
 export default function DataPortalsPage() {
   return (
-    <Layout>
+    <Layout isHomePage={true}>
       <Head>
         {generateNextSeo({
           title: "Data Portals Showcase | PortalJS",
@@ -15,7 +15,11 @@ export default function DataPortalsPage() {
         })}
       </Head>
       <DataPortalsStructuredData />
-      <Showcases />
+      <div className="flex justify-center">
+        <div className="max-w-8xl px-4 sm:px-8 xl:px-12 w-full">
+          <Showcases />
+        </div>
+      </div>
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary

- Replaces old gradient/oversized headings on `/case-studies` and `/data-portals` with the homepage design system
- Adds mono blue label above each h1 (`Case Studies` / `Data Portals`)
- Applies homepage h1 typography: `font-bold leading-[1.08] tracking-tight text-4xl sm:text-5xl xl:text-6xl`
- Gradient span on key words: *client stories* and *data portals*
- Two-line break on "See our / client stories", three-line break on "Discover / data portals / powered by PortalJS"
- Both pages now use `isHomePage={true}` + `flex justify-center / max-w-8xl px-4 sm:px-8 xl:px-12` for identical horizontal alignment with the homepage

## Test plan

- [ ] Visit `/case-studies` — label, two-line h1 with gradient, correct padding
- [ ] Visit `/data-portals` — label, three-line h1 with gradient, correct padding
- [ ] Check both pages on mobile and desktop
- [ ] Verify dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout and typography structure on the showcase page
  * Refined case studies page layout with enhanced gradient text styling
  * Adjusted data portals page layout structure for improved presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->