### PR TITLE
docs(cloud): PortalJS Cloud architecture spec + infra handoff (po-x8x)

### DIFF
--- a/cloud/INFRA.md
+++ b/cloud/INFRA.md
@@ -28,12 +28,15 @@ until these exist.
   (schema in `SPEC.md`). Staging counterpart.
 
 ## 5. Workers
-- Two Workers (or one with routes): **router** (`*.portaljs.com`) and **deploy API**
-  (`api.portaljs.com/v1/*` or `deploy.portaljs.com`). I author `wrangler.toml` with the R2
-  + D1 bindings; you confirm the route + binding names.
+- Two Workers (or one with routes): **router** (`*.app.portaljs.com/*`) and **deploy API**
+  (`api.app.portaljs.com/v1/*`). I author `wrangler.toml` with the R2 + D1 bindings; you
+  confirm the route + binding names.
+- **Avoid `cloud.portaljs.com` and `api.portaljs.com`** — both are used by the legacy
+  PortalJS Cloud app. The new system lives entirely under `app.portaljs.com`
+  (dashboard/auth at the `app.portaljs.com` apex, API at `api.app.portaljs.com`).
 
 ## 6. GitHub OAuth app (for auth)
-- A GitHub OAuth app for `cloud.portaljs.com` (callback `https://cloud.portaljs.com/auth/callback`).
+- A GitHub OAuth app for `app.portaljs.com` (callback `https://app.portaljs.com/auth/callback`).
 - Hand me the **client ID**; keep the **client secret** in the Worker secret store.
 
 ## Secrets I'll need (via `wrangler secret put`, not in the repo)
@@ -44,9 +47,11 @@ until these exist.
 
 ## Suggested order
 1. R2 bucket + D1 db (staging) → unblocks API/Worker staging tests.
-2. Wildcard `*.staging.portaljs.com` → staging router → end-to-end staging.
-3. GitHub OAuth app → real auth.
-4. Production R2/D1 + flip `*.portaljs.com` wildcard.
+2. Wildcard `*.staging.app.portaljs.com` → staging router (+ `api.staging.app.portaljs.com`
+   → staging deploy API) → end-to-end staging.
+3. GitHub OAuth app (`app.portaljs.com`) → real auth.
+4. Production R2/D1 + flip `*.app.portaljs.com` wildcard → router, and
+   `api.app.portaljs.com` → deploy API.
 
 Give me account ID + a scoped API token + the staging bucket/db names and I can wire and
 deploy to staging.

--- a/cloud/INFRA.md
+++ b/cloud/INFRA.md
@@ -1,6 +1,6 @@
-# PortalJS Cloud — infra handoff (Datopian)
+# PortalJS Arc — infra handoff (Datopian)
 
-What needs to exist on the Cloudflare side for PortalJS Cloud to run. I build the Workers,
+What needs to exist on the Cloudflare side for PortalJS Arc to run. I build the Workers,
 API, and skill against the contract in `SPEC.md` and test locally; this is what you
 provision so we can go to staging → production.
 
@@ -8,15 +8,15 @@ Nothing here blocks local development — the Workers run on Miniflare with a mo
 until these exist.
 
 ## 1. Cloudflare account + zone
-- A Cloudflare account for PortalJS Cloud (the existing Datopian one is fine).
+- A Cloudflare account for PortalJS Arc (the existing Datopian one is fine).
 - The **`portaljs.com` zone** managed in that account (it already is, for the marketing site).
 
 ## 2. DNS
-- A **wildcard** `*.app.portaljs.com` record (proxied) pointed at the **Router Worker** (via
-  a Workers route `*.app.portaljs.com/*`). **Scoped to `app.portaljs.com` on purpose** — it
+- A **wildcard** `*.arc.portaljs.com` record (proxied) pointed at the **Router Worker** (via
+  a Workers route `*.arc.portaljs.com/*`). **Scoped to `arc.portaljs.com` on purpose** — it
   does NOT cover bare `<prefix>.portaljs.com`, so existing/legacy PortalJS Cloud customer
   subdomains are unaffected (different name level, outside the wildcard).
-- For staging: `*.staging.app.portaljs.com` → the staging Router Worker.
+- For staging: `*.staging.arc.portaljs.com` → the staging Router Worker.
 - Legacy `<prefix>.portaljs.com` records stay exactly as they are — no changes needed.
 
 ## 3. R2
@@ -28,15 +28,15 @@ until these exist.
   (schema in `SPEC.md`). Staging counterpart.
 
 ## 5. Workers
-- Two Workers (or one with routes): **router** (`*.app.portaljs.com/*`) and **deploy API**
-  (`api.app.portaljs.com/v1/*`). I author `wrangler.toml` with the R2 + D1 bindings; you
+- Two Workers (or one with routes): **router** (`*.arc.portaljs.com/*`) and **deploy API**
+  (`api.arc.portaljs.com/v1/*`). I author `wrangler.toml` with the R2 + D1 bindings; you
   confirm the route + binding names.
 - **Avoid `cloud.portaljs.com` and `api.portaljs.com`** — both are used by the legacy
-  PortalJS Cloud app. The new system lives entirely under `app.portaljs.com`
-  (dashboard/auth at the `app.portaljs.com` apex, API at `api.app.portaljs.com`).
+  PortalJS Cloud app. The new system lives entirely under `arc.portaljs.com`
+  (dashboard/auth at the `arc.portaljs.com` apex, API at `api.arc.portaljs.com`).
 
 ## 6. GitHub OAuth app (for auth)
-- A GitHub OAuth app for `app.portaljs.com` (callback `https://app.portaljs.com/auth/callback`).
+- A GitHub OAuth app for `arc.portaljs.com` (callback `https://arc.portaljs.com/auth/callback`).
 - Hand me the **client ID**; keep the **client secret** in the Worker secret store.
 
 ## Secrets I'll need (via `wrangler secret put`, not in the repo)
@@ -47,11 +47,11 @@ until these exist.
 
 ## Suggested order
 1. R2 bucket + D1 db (staging) → unblocks API/Worker staging tests.
-2. Wildcard `*.staging.app.portaljs.com` → staging router (+ `api.staging.app.portaljs.com`
+2. Wildcard `*.staging.arc.portaljs.com` → staging router (+ `api.staging.arc.portaljs.com`
    → staging deploy API) → end-to-end staging.
-3. GitHub OAuth app (`app.portaljs.com`) → real auth.
-4. Production R2/D1 + flip `*.app.portaljs.com` wildcard → router, and
-   `api.app.portaljs.com` → deploy API.
+3. GitHub OAuth app (`arc.portaljs.com`) → real auth.
+4. Production R2/D1 + flip `*.arc.portaljs.com` wildcard → router, and
+   `api.arc.portaljs.com` → deploy API.
 
 Give me account ID + a scoped API token + the staging bucket/db names and I can wire and
 deploy to staging.

--- a/cloud/INFRA.md
+++ b/cloud/INFRA.md
@@ -19,13 +19,30 @@ until these exist.
 - For staging: `*.staging.arc.portaljs.com` → the staging Router Worker.
 - Legacy `<prefix>.portaljs.com` records stay exactly as they are — no changes needed.
 
+## 2b. TLS — Advanced Certificate Manager (REQUIRED)
+
+**Universal SSL is not enough.** Cloudflare's free Universal SSL covers only `portaljs.com`
+and the single-label wildcard `*.portaljs.com` — it does **not** cover `*.arc.portaljs.com`
+(two labels deep) or `*.staging.arc.portaljs.com` (three deep). Without a matching cert the
+edge returns a TLS handshake failure (confirmed on staging: `hello.staging.arc.portaljs.com`
+→ `sslv3 alert handshake failure`).
+
+Enable **Advanced Certificate Manager (ACM)** on the `portaljs.com` zone (~$10/mo) and order
+advanced certificates (or turn on **Total TLS**) covering:
+- `*.arc.portaljs.com` (production tenants) — plus `arc.portaljs.com` for the dashboard.
+- `*.staging.arc.portaljs.com` (staging).
+
+Certs take a few minutes to issue. (Alternative if you want to avoid ACM: a single-label
+scheme like `arc-<slug>.portaljs.com` is covered by Universal SSL — but it gives up the clean
+`arc.` namespace and reintroduces legacy-collision risk. ACM is the recommended path.)
+
 ## 3. R2
-- One **R2 bucket** (e.g. `portaljs-cloud`) for tenant static files. A separate
-  `portaljs-cloud-staging` bucket for staging.
+- One **R2 bucket** `portaljs-arc` for tenant static files (objects under `sites/<slug>/`),
+  plus `portaljs-arc-staging` for staging.
 
 ## 4. D1
-- One **D1 database** (e.g. `portaljs-cloud`) for `users`/`tokens`/`projects`/`deployments`
-  (schema in `SPEC.md`). Staging counterpart.
+- One **D1 database** `portaljs-arc` for `users`/`tokens`/`projects`/`deployments` (schema in
+  `SPEC.md`), plus `portaljs-arc-staging`.
 
 ## 5. Workers
 - Two Workers (or one with routes): **router** (`*.arc.portaljs.com/*`) and **deploy API**
@@ -39,19 +56,21 @@ until these exist.
 - A GitHub OAuth app for `arc.portaljs.com` (callback `https://arc.portaljs.com/auth/callback`).
 - Hand me the **client ID**; keep the **client secret** in the Worker secret store.
 
-## Secrets I'll need (via `wrangler secret put`, not in the repo)
-- `CLOUDFLARE_API_TOKEN` (account-scoped: Workers + R2 + D1 edit) — for deploys from CI/me.
-- `CLOUDFLARE_ACCOUNT_ID`.
-- `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET`.
+## Secrets (via `wrangler secret put`, not in the repo)
+- Deploys: I authenticate with `wrangler login` (OAuth) — **no `CLOUDFLARE_API_TOKEN` needed**.
+  Only needed for headless CI, and then via a local gitignored env file, never in chat.
+- `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` (auth worker).
 - A signing secret for API tokens (`TOKEN_SIGNING_KEY`).
 
 ## Suggested order
-1. R2 bucket + D1 db (staging) → unblocks API/Worker staging tests.
-2. Wildcard `*.staging.arc.portaljs.com` → staging router (+ `api.staging.arc.portaljs.com`
-   → staging deploy API) → end-to-end staging.
-3. GitHub OAuth app (`arc.portaljs.com`) → real auth.
-4. Production R2/D1 + flip `*.arc.portaljs.com` wildcard → router, and
-   `api.arc.portaljs.com` → deploy API.
+1. R2 bucket + D1 db (staging) → unblocks API/Worker staging tests. ✅ done
+2. Wildcard `*.staging.arc.portaljs.com` (proxied) → staging router. ✅ done
+3. **Enable ACM + order a `*.staging.arc.portaljs.com` cert** → unblocks HTTPS on staging
+   tenant URLs (currently blocked by the TLS handshake failure). ← **next**
+4. (+ `api.staging.arc.portaljs.com` → staging deploy API) → end-to-end staging.
+5. GitHub OAuth app (`arc.portaljs.com`) → real auth.
+6. Production: R2/D1 (`portaljs-arc`) + ACM cert for `*.arc.portaljs.com` + flip the
+   `*.arc.portaljs.com` wildcard → router, and `api.arc.portaljs.com` → deploy API.
 
-Give me account ID + a scoped API token + the staging bucket/db names and I can wire and
-deploy to staging.
+Auth: I use `wrangler login` (OAuth) for deploys — no API token needed. If a token is ever
+required (CI), provide it via a local gitignored env file, never in chat.

--- a/cloud/INFRA.md
+++ b/cloud/INFRA.md
@@ -45,9 +45,11 @@ scheme like `arc-<slug>.portaljs.com` is covered by Universal SSL — but it giv
   `SPEC.md`), plus `portaljs-arc-staging`.
 
 ## 5. Workers
-- Two Workers (or one with routes): **router** (`*.arc.portaljs.com/*`) and **deploy API**
-  (`api.arc.portaljs.com/v1/*`). I author `wrangler.toml` with the R2 + D1 bindings; you
-  confirm the route + binding names.
+- Three Workers (or one with routes): **router** (`*.arc.portaljs.com/*`), **deploy API**
+  (`api.arc.portaljs.com/v1/*`), and the **auth app / dashboard** (`arc.portaljs.com` apex —
+  GitHub OAuth + token issuance, bead po-5vk; the router + API are live first, auth lands
+  with po-5vk). I author each `wrangler.toml` with the R2/D1 bindings; you confirm the
+  routes + binding names.
 - **Avoid `cloud.portaljs.com` and `api.portaljs.com`** — both are used by the legacy
   PortalJS Cloud app. The new system lives entirely under `arc.portaljs.com`
   (dashboard/auth at the `arc.portaljs.com` apex, API at `api.arc.portaljs.com`).

--- a/cloud/INFRA.md
+++ b/cloud/INFRA.md
@@ -12,10 +12,12 @@ until these exist.
 - The **`portaljs.com` zone** managed in that account (it already is, for the marketing site).
 
 ## 2. DNS
-- A **wildcard** `*.portaljs.com` record (proxied) pointed at the **Router Worker** (via a
-  Workers route `*.portaljs.com/*`). Existing hosts (`www`, `docs`, `api`, etc.) keep their
-  own records and are excluded by the Worker's reserved-list.
-- For staging: `*.staging.portaljs.com` → the staging Router Worker.
+- A **wildcard** `*.app.portaljs.com` record (proxied) pointed at the **Router Worker** (via
+  a Workers route `*.app.portaljs.com/*`). **Scoped to `app.portaljs.com` on purpose** — it
+  does NOT cover bare `<prefix>.portaljs.com`, so existing/legacy PortalJS Cloud customer
+  subdomains are unaffected (different name level, outside the wildcard).
+- For staging: `*.staging.app.portaljs.com` → the staging Router Worker.
+- Legacy `<prefix>.portaljs.com` records stay exactly as they are — no changes needed.
 
 ## 3. R2
 - One **R2 bucket** (e.g. `portaljs-cloud`) for tenant static files. A separate

--- a/cloud/INFRA.md
+++ b/cloud/INFRA.md
@@ -1,0 +1,50 @@
+# PortalJS Cloud — infra handoff (Datopian)
+
+What needs to exist on the Cloudflare side for PortalJS Cloud to run. I build the Workers,
+API, and skill against the contract in `SPEC.md` and test locally; this is what you
+provision so we can go to staging → production.
+
+Nothing here blocks local development — the Workers run on Miniflare with a mock R2/D1
+until these exist.
+
+## 1. Cloudflare account + zone
+- A Cloudflare account for PortalJS Cloud (the existing Datopian one is fine).
+- The **`portaljs.com` zone** managed in that account (it already is, for the marketing site).
+
+## 2. DNS
+- A **wildcard** `*.portaljs.com` record (proxied) pointed at the **Router Worker** (via a
+  Workers route `*.portaljs.com/*`). Existing hosts (`www`, `docs`, `api`, etc.) keep their
+  own records and are excluded by the Worker's reserved-list.
+- For staging: `*.staging.portaljs.com` → the staging Router Worker.
+
+## 3. R2
+- One **R2 bucket** (e.g. `portaljs-cloud`) for tenant static files. A separate
+  `portaljs-cloud-staging` bucket for staging.
+
+## 4. D1
+- One **D1 database** (e.g. `portaljs-cloud`) for `users`/`tokens`/`projects`/`deployments`
+  (schema in `SPEC.md`). Staging counterpart.
+
+## 5. Workers
+- Two Workers (or one with routes): **router** (`*.portaljs.com`) and **deploy API**
+  (`api.portaljs.com/v1/*` or `deploy.portaljs.com`). I author `wrangler.toml` with the R2
+  + D1 bindings; you confirm the route + binding names.
+
+## 6. GitHub OAuth app (for auth)
+- A GitHub OAuth app for `cloud.portaljs.com` (callback `https://cloud.portaljs.com/auth/callback`).
+- Hand me the **client ID**; keep the **client secret** in the Worker secret store.
+
+## Secrets I'll need (via `wrangler secret put`, not in the repo)
+- `CLOUDFLARE_API_TOKEN` (account-scoped: Workers + R2 + D1 edit) — for deploys from CI/me.
+- `CLOUDFLARE_ACCOUNT_ID`.
+- `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET`.
+- A signing secret for API tokens (`TOKEN_SIGNING_KEY`).
+
+## Suggested order
+1. R2 bucket + D1 db (staging) → unblocks API/Worker staging tests.
+2. Wildcard `*.staging.portaljs.com` → staging router → end-to-end staging.
+3. GitHub OAuth app → real auth.
+4. Production R2/D1 + flip `*.portaljs.com` wildcard.
+
+Give me account ID + a scoped API token + the staging bucket/db names and I can wire and
+deploy to staging.

--- a/cloud/SPEC.md
+++ b/cloud/SPEC.md
@@ -51,12 +51,42 @@ becomes an implementation detail we've wrapped away.
 
 ## URL & namespace scheme
 
-- Public URL: `https://<slug>.portaljs.com`.
-- `<slug>` is unique **globally** across tenants (it's a hostname). On collision at deploy
-  time, the API suffixes (`<slug>-2`) or, preferably, namespaces under the user
-  (`<slug>-<user>` only when needed) — final scheme TBD, see Open questions.
+- Public URL: `https://<slug>.<cloud-zone>` where `<cloud-zone>` is **TBD** — see *Legacy
+  coexistence* below. Either bare `portaljs.com` (with safeguards) or a dedicated namespace
+  like `app.portaljs.com` / a separate `portaljs.cloud` zone.
+- `<slug>` is unique within the cloud zone (it's a hostname). On collision at deploy time,
+  the API suffixes (`<slug>-2`) or namespaces under the user — final scheme TBD, see Open
+  questions.
 - **Reserved subdomains** (never assignable): `www docs app api cloud blog status
-  staging admin assets cdn` (+ existing marketing hosts).
+  staging admin assets cdn` (+ **every existing host in the `portaljs.com` zone** — built
+  from a live inventory, not a guess).
+
+## Legacy `*.portaljs.com` coexistence (must resolve before prod DNS)
+
+Legacy PortalJS Cloud customers already deploy at `<prefix>.portaljs.com`. A wildcard
+`*.portaljs.com` → Router Worker must not break them.
+
+**Cloudflare precedence (the safety net):** a specific DNS record always wins over a
+wildcard, and Workers match the most specific route. So a legacy customer with an explicit
+`customer.portaljs.com` record/route is **not** shadowed by our wildcard — the wildcard
+only catches hostnames with no explicit record.
+
+**Residual risks:** (a) legacy customers served *by* a wildcard/router rather than explicit
+per-customer records; (b) informal/unclaimed names; (c) a new user's slug colliding with an
+existing customer's prefix.
+
+**Plan (in order of safety):**
+1. **Dedicated namespace (recommended).** Point the wildcard at a namespace legacy never
+   used — `*.app.portaljs.com` or a separate zone `*.portaljs.cloud` — so new deploys cannot
+   collide with anything on bare `portaljs.com`. Still presented as "PortalJS Cloud."
+2. **Inventory + reserved-list.** Before any wildcard, enumerate every existing
+   `portaljs.com` subdomain in the Cloudflare zone; bake them into the Worker reserved list
+   and confirm each has an explicit record (so DNS specificity protects it).
+3. **Staging-first.** Validate on `*.staging.portaljs.com`; never flip the bare
+   `*.portaljs.com` wildcard until 1–2 are confirmed.
+
+If bare `<slug>.portaljs.com` is required (not a dedicated namespace), then **(2) + (3) are
+mandatory** and the deploy API must reject any slug already present in the zone inventory.
 
 ## R2 layout
 

--- a/cloud/SPEC.md
+++ b/cloud/SPEC.md
@@ -1,10 +1,10 @@
-# PortalJS Cloud — managed static hosting + `/deploy`
+# PortalJS Arc — managed static hosting + `/deploy`
 
 Status: **design** (epic `po-x8x`). Architecture locked 2026-06-15.
 
-PortalJS Cloud is Datopian-managed static hosting for PortalJS portals. The `/deploy`
-skill has **one target** — PortalJS Cloud. A user runs `/deploy`, authenticates once, and
-gets a live `https://<slug>.app.portaljs.com` serving their static build. Users who want their
+PortalJS Arc is Datopian-managed static hosting for PortalJS portals. The `/deploy`
+skill has **one target** — PortalJS Arc. A user runs `/deploy`, authenticates once, and
+gets a live `https://<slug>.arc.portaljs.com` serving their static build. Users who want their
 own host (Vercel, their own Cloudflare, Netlify, …) self-serve; the skill does not cover
 that.
 
@@ -15,9 +15,9 @@ locally testable with `wrangler dev` / Miniflare before real DNS is involved.
 
 ```
 $ /deploy
-→ first run: "Sign in to PortalJS Cloud" → app.portaljs.com → paste token (or device code)
+→ first run: "Sign in to PortalJS Arc" → arc.portaljs.com → paste token (or device code)
 → next build (static export) → out/
-→ uploading to PortalJS Cloud…
+→ uploading to PortalJS Arc…
 ✓ Live at https://my-portal.portaljs.com
 ```
 
@@ -30,7 +30,7 @@ Re-running `/deploy` updates the same site (idempotent, keyed on the project slu
    (in portal repo)                     POST /v1/deploy                       │
                                         validate token (D1)                   │
                                         record deployment (D1)                │
-        browser ◀── https://<slug>.app.portaljs.com ◀── Router Worker ◀──get──────┘
+        browser ◀── https://<slug>.arc.portaljs.com ◀── Router Worker ◀──get──────┘
                          (wildcard *.portaljs.com → Worker, serves from R2)
 ```
 
@@ -42,20 +42,20 @@ Two Workers (or one Worker with two route groups), one R2 bucket, one D1 databas
 - **Deploy API (Worker)** — `POST /v1/deploy`; authenticates, writes the upload to R2,
   records the deployment.
 - **D1** — relational state: `users`, `tokens`, `projects`, `deployments`.
-- **Auth app / dashboard** — `app.portaljs.com` (apex of the new namespace; a wildcard
-  `*.app.portaljs.com` does not match the apex, so the dashboard and tenant portals coexist):
+- **Auth app / dashboard** — `arc.portaljs.com` (apex of the new namespace; a wildcard
+  `*.arc.portaljs.com` does not match the apex, so the dashboard and tenant portals coexist):
   GitHub OAuth sign-up + API-token issuance.
 
 ### Hostnames (locked)
 
 | Purpose | Host | Notes |
 | ------- | ---- | ----- |
-| Tenant portals | `<slug>.app.portaljs.com` | wildcard → Router Worker |
-| Dashboard / auth | `app.portaljs.com` | apex; not matched by the wildcard |
-| Deploy API | `api.app.portaljs.com` | reserved label; more-specific Worker route beats the wildcard |
+| Tenant portals | `<slug>.arc.portaljs.com` | wildcard → Router Worker |
+| Dashboard / auth | `arc.portaljs.com` | apex; not matched by the wildcard |
+| Deploy API | `api.arc.portaljs.com` | reserved label; more-specific Worker route beats the wildcard |
 
 > **Avoid `cloud.portaljs.com` and `api.portaljs.com`** — both are already used by the
-> legacy PortalJS Cloud app. Everything for the new system lives under `app.portaljs.com`.
+> legacy PortalJS Cloud app. Everything for the new system lives under `arc.portaljs.com`.
 
 ### Why R2 + Worker (not Pages-per-project)
 Wildcard `*.portaljs.com` → one Worker means **zero per-tenant DNS/provisioning** and scale
@@ -64,13 +64,13 @@ becomes an implementation detail we've wrapped away.
 
 ## URL & namespace scheme
 
-- Public URL: **`https://<slug>.app.portaljs.com`** (locked 2026-06-15). The wildcard lives
-  on `app.portaljs.com`, **not** bare `portaljs.com` — so legacy `<prefix>.portaljs.com`
+- Public URL: **`https://<slug>.arc.portaljs.com`** (locked 2026-06-15). The wildcard lives
+  on `arc.portaljs.com`, **not** bare `portaljs.com` — so legacy `<prefix>.portaljs.com`
   customers are physically out of the wildcard's scope and unaffected.
-- `<slug>` is unique within `app.portaljs.com` (only ever new-system tenants — no legacy
+- `<slug>` is unique within `arc.portaljs.com` (only ever new-system tenants — no legacy
   collision possible). On collision among new tenants, the API suffixes (`<slug>-2`) or
   namespaces under the user — final scheme TBD, see Open questions.
-- **Reserved labels** under `app.portaljs.com`: `www api staging admin` (small list — the
+- **Reserved labels** under `arc.portaljs.com`: `www api staging admin` (small list — the
   legacy-collision problem is gone, so the big zone-inventory reserved-list is no longer
   required).
 
@@ -88,14 +88,14 @@ only catches hostnames with no explicit record.
 per-customer records; (b) informal/unclaimed names; (c) a new user's slug colliding with an
 existing customer's prefix.
 
-**Resolution (locked 2026-06-15): dedicated namespace `*.app.portaljs.com`.** The wildcard is
-scoped to `app.portaljs.com`, a name legacy never used, so new deploys **cannot** collide
+**Resolution (locked 2026-06-15): dedicated namespace `*.arc.portaljs.com`.** The wildcard is
+scoped to `arc.portaljs.com`, a name legacy never used, so new deploys **cannot** collide
 with any bare-`portaljs.com` customer subdomain — the wildcard simply doesn't cover them.
 This removes the need for a zone inventory / large reserved-list. Legacy
 `<prefix>.portaljs.com` deployments are entirely untouched.
 
-Still observed: **staging-first** — validate on `*.staging.app.portaljs.com` before flipping
-the production `*.app.portaljs.com` wildcard.
+Still observed: **staging-first** — validate on `*.staging.arc.portaljs.com` before flipping
+the production `*.arc.portaljs.com` wildcard.
 
 ## R2 layout
 
@@ -128,36 +128,36 @@ of the previous deployment.
   index resolution, content-types, 404s.
 
 ### 2. Deploy API Worker (`cloud/api/`) — bead `po-bn9`
-- Served at `api.app.portaljs.com` (reserved label; a more-specific Worker route beats the
-  `*.app.portaljs.com` tenant wildcard).
+- Served at `api.arc.portaljs.com` (reserved label; a more-specific Worker route beats the
+  `*.arc.portaljs.com` tenant wildcard).
 - `POST /v1/deploy` — multipart/tar body + `slug`; `Authorization: Bearer <token>`.
   1. Validate token (D1 `tokens` → `user_id`); 401 on failure.
   2. Resolve/allocate `<slug>` for this user; reject reserved slugs.
   3. Unpack the bundle; `put` each file to `portals/<user>/<slug>/…`; write `manifest.json`.
   4. Record a `deployments` row (status, file count, bytes, timestamp).
   5. Delete the prior deployment's orphaned objects (atomic-ish switch).
-  6. Return `{ url: "https://<slug>.app.portaljs.com", deployment_id, status }`.
+  6. Return `{ url: "https://<slug>.arc.portaljs.com", deployment_id, status }`.
 - `GET /v1/deploy/:id` — status (for the skill to poll, if upload is async).
 - Limits: max bundle size, file count, per-user project cap (configurable).
 - **Local test:** `wrangler dev`; POST a sample `out/`; assert R2 contents + D1 row + URL.
 
-### 3. Auth — `app.portaljs.com` (`cloud/auth/`) — bead `po-5vk`
+### 3. Auth — `arc.portaljs.com` (`cloud/auth/`) — bead `po-5vk`
 - GitHub OAuth → create `users` row; UI to generate/revoke API tokens.
 - Client login: `npx portaljs login` (or folded into the skill) → device-code or
   paste-token → write `~/.portaljs/credentials` (`{ token, api }`, where `api` defaults to
-  `https://api.app.portaljs.com`). `PORTALJS_TOKEN` env overrides (CI).
+  `https://api.arc.portaljs.com`). `PORTALJS_TOKEN` env overrides (CI).
 - API tokens are opaque, hashed at rest in D1.
 
 ### 4. `/deploy` skill rewrite (`.claude/commands/deploy.md`) — bead `po-4yq`
 - Single target. Steps: ensure `output: 'export'` in `next.config.js` → `next build` →
   verify `out/` → ensure auth (run login if no creds) → tar `out/` → `POST /v1/deploy` →
-  poll → print `https://<slug>.app.portaljs.com`. Never report success on a failing build.
+  poll → print `https://<slug>.arc.portaljs.com`. Never report success on a failing build.
 - Slug defaults to the project slug (from `package.json`/dir), overridable with a flag.
 - Drop the Vercel/static-host branching; add a one-line "to self-host elsewhere, run
   `next build && next export` and upload `out/` to any static host."
 
 ### 5. Docs (`site/content/docs/…`) — bead `po-xqq`
-- Rewrite the `/deploy` skill page to the single target; add a PortalJS Cloud concept page.
+- Rewrite the `/deploy` skill page to the single target; add a PortalJS Arc concept page.
 
 ## D1 schema (draft)
 
@@ -175,7 +175,7 @@ deployments(id TEXT PK, project_id TEXT, status TEXT, files INT, bytes INT, crea
 2. **Skill (po-4yq)** built against the API contract; tested against the local API.
 3. **Auth (po-5vk)** — GitHub OAuth needs a real app; can stub token validation locally.
 4. **Staging**: deploy to the real Cloudflare account on a staging subdomain
-   (`*.staging.app.portaljs.com`), end-to-end test.
+   (`*.staging.arc.portaljs.com`), end-to-end test.
 5. Flip `*.portaljs.com` wildcard to the Router Worker.
 
 ## Infra handoff (Datopian-provisioned)

--- a/cloud/SPEC.md
+++ b/cloud/SPEC.md
@@ -18,7 +18,7 @@ $ /deploy
 → first run: "Sign in to PortalJS Arc" → arc.portaljs.com → paste token (or device code)
 → next build (static export) → out/
 → uploading to PortalJS Arc…
-✓ Live at https://my-portal.portaljs.com
+✓ Live at https://my-portal.arc.portaljs.com
 ```
 
 Re-running `/deploy` updates the same site (idempotent, keyed on the project slug).
@@ -26,18 +26,19 @@ Re-running `/deploy` updates the same site (idempotent, keyed on the project slu
 ## Architecture
 
 ```
-  /deploy skill ──tar(out/)+token──▶  Deploy API (Worker)  ──put──▶  R2: portals/<user>/<slug>/…
+  /deploy skill ──tar(out/)+token──▶  Deploy API (Worker)  ──put──▶  R2: sites/<slug>/…
    (in portal repo)                     POST /v1/deploy                       │
                                         validate token (D1)                   │
                                         record deployment (D1)                │
         browser ◀── https://<slug>.arc.portaljs.com ◀── Router Worker ◀──get──────┘
-                         (wildcard *.portaljs.com → Worker, serves from R2)
+                       (wildcard *.arc.portaljs.com → Worker, serves from R2)
 ```
 
 Two Workers (or one Worker with two route groups), one R2 bucket, one D1 database.
 
-- **R2** — object store for all tenants' static files: `portals/<user>/<slug>/<path>`.
-- **Router Worker** — bound to `*.portaljs.com`; resolves the hostname's `<slug>` to a
+- **R2** — object store for all tenants' static files: `sites/<slug>/<path>` (slug-addressable
+  so the router needs no DB on the request path; ownership lives in D1).
+- **Router Worker** — bound to `*.arc.portaljs.com`; resolves the hostname's `<slug>` to a
   tenant and streams assets from R2.
 - **Deploy API (Worker)** — `POST /v1/deploy`; authenticates, writes the upload to R2,
   records the deployment.
@@ -58,7 +59,7 @@ Two Workers (or one Worker with two route groups), one R2 bucket, one D1 databas
 > legacy PortalJS Cloud app. Everything for the new system lives under `arc.portaljs.com`.
 
 ### Why R2 + Worker (not Pages-per-project)
-Wildcard `*.portaljs.com` → one Worker means **zero per-tenant DNS/provisioning** and scale
+Wildcard `*.arc.portaljs.com` → one Worker means **zero per-tenant DNS/provisioning** and scale
 to many thousands of portals, with no Cloudflare Pages project/custom-domain limits. Pages
 becomes an implementation detail we've wrapped away.
 
@@ -100,12 +101,15 @@ the production `*.arc.portaljs.com` wildcard.
 ## R2 layout
 
 ```
-portals/<user_id>/<slug>/
+sites/<slug>/
   index.html
   _next/static/…            # hashed assets, immutable
   data/…                    # /public/data files (download-mode portals)
   …                         # everything from out/
 ```
+
+Slug-addressable (not `portals/<user>/<slug>/`) so the Router Worker serves by hostname
+with no DB lookup on the request path; ownership/quota live in D1 (`projects.slug`).
 
 Object metadata carries `content-type` (from extension) and a `deployment_id` for cache
 busting. A small `manifest.json` per deploy lists files for atomic switchover and cleanup
@@ -114,7 +118,7 @@ of the previous deployment.
 ## Components
 
 ### 1. Router Worker (`cloud/worker/`) — bead `po-2xm`
-- Bound to `*.portaljs.com`. Extract `<slug>` from `Host`.
+- Bound to `*.arc.portaljs.com`. Extract `<slug>` from `Host`.
 - Reserved/marketing hostnames → pass through / 404 (not served from R2).
 - Look up `<slug>` → `<user_id>` (D1, cached in the Worker's in-memory/KV cache).
 - Resolve the request path in R2:
@@ -133,7 +137,7 @@ of the previous deployment.
 - `POST /v1/deploy` — multipart/tar body + `slug`; `Authorization: Bearer <token>`.
   1. Validate token (D1 `tokens` → `user_id`); 401 on failure.
   2. Resolve/allocate `<slug>` for this user; reject reserved slugs.
-  3. Unpack the bundle; `put` each file to `portals/<user>/<slug>/…`; write `manifest.json`.
+  3. Unpack the bundle; `put` each file to `sites/<slug>/…`; write `manifest.json`.
   4. Record a `deployments` row (status, file count, bytes, timestamp).
   5. Delete the prior deployment's orphaned objects (atomic-ish switch).
   6. Return `{ url: "https://<slug>.arc.portaljs.com", deployment_id, status }`.
@@ -176,7 +180,7 @@ deployments(id TEXT PK, project_id TEXT, status TEXT, files INT, bytes INT, crea
 3. **Auth (po-5vk)** — GitHub OAuth needs a real app; can stub token validation locally.
 4. **Staging**: deploy to the real Cloudflare account on a staging subdomain
    (`*.staging.arc.portaljs.com`), end-to-end test.
-5. Flip `*.portaljs.com` wildcard to the Router Worker.
+5. Flip `*.arc.portaljs.com` wildcard to the Router Worker.
 
 ## Infra handoff (Datopian-provisioned)
 

--- a/cloud/SPEC.md
+++ b/cloud/SPEC.md
@@ -4,7 +4,7 @@ Status: **design** (epic `po-x8x`). Architecture locked 2026-06-15.
 
 PortalJS Cloud is Datopian-managed static hosting for PortalJS portals. The `/deploy`
 skill has **one target** — PortalJS Cloud. A user runs `/deploy`, authenticates once, and
-gets a live `https://<slug>.portaljs.com` serving their static build. Users who want their
+gets a live `https://<slug>.app.portaljs.com` serving their static build. Users who want their
 own host (Vercel, their own Cloudflare, Netlify, …) self-serve; the skill does not cover
 that.
 
@@ -15,7 +15,7 @@ locally testable with `wrangler dev` / Miniflare before real DNS is involved.
 
 ```
 $ /deploy
-→ first run: "Sign in to PortalJS Cloud" → cloud.portaljs.com → paste token (or device code)
+→ first run: "Sign in to PortalJS Cloud" → app.portaljs.com → paste token (or device code)
 → next build (static export) → out/
 → uploading to PortalJS Cloud…
 ✓ Live at https://my-portal.portaljs.com
@@ -30,7 +30,7 @@ Re-running `/deploy` updates the same site (idempotent, keyed on the project slu
    (in portal repo)                     POST /v1/deploy                       │
                                         validate token (D1)                   │
                                         record deployment (D1)                │
-        browser ◀── https://<slug>.portaljs.com ◀── Router Worker ◀──get──────┘
+        browser ◀── https://<slug>.app.portaljs.com ◀── Router Worker ◀──get──────┘
                          (wildcard *.portaljs.com → Worker, serves from R2)
 ```
 
@@ -42,7 +42,20 @@ Two Workers (or one Worker with two route groups), one R2 bucket, one D1 databas
 - **Deploy API (Worker)** — `POST /v1/deploy`; authenticates, writes the upload to R2,
   records the deployment.
 - **D1** — relational state: `users`, `tokens`, `projects`, `deployments`.
-- **Auth app** — `cloud.portaljs.com`: GitHub OAuth sign-up + API-token issuance.
+- **Auth app / dashboard** — `app.portaljs.com` (apex of the new namespace; a wildcard
+  `*.app.portaljs.com` does not match the apex, so the dashboard and tenant portals coexist):
+  GitHub OAuth sign-up + API-token issuance.
+
+### Hostnames (locked)
+
+| Purpose | Host | Notes |
+| ------- | ---- | ----- |
+| Tenant portals | `<slug>.app.portaljs.com` | wildcard → Router Worker |
+| Dashboard / auth | `app.portaljs.com` | apex; not matched by the wildcard |
+| Deploy API | `api.app.portaljs.com` | reserved label; more-specific Worker route beats the wildcard |
+
+> **Avoid `cloud.portaljs.com` and `api.portaljs.com`** — both are already used by the
+> legacy PortalJS Cloud app. Everything for the new system lives under `app.portaljs.com`.
 
 ### Why R2 + Worker (not Pages-per-project)
 Wildcard `*.portaljs.com` → one Worker means **zero per-tenant DNS/provisioning** and scale
@@ -115,28 +128,30 @@ of the previous deployment.
   index resolution, content-types, 404s.
 
 ### 2. Deploy API Worker (`cloud/api/`) — bead `po-bn9`
+- Served at `api.app.portaljs.com` (reserved label; a more-specific Worker route beats the
+  `*.app.portaljs.com` tenant wildcard).
 - `POST /v1/deploy` — multipart/tar body + `slug`; `Authorization: Bearer <token>`.
   1. Validate token (D1 `tokens` → `user_id`); 401 on failure.
   2. Resolve/allocate `<slug>` for this user; reject reserved slugs.
   3. Unpack the bundle; `put` each file to `portals/<user>/<slug>/…`; write `manifest.json`.
   4. Record a `deployments` row (status, file count, bytes, timestamp).
   5. Delete the prior deployment's orphaned objects (atomic-ish switch).
-  6. Return `{ url: "https://<slug>.portaljs.com", deployment_id, status }`.
+  6. Return `{ url: "https://<slug>.app.portaljs.com", deployment_id, status }`.
 - `GET /v1/deploy/:id` — status (for the skill to poll, if upload is async).
 - Limits: max bundle size, file count, per-user project cap (configurable).
 - **Local test:** `wrangler dev`; POST a sample `out/`; assert R2 contents + D1 row + URL.
 
-### 3. Auth — `cloud.portaljs.com` (`cloud/auth/`) — bead `po-5vk`
+### 3. Auth — `app.portaljs.com` (`cloud/auth/`) — bead `po-5vk`
 - GitHub OAuth → create `users` row; UI to generate/revoke API tokens.
 - Client login: `npx portaljs login` (or folded into the skill) → device-code or
-  paste-token → write `~/.portaljs/credentials` (`{ token, api }`). `PORTALJS_TOKEN` env
-  overrides (CI).
+  paste-token → write `~/.portaljs/credentials` (`{ token, api }`, where `api` defaults to
+  `https://api.app.portaljs.com`). `PORTALJS_TOKEN` env overrides (CI).
 - API tokens are opaque, hashed at rest in D1.
 
 ### 4. `/deploy` skill rewrite (`.claude/commands/deploy.md`) — bead `po-4yq`
 - Single target. Steps: ensure `output: 'export'` in `next.config.js` → `next build` →
   verify `out/` → ensure auth (run login if no creds) → tar `out/` → `POST /v1/deploy` →
-  poll → print `https://<slug>.portaljs.com`. Never report success on a failing build.
+  poll → print `https://<slug>.app.portaljs.com`. Never report success on a failing build.
 - Slug defaults to the project slug (from `package.json`/dir), overridable with a flag.
 - Drop the Vercel/static-host branching; add a one-line "to self-host elsewhere, run
   `next build && next export` and upload `out/` to any static host."
@@ -160,7 +175,7 @@ deployments(id TEXT PK, project_id TEXT, status TEXT, files INT, bytes INT, crea
 2. **Skill (po-4yq)** built against the API contract; tested against the local API.
 3. **Auth (po-5vk)** — GitHub OAuth needs a real app; can stub token validation locally.
 4. **Staging**: deploy to the real Cloudflare account on a staging subdomain
-   (`*.staging.portaljs.com`), end-to-end test.
+   (`*.staging.app.portaljs.com`), end-to-end test.
 5. Flip `*.portaljs.com` wildcard to the Router Worker.
 
 ## Infra handoff (Datopian-provisioned)

--- a/cloud/SPEC.md
+++ b/cloud/SPEC.md
@@ -51,15 +51,15 @@ becomes an implementation detail we've wrapped away.
 
 ## URL & namespace scheme
 
-- Public URL: `https://<slug>.<cloud-zone>` where `<cloud-zone>` is **TBD** — see *Legacy
-  coexistence* below. Either bare `portaljs.com` (with safeguards) or a dedicated namespace
-  like `app.portaljs.com` / a separate `portaljs.cloud` zone.
-- `<slug>` is unique within the cloud zone (it's a hostname). On collision at deploy time,
-  the API suffixes (`<slug>-2`) or namespaces under the user — final scheme TBD, see Open
-  questions.
-- **Reserved subdomains** (never assignable): `www docs app api cloud blog status
-  staging admin assets cdn` (+ **every existing host in the `portaljs.com` zone** — built
-  from a live inventory, not a guess).
+- Public URL: **`https://<slug>.app.portaljs.com`** (locked 2026-06-15). The wildcard lives
+  on `app.portaljs.com`, **not** bare `portaljs.com` — so legacy `<prefix>.portaljs.com`
+  customers are physically out of the wildcard's scope and unaffected.
+- `<slug>` is unique within `app.portaljs.com` (only ever new-system tenants — no legacy
+  collision possible). On collision among new tenants, the API suffixes (`<slug>-2`) or
+  namespaces under the user — final scheme TBD, see Open questions.
+- **Reserved labels** under `app.portaljs.com`: `www api staging admin` (small list — the
+  legacy-collision problem is gone, so the big zone-inventory reserved-list is no longer
+  required).
 
 ## Legacy `*.portaljs.com` coexistence (must resolve before prod DNS)
 
@@ -75,18 +75,14 @@ only catches hostnames with no explicit record.
 per-customer records; (b) informal/unclaimed names; (c) a new user's slug colliding with an
 existing customer's prefix.
 
-**Plan (in order of safety):**
-1. **Dedicated namespace (recommended).** Point the wildcard at a namespace legacy never
-   used — `*.app.portaljs.com` or a separate zone `*.portaljs.cloud` — so new deploys cannot
-   collide with anything on bare `portaljs.com`. Still presented as "PortalJS Cloud."
-2. **Inventory + reserved-list.** Before any wildcard, enumerate every existing
-   `portaljs.com` subdomain in the Cloudflare zone; bake them into the Worker reserved list
-   and confirm each has an explicit record (so DNS specificity protects it).
-3. **Staging-first.** Validate on `*.staging.portaljs.com`; never flip the bare
-   `*.portaljs.com` wildcard until 1–2 are confirmed.
+**Resolution (locked 2026-06-15): dedicated namespace `*.app.portaljs.com`.** The wildcard is
+scoped to `app.portaljs.com`, a name legacy never used, so new deploys **cannot** collide
+with any bare-`portaljs.com` customer subdomain — the wildcard simply doesn't cover them.
+This removes the need for a zone inventory / large reserved-list. Legacy
+`<prefix>.portaljs.com` deployments are entirely untouched.
 
-If bare `<slug>.portaljs.com` is required (not a dedicated namespace), then **(2) + (3) are
-mandatory** and the deploy API must reject any slug already present in the zone inventory.
+Still observed: **staging-first** — validate on `*.staging.app.portaljs.com` before flipping
+the production `*.app.portaljs.com` wildcard.
 
 ## R2 layout
 

--- a/cloud/SPEC.md
+++ b/cloud/SPEC.md
@@ -1,0 +1,154 @@
+# PortalJS Cloud — managed static hosting + `/deploy`
+
+Status: **design** (epic `po-x8x`). Architecture locked 2026-06-15.
+
+PortalJS Cloud is Datopian-managed static hosting for PortalJS portals. The `/deploy`
+skill has **one target** — PortalJS Cloud. A user runs `/deploy`, authenticates once, and
+gets a live `https://<slug>.portaljs.com` serving their static build. Users who want their
+own host (Vercel, their own Cloudflare, Netlify, …) self-serve; the skill does not cover
+that.
+
+Static export only for now (no SSR). Cloudflare-native throughout, so every piece is
+locally testable with `wrangler dev` / Miniflare before real DNS is involved.
+
+## User experience
+
+```
+$ /deploy
+→ first run: "Sign in to PortalJS Cloud" → cloud.portaljs.com → paste token (or device code)
+→ next build (static export) → out/
+→ uploading to PortalJS Cloud…
+✓ Live at https://my-portal.portaljs.com
+```
+
+Re-running `/deploy` updates the same site (idempotent, keyed on the project slug).
+
+## Architecture
+
+```
+  /deploy skill ──tar(out/)+token──▶  Deploy API (Worker)  ──put──▶  R2: portals/<user>/<slug>/…
+   (in portal repo)                     POST /v1/deploy                       │
+                                        validate token (D1)                   │
+                                        record deployment (D1)                │
+        browser ◀── https://<slug>.portaljs.com ◀── Router Worker ◀──get──────┘
+                         (wildcard *.portaljs.com → Worker, serves from R2)
+```
+
+Two Workers (or one Worker with two route groups), one R2 bucket, one D1 database.
+
+- **R2** — object store for all tenants' static files: `portals/<user>/<slug>/<path>`.
+- **Router Worker** — bound to `*.portaljs.com`; resolves the hostname's `<slug>` to a
+  tenant and streams assets from R2.
+- **Deploy API (Worker)** — `POST /v1/deploy`; authenticates, writes the upload to R2,
+  records the deployment.
+- **D1** — relational state: `users`, `tokens`, `projects`, `deployments`.
+- **Auth app** — `cloud.portaljs.com`: GitHub OAuth sign-up + API-token issuance.
+
+### Why R2 + Worker (not Pages-per-project)
+Wildcard `*.portaljs.com` → one Worker means **zero per-tenant DNS/provisioning** and scale
+to many thousands of portals, with no Cloudflare Pages project/custom-domain limits. Pages
+becomes an implementation detail we've wrapped away.
+
+## URL & namespace scheme
+
+- Public URL: `https://<slug>.portaljs.com`.
+- `<slug>` is unique **globally** across tenants (it's a hostname). On collision at deploy
+  time, the API suffixes (`<slug>-2`) or, preferably, namespaces under the user
+  (`<slug>-<user>` only when needed) — final scheme TBD, see Open questions.
+- **Reserved subdomains** (never assignable): `www docs app api cloud blog status
+  staging admin assets cdn` (+ existing marketing hosts).
+
+## R2 layout
+
+```
+portals/<user_id>/<slug>/
+  index.html
+  _next/static/…            # hashed assets, immutable
+  data/…                    # /public/data files (download-mode portals)
+  …                         # everything from out/
+```
+
+Object metadata carries `content-type` (from extension) and a `deployment_id` for cache
+busting. A small `manifest.json` per deploy lists files for atomic switchover and cleanup
+of the previous deployment.
+
+## Components
+
+### 1. Router Worker (`cloud/worker/`) — bead `po-2xm`
+- Bound to `*.portaljs.com`. Extract `<slug>` from `Host`.
+- Reserved/marketing hostnames → pass through / 404 (not served from R2).
+- Look up `<slug>` → `<user_id>` (D1, cached in the Worker's in-memory/KV cache).
+- Resolve the request path in R2:
+  - exact key → serve;
+  - directory (`/` or no extension) → `…/index.html`;
+  - miss → `404.html` if present, else a default 404.
+- Headers: correct `content-type`; long-lived immutable cache for `_next/static/*`;
+  `no-cache`/short TTL for HTML.
+- Unknown slug → branded "portal not found" page.
+- **Local test:** `wrangler dev` + Miniflare R2; seed a fake portal, assert routing,
+  index resolution, content-types, 404s.
+
+### 2. Deploy API Worker (`cloud/api/`) — bead `po-bn9`
+- `POST /v1/deploy` — multipart/tar body + `slug`; `Authorization: Bearer <token>`.
+  1. Validate token (D1 `tokens` → `user_id`); 401 on failure.
+  2. Resolve/allocate `<slug>` for this user; reject reserved slugs.
+  3. Unpack the bundle; `put` each file to `portals/<user>/<slug>/…`; write `manifest.json`.
+  4. Record a `deployments` row (status, file count, bytes, timestamp).
+  5. Delete the prior deployment's orphaned objects (atomic-ish switch).
+  6. Return `{ url: "https://<slug>.portaljs.com", deployment_id, status }`.
+- `GET /v1/deploy/:id` — status (for the skill to poll, if upload is async).
+- Limits: max bundle size, file count, per-user project cap (configurable).
+- **Local test:** `wrangler dev`; POST a sample `out/`; assert R2 contents + D1 row + URL.
+
+### 3. Auth — `cloud.portaljs.com` (`cloud/auth/`) — bead `po-5vk`
+- GitHub OAuth → create `users` row; UI to generate/revoke API tokens.
+- Client login: `npx portaljs login` (or folded into the skill) → device-code or
+  paste-token → write `~/.portaljs/credentials` (`{ token, api }`). `PORTALJS_TOKEN` env
+  overrides (CI).
+- API tokens are opaque, hashed at rest in D1.
+
+### 4. `/deploy` skill rewrite (`.claude/commands/deploy.md`) — bead `po-4yq`
+- Single target. Steps: ensure `output: 'export'` in `next.config.js` → `next build` →
+  verify `out/` → ensure auth (run login if no creds) → tar `out/` → `POST /v1/deploy` →
+  poll → print `https://<slug>.portaljs.com`. Never report success on a failing build.
+- Slug defaults to the project slug (from `package.json`/dir), overridable with a flag.
+- Drop the Vercel/static-host branching; add a one-line "to self-host elsewhere, run
+  `next build && next export` and upload `out/` to any static host."
+
+### 5. Docs (`site/content/docs/…`) — bead `po-xqq`
+- Rewrite the `/deploy` skill page to the single target; add a PortalJS Cloud concept page.
+
+## D1 schema (draft)
+
+```sql
+users(id TEXT PK, github_id INTEGER UNIQUE, login TEXT, created_at)
+tokens(id TEXT PK, user_id TEXT, hash TEXT UNIQUE, label TEXT, created_at, revoked_at)
+projects(id TEXT PK, user_id TEXT, slug TEXT UNIQUE, created_at)        -- slug = hostname label
+deployments(id TEXT PK, project_id TEXT, status TEXT, files INT, bytes INT, created_at)
+```
+
+## Build / test plan
+
+1. **Worker (po-2xm)** + **API (po-bn9)** built and tested **locally** (wrangler/Miniflare,
+   mock R2 + D1) against this contract — no real Cloudflare needed.
+2. **Skill (po-4yq)** built against the API contract; tested against the local API.
+3. **Auth (po-5vk)** — GitHub OAuth needs a real app; can stub token validation locally.
+4. **Staging**: deploy to the real Cloudflare account on a staging subdomain
+   (`*.staging.portaljs.com`), end-to-end test.
+5. Flip `*.portaljs.com` wildcard to the Router Worker.
+
+## Infra handoff (Datopian-provisioned)
+
+See `cloud/INFRA.md`.
+
+## Open questions
+
+- **Slug scheme** — global-unique with suffixing, or always per-user namespace? (Affects
+  URL aesthetics vs collision UX.)
+- **Custom domains** — let users map their own domain to a portal later? (Cloudflare for
+  SaaS / CNAME.) Out of scope for v1, but the data model should not preclude it.
+- **Quotas/pricing** — free tier limits (projects, bytes, bandwidth)? Ties into the pricing
+  page.
+- **Auth UX** — device-code flow vs paste-token for v1. Paste-token is simplest to ship.
+- **Repo location** — keep `cloud/` in the monorepo, or extract to `datopian/portaljs-cloud`
+  once it stabilizes? (Defaulting to monorepo for now.)


### PR DESCRIPTION
Design baseline for **PortalJS Cloud** — making `/deploy` a single-target skill that publishes a portal to Datopian-managed static hosting, returning a `<slug>.portaljs.com` URL.

Decisions locked with the user:
- **Single target**: `/deploy` → PortalJS Cloud only (users self-host elsewhere themselves).
- **Architecture**: R2 + a Worker router on `*.portaljs.com` (static-only for now). Cloudflare-native (Workers + R2 + D1), locally testable with wrangler/Miniflare before real DNS.
- **Infra**: Datopian-provisioned (account, wildcard DNS, R2, D1, OAuth, secrets) — see `cloud/INFRA.md`.

Adds:
- `cloud/SPEC.md` — UX, architecture diagram, URL/namespace scheme, R2 layout, components (router worker, deploy API, auth, skill rewrite), D1 schema, build/test plan, open questions.
- `cloud/INFRA.md` — the Cloudflare/DNS/R2/D1/OAuth + secrets handoff.

Epic **po-x8x**; children: po-2xm (router worker), po-bn9 (deploy API), po-5vk (auth), po-4yq (/deploy rewrite), po-xqq (docs). Implementation lands in subsequent PRs per bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the PortalJS Arc cloud specification to a Cloudflare-native, static-export-only workflow with a single `/deploy` target and idempotent redeploys by project slug.
  * Defined the two-worker approach (tenant asset routing plus a Deploy API with `POST /v1/deploy` and deployment status polling) and the expected R2/D1 storage layout.
  * Refreshed infrastructure handoff guidance, including wildcard DNS, staging-first provisioning, ACM-based TLS requirements, OAuth callback setup, and the required runtime secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->