### PR TITLE
Align compare pages with homepage design system

### DIFF
--- a/site/pages/compare/custom-solution.tsx
+++ b/site/pages/compare/custom-solution.tsx
@@ -1,10 +1,8 @@
 import Layout from '@/components/Layout'
 import SocialProofStrip from '@/components/SocialProofStrip'
-import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
 import Head from 'next/head';
-import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
 
@@ -241,19 +239,19 @@ export default function PortalJSvsCustomSolution() {
         <div className="py-16 sm:px-2 lg:relative lg:py-20 lg:px-0">
           <div className="mx-auto max-w-2xl px-4 lg:max-w-8xl lg:px-8 xl:px-12">
             <div className="relative mb-10 lg:mb-0 text-center">
-              <h1 className="inline bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-5xl tracking-tight text-transparent">
+              <h1 className="inline bg-gradient-to-r from-sky-400 to-blue-600 bg-clip-text text-5xl font-bold leading-[1.08] tracking-tight text-transparent">
                 PortalJS vs Custom Solution
               </h1>
-              <p className="mt-4 text-xl tracking-tight text-slate-400">
+              <p className="mt-4 text-xl tracking-tight text-slate-600 dark:text-slate-400">
                 Skip months of development and costly mistakes with a proven data portal solution.
               </p>
-              <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                <ButtonLink href={calendarLink} title="Book a demo">
+              <div className="mt-9 flex flex-wrap justify-center gap-3.5">
+                <a href={calendarLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-[10px] bg-gradient-to-br from-sky-400 to-blue-600 px-[18px] py-2.5 text-[14.5px] font-semibold text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] transition-all duration-150 hover:-translate-y-px hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)]">
                   Book a demo
-                </ButtonLink>
-                <ButtonLink href="https://cloud.portaljs.com/auth/signup" title="Sign up for free" style="secondary" trackConversion={true}>
+                </a>
+                <a href="https://cloud.portaljs.com/auth/signup" className="inline-flex items-center gap-1.5 rounded-[10px] border border-slate-300 bg-white px-[18px] py-2.5 text-[14.5px] font-semibold text-slate-700 transition-all duration-150 hover:-translate-y-px hover:border-blue-400 hover:text-blue-600">
                   Sign up for free
-                </ButtonLink>
+                </a>
               </div>
             </div>
           </div>
@@ -268,7 +266,7 @@ export default function PortalJSvsCustomSolution() {
         <div className="pt-8 pb-24">
           <div className="mx-auto">
             <div className="flex flex-col items-center">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-transparent">
+              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl text-slate-900 dark:text-white">
                 Organizations who chose PortalJS over custom development
               </h2>
               <p className="mt-4 text-lg text-slate-500 dark:text-slate-400 text-center max-w-2xl">
@@ -309,7 +307,7 @@ export default function PortalJSvsCustomSolution() {
         <div className="pt-8 pb-24">
           <div className="mx-auto px-4 sm:px-8 xl:px-12 max-w-8xl">
             <div className="text-center mb-16">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-transparent">
+              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl text-slate-900 dark:text-white">
                 Build vs Buy Analysis
               </h2>
               <p className="mt-4 text-lg text-slate-600 dark:text-slate-400">
@@ -320,7 +318,7 @@ export default function PortalJSvsCustomSolution() {
             <div className="mt-16 space-y-16">
               {comparisonTable.map((category, idx) => (
                 <div key={category.category} className={idx % 2 === 0 ? "bg-white dark:bg-slate-800 p-8 rounded-xl shadow-sm ring-1 ring-slate-200 dark:ring-slate-700" : "bg-slate-50 dark:bg-slate-800 p-8 rounded-xl shadow-sm ring-1 ring-slate-200 dark:ring-slate-700"}>
-                  <h3 className="text-xl font-semibold mb-6 bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-transparent">
+                  <h3 className="text-xl font-semibold mb-6 text-slate-900 dark:text-white">
                     {category.category}
                   </h3>
                   <div className="overflow-hidden rounded-xl ring-1 ring-slate-200 dark:ring-slate-700 shadow-sm">
@@ -368,7 +366,25 @@ export default function PortalJSvsCustomSolution() {
       </div>
 
       {/* CTA Section */}
-      <Schedule calendar={calendarLink} />
+      <section className="w-full pb-[88px] pt-[30px]">
+        <div className="mx-auto max-w-8xl px-4 sm:px-6 lg:px-12">
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-[#0b1830] via-[#10254a] to-[#173a78] px-7 py-12 text-center sm:px-14 sm:py-16">
+            <div aria-hidden="true" className="pointer-events-none absolute inset-0" style={{ background: 'radial-gradient(50% 90% at 50% -10%,rgba(125,211,252,0.22),transparent 70%)' }} />
+            <div className="relative z-10">
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Skip the build — launch your portal today.</h2>
+              <p className="mx-auto mt-4 max-w-[48ch] text-[17px] text-[#b9c9e4]">Skip months of development and costly mistakes with a proven data portal solution.</p>
+              <div className="mt-[30px] flex flex-wrap justify-center gap-3.5">
+                <a href={calendarLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-[10px] bg-gradient-to-br from-sky-400 to-blue-600 px-[18px] py-2.5 text-[14.5px] font-semibold text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] transition-all duration-150 hover:-translate-y-px hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)]">
+                  Schedule a free call
+                </a>
+                <a href="https://cloud.portaljs.com/auth/signup" className="inline-flex items-center gap-2 rounded-[10px] border border-white/20 bg-white/[0.06] px-[18px] py-2.5 text-[14.5px] font-semibold text-white transition-all duration-150 hover:-translate-y-px hover:bg-white/[0.12]">
+                  Book a demo
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </Layout>
   )
 }

--- a/site/pages/compare/index.tsx
+++ b/site/pages/compare/index.tsx
@@ -2,9 +2,7 @@ import Layout from '@/components/Layout'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
 import Head from 'next/head';
-import ButtonLink from '@/components/ButtonLink'
 import Link from 'next/link'
-import Schedule from '@/components/home/Schedule'
 
 export default function CompareIndex() {
   // Calendar link for all CTAs
@@ -121,19 +119,19 @@ export default function CompareIndex() {
         <div className="py-16 sm:px-2 lg:relative lg:py-20 lg:px-0">
           <div className="mx-auto max-w-2xl px-4 lg:max-w-8xl lg:px-8 xl:px-12">
             <div className="relative mb-10 lg:mb-0 text-center">
-              <h1 className="inline bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-5xl tracking-tight text-transparent">
+              <h1 className="inline bg-gradient-to-r from-sky-400 to-blue-600 bg-clip-text text-5xl font-bold leading-[1.08] tracking-tight text-transparent">
                 Compare PortalJS vs alternatives
               </h1>
-              <p className="mt-4 text-xl tracking-tight text-slate-400">
+              <p className="mt-4 text-xl tracking-tight text-slate-600 dark:text-slate-400">
                 See how open source PortalJS approach delivers more flexibility, better performance, and lower total cost of ownership.
               </p>
-              <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                <ButtonLink href={calendarLink} title="Book a demo">
+              <div className="mt-9 flex flex-wrap justify-center gap-3.5">
+                <a href={calendarLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-[10px] bg-gradient-to-br from-sky-400 to-blue-600 px-[18px] py-2.5 text-[14.5px] font-semibold text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] transition-all duration-150 hover:-translate-y-px hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)]">
                   Book a demo
-                </ButtonLink>
-                <ButtonLink href="https://cloud.portaljs.com/auth/signup" title="Sign up for free" style="secondary" trackConversion={true}>
+                </a>
+                <a href="https://cloud.portaljs.com/auth/signup" className="inline-flex items-center gap-1.5 rounded-[10px] border border-slate-300 bg-white px-[18px] py-2.5 text-[14.5px] font-semibold text-slate-700 transition-all duration-150 hover:-translate-y-px hover:border-blue-400 hover:text-blue-600">
                   Sign up for free
-                </ButtonLink>
+                </a>
               </div>
             </div>
           </div>
@@ -142,10 +140,10 @@ export default function CompareIndex() {
 
       {/* Comparison Cards Section */}
       <div className="flex justify-center">
-        <div className="max-w-8xl px-4 sm:px-8 xl:px-12 py-24">
+        <div className="max-w-8xl px-4 sm:px-8 xl:px-12 pt-8 pb-24">
           <div className="mx-auto max-w-2xl lg:max-w-none">
             <div className="text-center mb-16">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-transparent">
+              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl text-slate-900 dark:text-white">
                 Platform Comparisons
               </h2>
               <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
@@ -153,39 +151,32 @@ export default function CompareIndex() {
               </p>
             </div>
 
-            <div className="mt-16 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="mt-16 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
               {comparisons.map((comparison) => (
-                <div
-                  key={comparison.id}
-                  className="relative flex flex-col overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-md transition-all hover:shadow-lg"
-                >
-                  {comparison.status === 'coming-soon' && (
-                    <div className="absolute top-4 right-4 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 text-xs font-semibold px-2.5 py-0.5 rounded">
+                comparison.status === 'published' ? (
+                  <Link
+                    key={comparison.id}
+                    href={comparison.href}
+                    className="group flex flex-col rounded-2xl border border-slate-200 bg-white p-6 transition-all duration-200 hover:-translate-y-[3px] hover:border-slate-300 hover:shadow-[0_16px_36px_-20px_rgba(15,23,42,0.28)] dark:border-slate-800 dark:bg-slate-900/60 dark:hover:border-slate-700 cursor-pointer"
+                  >
+                    <h3 className="mb-[7px] text-[17.5px] font-semibold text-slate-900 dark:text-white">{comparison.title}</h3>
+                    <p className="flex-1 text-[14.5px] text-slate-600 dark:text-slate-300">{comparison.description}</p>
+                    <span className="mt-5 text-[13px] font-semibold text-blue-600 dark:text-blue-400 group-hover:underline">
+                      View comparison →
+                    </span>
+                  </Link>
+                ) : (
+                  <div
+                    key={comparison.id}
+                    className="relative flex flex-col rounded-2xl border border-slate-200 bg-white p-6 opacity-60 dark:border-slate-800 dark:bg-slate-900/60"
+                  >
+                    <span className="absolute top-4 right-4 rounded-full bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 text-xs font-semibold px-2.5 py-0.5">
                       Coming Soon
-                    </div>
-                  )}
-                  <div className="p-6 flex-1">
-                    <h3 className="text-xl font-semibold mb-2">{comparison.title}</h3>
-                    <p className="text-slate-600 dark:text-slate-400 mb-6">{comparison.description}</p>
+                    </span>
+                    <h3 className="mb-[7px] text-[17.5px] font-semibold text-slate-900 dark:text-white">{comparison.title}</h3>
+                    <p className="text-[14.5px] text-slate-600 dark:text-slate-300">{comparison.description}</p>
                   </div>
-                  <div className="px-6 pb-6">
-                    {comparison.status === 'published' ? (
-                      <Link
-                        href={comparison.href}
-                        className="inline-block w-full text-center bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-md transition-colors"
-                      >
-                        View Comparison
-                      </Link>
-                    ) : (
-                      <button
-                        disabled
-                        className="inline-block w-full text-center bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400 font-medium py-2 px-4 rounded-md cursor-not-allowed"
-                      >
-                        Coming Soon
-                      </button>
-                    )}
-                  </div>
-                </div>
+                )
               ))}
             </div>
           </div>
@@ -197,7 +188,7 @@ export default function CompareIndex() {
         <div className="flex justify-center">
           <div className="max-w-8xl px-4 sm:px-8 xl:px-12 py-24">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold tracking-tight sm:text-4xl bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-transparent">
+            <h2 className="text-3xl font-bold tracking-tight sm:text-4xl text-slate-900 dark:text-white">
               PortalJS Key Advantages
             </h2>
             <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
@@ -282,7 +273,25 @@ export default function CompareIndex() {
       </div>
       </div>
 
-      <Schedule calendar={calendarLink} />
+      <section className="w-full pb-[88px] pt-[30px]">
+        <div className="mx-auto max-w-8xl px-4 sm:px-6 lg:px-12">
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-[#0b1830] via-[#10254a] to-[#173a78] px-7 py-12 text-center sm:px-14 sm:py-16">
+            <div aria-hidden="true" className="pointer-events-none absolute inset-0" style={{ background: 'radial-gradient(50% 90% at 50% -10%,rgba(125,211,252,0.22),transparent 70%)' }} />
+            <div className="relative z-10">
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Ready to launch your data portal?</h2>
+              <p className="mx-auto mt-4 max-w-[48ch] text-[17px] text-[#b9c9e4]">Join hundreds of organizations worldwide that trust PortalJS Cloud for their data publishing needs.</p>
+              <div className="mt-[30px] flex flex-wrap justify-center gap-3.5">
+                <a href={calendarLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-[10px] bg-gradient-to-br from-sky-400 to-blue-600 px-[18px] py-2.5 text-[14.5px] font-semibold text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] transition-all duration-150 hover:-translate-y-px hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)]">
+                  Schedule a free call
+                </a>
+                <a href="https://cloud.portaljs.com/auth/signup" className="inline-flex items-center gap-2 rounded-[10px] border border-white/20 bg-white/[0.06] px-[18px] py-2.5 text-[14.5px] font-semibold text-white transition-all duration-150 hover:-translate-y-px hover:bg-white/[0.12]">
+                  Book a demo
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </Layout>
   )
 }

--- a/site/pages/compare/opendatasoft.tsx
+++ b/site/pages/compare/opendatasoft.tsx
@@ -1,10 +1,8 @@
 import Layout from '@/components/Layout'
 import SocialProofStrip from '@/components/SocialProofStrip'
-import Schedule from '@/components/home/Schedule'
 import { OrganizationJsonLd, BreadcrumbJsonLd } from 'next-seo';
 import { generateNextSeo } from 'next-seo/pages';
 import Head from 'next/head';
-import ButtonLink from '@/components/ButtonLink'
 import Image from 'next/image'
 import Link from 'next/link'
 
@@ -216,19 +214,19 @@ export default function PortalJSvsOpenDataSoft() {
         <div className="py-16 sm:px-2 lg:relative lg:py-20 lg:px-0">
           <div className="mx-auto max-w-2xl px-4 lg:max-w-8xl lg:px-8 xl:px-12">
             <div className="relative mb-10 lg:mb-0 text-center">
-              <h1 className="inline bg-gradient-to-r from-blue-500 via-blue-300 to-blue-500 bg-clip-text text-5xl tracking-tight text-transparent">
+              <h1 className="inline bg-gradient-to-r from-sky-400 to-blue-600 bg-clip-text text-5xl font-bold leading-[1.08] tracking-tight text-transparent">
                 PortalJS vs OpenDataSoft
               </h1>
-              <p className="mt-4 text-xl tracking-tight text-slate-400">
+              <p className="mt-4 text-xl tracking-tight text-slate-600 dark:text-slate-400">
                 See how PortalJS delivers greater flexibility, modern technology, and no vendor lock-in.
               </p>
-              <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                <ButtonLink href={calendarLink} title="Book a demo">
+              <div className="mt-9 flex flex-wrap justify-center gap-3.5">
+                <a href={calendarLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-[10px] bg-gradient-to-br from-sky-400 to-blue-600 px-[18px] py-2.5 text-[14.5px] font-semibold text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] transition-all duration-150 hover:-translate-y-px hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)]">
                   Book a demo
-                </ButtonLink>
-                <ButtonLink href="https://cloud.portaljs.com/auth/signup" title="Sign up for free" style="secondary" trackConversion={true}>
+                </a>
+                <a href="https://cloud.portaljs.com/auth/signup" className="inline-flex items-center gap-1.5 rounded-[10px] border border-slate-300 bg-white px-[18px] py-2.5 text-[14.5px] font-semibold text-slate-700 transition-all duration-150 hover:-translate-y-px hover:border-blue-400 hover:text-blue-600">
                   Sign up for free
-                </ButtonLink>
+                </a>
               </div>
             </div>
           </div>
@@ -343,7 +341,25 @@ export default function PortalJSvsOpenDataSoft() {
       </div>
 
       {/* CTA Section */}
-      <Schedule calendar={calendarLink} />
+      <section className="w-full pb-[88px] pt-[30px]">
+        <div className="mx-auto max-w-8xl px-4 sm:px-6 lg:px-12">
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-[#0b1830] via-[#10254a] to-[#173a78] px-7 py-12 text-center sm:px-14 sm:py-16">
+            <div aria-hidden="true" className="pointer-events-none absolute inset-0" style={{ background: 'radial-gradient(50% 90% at 50% -10%,rgba(125,211,252,0.22),transparent 70%)' }} />
+            <div className="relative z-10">
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Ready to make the switch?</h2>
+              <p className="mx-auto mt-4 max-w-[48ch] text-[17px] text-[#b9c9e4]">See how PortalJS delivers more flexibility, modern technology, and no vendor lock-in.</p>
+              <div className="mt-[30px] flex flex-wrap justify-center gap-3.5">
+                <a href={calendarLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-[10px] bg-gradient-to-br from-sky-400 to-blue-600 px-[18px] py-2.5 text-[14.5px] font-semibold text-white shadow-[0_6px_20px_-6px_rgba(37,99,235,0.55)] transition-all duration-150 hover:-translate-y-px hover:shadow-[0_10px_28px_-8px_rgba(37,99,235,0.7)]">
+                  Schedule a free call
+                </a>
+                <a href="https://cloud.portaljs.com/auth/signup" className="inline-flex items-center gap-2 rounded-[10px] border border-white/20 bg-white/[0.06] px-[18px] py-2.5 text-[14.5px] font-semibold text-white transition-all duration-150 hover:-translate-y-px hover:bg-white/[0.12]">
+                  Book a demo
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary

Brings `/compare`, `/compare/opendatasoft`, and `/compare/custom-solution` up to the same standard as the other compare pages.

- **H1**: updated gradient from `from-blue-500 via-blue-300 to-blue-500` → `from-sky-400 to-blue-600` with `font-bold leading-[1.08]`
- **Subtitle**: `text-slate-400` → `text-slate-600 dark:text-slate-400` (darker, matches homepage)
- **Hero buttons**: replaced `ButtonLink` with homepage-style inline `<a>` tags; secondary button is now white with slate border (not transparent)
- **H2/H3 headings**: removed old blue gradients → solid `text-slate-900 dark:text-white`
- **Bottom CTA**: replaced `Schedule` component with dark navy gradient block matching `/ckan`
- **Compare index cards**: redesigned to match the ValueProps card style — full card is clickable with hand cursor, lift on hover, no separate button; coming-soon cards are dimmed with a pill badge
- **Spacing**: reduced gap between hero and comparison cards by 2/3

## Test plan

- [ ] `/compare` — cards lift on hover, hand cursor, no button, correct h1/h2 styles
- [ ] `/compare/opendatasoft` — correct h1 gradient, white secondary button, dark navy bottom CTA
- [ ] `/compare/custom-solution` — same as above, no gradient h2s
- [ ] Dark mode on all three pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated hero, headings, and CTA layout across comparison pages, switching to styled link-based actions, refining spacing/typography, and solidifying section heading colors.
  * Replaced scheduled/demo widgets with fully inlined gradient CTA sections, including updated “Coming Soon” comparison card variants for non-published items.
* **New Features**
  * Added a complete “PortalJS Cloud” landing page with multi-section marketing content and pricing CTAs.
  * Added blog preview card components (featured, mini, and standard) and rebuilt the blog index with segment filtering, featured/mini layout, and “Load more” pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->