### PR TITLE
fix: restore clipped edge on PortalJS logo

### DIFF
--- a/site/public/static/img/portaljs-logo.svg
+++ b/site/public/static/img/portaljs-logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="PortalJS">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 108 108" width="100" height="100" role="img" aria-label="PortalJS">
   <defs>
     <linearGradient id="cyc" x1="15%" y1="0%" x2="85%" y2="100%">
       <stop offset="0%" stop-color="#7dd3fc"/>


### PR DESCRIPTION
## Problem

The PortalJS logo SVG had `viewBox="0 0 100 100"` but the path coordinates extend to ~102 — causing the right side of the logo to be clipped.

## Fix

Expanded `viewBox` to `"-4 -4 108 108"` (4px padding on all sides). No path data changed.

## Before / After

| Before | After |
|--------|-------|
| <img src="https://raw.githubusercontent.com/datopian/portaljs/main/site/public/static/img/portaljs-logo.svg?sanitize=true" width="80"> | <img src="https://raw.githubusercontent.com/datopian/portaljs/fix/portaljs-logo-clipping/site/public/static/img/portaljs-logo.svg?sanitize=true" width="80"> |
| `viewBox="0 0 100 100"` — right edge clipped | `viewBox="-4 -4 108 108"` — full logo visible |

## Test plan
- [ ] Logo renders without clipping in the nav on all pages
- [ ] Logo looks correct in dark mode
- [ ] Favicon / OG image unaffected (separate files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)