### PR TITLE
feat(deploy): /deploy → PortalJS Arc (single target) + router .html fix (po-4yq)

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -48,7 +48,11 @@ is reserved or invalid, ask for a `--slug`.
 
 ```bash
 TOKEN="${PORTALJS_TOKEN:-}"
-[ -z "$TOKEN" ] && [ -f "$HOME/.portaljs/credentials" ] && TOKEN=$(node -e "try{process.stdout.write(require('$HOME/.portaljs/credentials').token||'')}catch{}" 2>/dev/null)
+# Read the credentials file as JSON (never require() it — that executes it as JS
+# and an extensionless file won't parse the documented {"token":"…"} shape).
+if [ -z "$TOKEN" ] && [ -f "$HOME/.portaljs/credentials" ]; then
+  TOKEN=$(node -e "const fs=require('fs');try{process.stdout.write(JSON.parse(fs.readFileSync(process.env.HOME+'/.portaljs/credentials','utf8')).token||'')}catch{}")
+fi
 ```
 If `TOKEN` is empty, **do not proceed** — tell the user:
 ```
@@ -67,8 +71,12 @@ Ensure `PORTAL_DIR/next.config.js` enables static export — it must set
 `output: 'export'` and `images: { unoptimized: true }` (the image optimizer needs a server).
 If those are missing, add them (preserve the rest of the config), and tell the user you did.
 
+Set shell variables to the values resolved in step 1, then build (these bash blocks are
+self-contained — set the variables in each block, since shell state doesn't persist):
+
 ```bash
-cd PORTAL_DIR
+PORTAL_DIR="."          # ← the portal directory from step 1
+cd "$PORTAL_DIR"
 npm run build > /tmp/arc-build.log 2>&1
 BUILD_EXIT=$?
 tail -30 /tmp/arc-build.log
@@ -85,13 +93,28 @@ a failing build. Confirm the export landed: `PORTAL_DIR/out/index.html` must exi
 Tar the export (gzip; exclude macOS AppleDouble files) and POST it to the Arc API:
 
 ```bash
-cd PORTAL_DIR
-COPYFILE_DISABLE=1 tar czf /tmp/arc-deploy.tgz -C out .
+PORTAL_DIR="."          # ← portal directory (step 1)
+SLUG="my-portal"        # ← validated slug (step 1)
 API="${PORTALJS_ARC_API:-https://api.arc.portaljs.com}"
-HTTP=$(curl -s -o /tmp/arc-resp.json -w "%{http_code}" -m 120 \
-  -X POST "$API/v1/deploy?slug=SLUG" \
-  -H "Authorization: Bearer $TOKEN" \
+
+# Re-resolve the token (self-contained block; see step 2 for the missing-token path).
+TOKEN="${PORTALJS_TOKEN:-}"
+if [ -z "$TOKEN" ] && [ -f "$HOME/.portaljs/credentials" ]; then
+  TOKEN=$(node -e "const fs=require('fs');try{process.stdout.write(JSON.parse(fs.readFileSync(process.env.HOME+'/.portaljs/credentials','utf8')).token||'')}catch{}")
+fi
+[ -z "$TOKEN" ] && { echo "No Arc token — see step 2."; exit 1; }
+
+cd "$PORTAL_DIR"
+COPYFILE_DISABLE=1 tar czf /tmp/arc-deploy.tgz -C out .
+
+# Pass the bearer token via a 0600 curl config file, not argv — so it doesn't leak
+# through the process list on shared/CI machines. Remove it right after.
+HDR=$(mktemp); chmod 600 "$HDR"
+printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$HDR"
+HTTP=$(curl -s -o /tmp/arc-resp.json -w "%{http_code}" -m 120 -K "$HDR" \
+  -X POST "$API/v1/deploy?slug=$SLUG" \
   --data-binary @/tmp/arc-deploy.tgz)
+rm -f "$HDR"
 echo "HTTP $HTTP"; cat /tmp/arc-resp.json
 ```
 

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,210 +1,125 @@
 ---
-description: One-shot deploy of a PortalJS portal to Cloudflare Pages (recommended), Vercel, or any static host. Detects the target, builds, and publishes — with a live URL at the end.
+description: Deploy a PortalJS portal to PortalJS Arc — Datopian-managed static hosting on Cloudflare. Builds a static export, uploads it, and returns a live <slug>.arc.portaljs.com URL. One command, one target.
 allowed-tools: Read, Write, Edit, Bash
 ---
 
 # /deploy
 
-Deploy an existing PortalJS portal in one shot. Two targets:
+Publish an existing PortalJS portal to **PortalJS Arc** — Datopian's managed static hosting.
+The skill builds a static export of the portal, uploads it to the Arc API, and prints a live
+`https://<slug>.arc.portaljs.com` URL. Re-running redeploys the same portal (idempotent on
+the slug).
 
-- **`vercel`** — push to Vercel via the `vercel` CLI. Handles SSR/ISR natively, gives a live `*.vercel.app` URL (or your custom domain). Zero-config if the user already has the Vercel CLI, so the skill may auto-detect it.
-- **`static`** — build a fully static site (`next export` → `out/`) for any static host: **Cloudflare Pages** (`npx wrangler pages deploy out`), GitHub Pages, Netlify, S3 + CloudFront, plain nginx. No server required.
+This is a **single-target** skill: it deploys to PortalJS Arc only. If you'd rather host the
+portal yourself, it's a standard static Next.js export — run `npm run build` and upload `out/`
+to any static host (Vercel, your own Cloudflare, Netlify, S3, …); you don't need this skill
+for that.
 
-> **Recommended host: Cloudflare Pages** (the `static` target). PortalJS's architecture docs default to a static-first, S3-compatible, no-lock-in stack on Cloudflare (Pages for static; Workers for the opt-in runtime). Vercel is offered as a convenient SSR option, not the recommended production default — if the skill auto-detects Vercel (because the CLI is installed) it will say so before proceeding, and you can choose `static` + Cloudflare instead. A first-class managed/bring-your-own Cloudflare deploy flow is on the roadmap.
+> **Static only (for now).** Arc serves static exports — the catalog template, `/add-dataset`,
+> `/migrate`, and `/connect-ckan` (SSG) all export cleanly. SSR isn't hosted on Arc yet.
 
-This skill builds, verifies the build passes, and either publishes (Vercel) or produces a ready-to-upload `out/` directory (static). It never reports success on a failing build.
+## Required input — ask, don't error
 
-## Required input
-
-- **Portal directory** — path to the portal project (default: current directory). Must contain a `package.json` with a `next` dependency.
-- **Target** — `vercel` or `static`. If omitted, the skill auto-detects (see Step 2) and tells you what it chose before proceeding.
-
-If the directory is not a PortalJS / Next.js project:
-```
-ERROR: [deploy] NOT_A_PORTAL No Next.js project found in <dir> — run from a portal directory (one containing package.json with a "next" dependency).
-```
+- **Portal directory** (optional) — the portal project (default: current directory). Must be a
+  Next.js portal (`package.json` with a `next` dependency).
+- **Slug** (optional) — the subdomain to publish under (`<slug>.arc.portaljs.com`). Default:
+  the project's `package.json` `name` (or the directory name), slugified. Override with
+  `--slug <name>`.
+- **Auth** — a PortalJS Arc token. Read from `PORTALJS_TOKEN`, else `~/.portaljs/credentials`
+  (`{ "token": "…" }`). If neither is present, **stop and tell the user how to sign in** (see
+  step 2) rather than failing cryptically.
 
 ## Steps
 
-### 1. Parse arguments from `$ARGUMENTS`
+### 1. Gather input + validate the portal
 
-Extract:
-- `PORTAL_DIR` — portal directory (default: `.`)
-- `TARGET` — `vercel` | `static` (default: auto-detect)
-- `PROD` — whether this is a production deploy (default: `true` for Vercel; static is always a build)
+Extract from `$ARGUMENTS`:
+- `PORTAL_DIR` (default `.`), `SLUG` (default from `package.json` name / dir, slugified to a
+  DNS label: lowercase, `[a-z0-9-]`, ≤63 chars).
 
-Verify the portal:
-```bash
-cd "$PORTAL_DIR"
-if [ ! -f package.json ] || ! grep -q '"next"' package.json; then
-  echo "ERROR: [deploy] NOT_A_PORTAL No Next.js project found in $PORTAL_DIR — run from a portal directory."
-  exit 1
-fi
+Confirm `PORTAL_DIR/package.json` exists and lists `next`. If not:
 ```
-
-### 2. Determine the target
-
-If `TARGET` was given, use it. Otherwise auto-detect, in this order:
-
-1. If a `.vercel/` directory or `vercel.json` exists → **vercel** (already linked).
-2. If `next.config.js` already sets `output: 'export'` → **static**.
-3. Otherwise default to **vercel** if the `vercel` CLI is installed and authenticated; else **static**.
-
-Always announce the choice before continuing:
+ERROR: [deploy] NOT_A_PORTAL No Next.js project in <dir> — run from a portal directory.
 ```
-Target: vercel (auto-detected — .vercel/ project link found)
-```
+Reserved slugs (`www`, `api`, `admin`, `staging`, `arc`) are not allowed — if the derived slug
+is reserved or invalid, ask for a `--slug`.
 
-### 3. Install dependencies if needed
+### 2. Resolve the Arc token
 
 ```bash
-[ -d node_modules ] || npm install
+TOKEN="${PORTALJS_TOKEN:-}"
+[ -z "$TOKEN" ] && [ -f "$HOME/.portaljs/credentials" ] && TOKEN=$(node -e "try{process.stdout.write(require('$HOME/.portaljs/credentials').token||'')}catch{}" 2>/dev/null)
 ```
-
-If `npm install` fails:
+If `TOKEN` is empty, **do not proceed** — tell the user:
 ```
-ERROR: [deploy] INSTALL_FAILED npm install failed — check Node.js >=18 and network access, then retry.
+To deploy to PortalJS Arc you need a token. Sign in at https://arc.portaljs.com to get one,
+then either:
+  export PORTALJS_TOKEN=<token>
+or save it to ~/.portaljs/credentials as {"token":"<token>"}.
+Then re-run /deploy.
 ```
+(The API base URL defaults to `https://api.arc.portaljs.com`; override with `PORTALJS_ARC_API`
+for staging, e.g. the staging API worker URL.)
 
----
+### 3. Build a static export
 
-## Target A — Vercel
-
-### A1. Check the CLI is installed and authenticated
+Ensure `PORTAL_DIR/next.config.js` enables static export — it must set
+`output: 'export'` and `images: { unoptimized: true }` (the image optimizer needs a server).
+If those are missing, add them (preserve the rest of the config), and tell the user you did.
 
 ```bash
-if ! command -v vercel >/dev/null 2>&1; then
-  echo "ERROR: [deploy] VERCEL_CLI_MISSING vercel CLI not found — install it with: npm i -g vercel"
-  exit 1
-fi
-vercel whoami >/dev/null 2>&1 || {
-  echo "ERROR: [deploy] VERCEL_AUTH Not logged in to Vercel — run: vercel login  (then retry /deploy)"
-  exit 1
-}
-```
-
-Do not attempt an interactive `vercel login` from inside the skill — it requires the user's terminal. Stop and tell the user to run it, then re-run `/deploy`.
-
-### A2. Deploy
-
-Vercel builds the Next.js app on its own infrastructure, so no local `next build` is required. Run a non-interactive deploy:
-
-```bash
-# --yes accepts project-link defaults on first deploy (no prompts)
-if [ "$PROD" = "true" ]; then
-  vercel deploy --prod --yes > /tmp/deploy-vercel.log 2>&1
-else
-  vercel deploy --yes > /tmp/deploy-vercel.log 2>&1
-fi
-DEPLOY_EXIT=$?
-tail -30 /tmp/deploy-vercel.log
-```
-
-If `DEPLOY_EXIT` is non-zero, print the full log and stop:
-```
-ERROR: [deploy] VERCEL_DEPLOY_FAILED vercel deploy exited <code> — see log above for the failing step.
-```
-
-### A3. Report the live URL
-
-The deployment URL is the last line of stdout from the Vercel CLI. Extract and present it:
-```
-✓ Deployed to Vercel
-  URL: https://<project>-<hash>.vercel.app
-  Inspect: <inspect URL from log>
-```
-
-If this was a preview (non-prod) deploy, remind the user:
-```
-This was a PREVIEW deploy. Promote to production with: /deploy --prod  (or `vercel deploy --prod`)
-```
-
----
-
-## Target B — Static export
-
-A PortalJS template portal is fully client-rendered (the `Table` component fetches CSVs in the browser), so it exports cleanly to static HTML. Dynamic routes are only safe if every page is pre-rendered — see B4.
-
-### B1. Enable static export in `next.config.js`
-
-Read the current config. Ensure it contains `output: 'export'` and `images: { unoptimized: true }` (Next's image optimizer needs a server; static export requires it disabled).
-
-If missing, edit `next.config.js` to add them. Target shape:
-```js
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  eslint: { ignoreDuringBuilds: true },
-  output: 'export',
-  images: { unoptimized: true },
-}
-module.exports = nextConfig
-```
-
-If the portal sets a non-root base path (deploying to `https://user.github.io/repo/`), also add `basePath: '/repo'` and `assetPrefix: '/repo/'`. Ask the user for the repo path only if they named GitHub Pages as the host; otherwise assume root.
-
-### B2. Build
-
-```bash
-npm run build > /tmp/deploy-build.log 2>&1
+cd PORTAL_DIR
+npm run build > /tmp/arc-build.log 2>&1
 BUILD_EXIT=$?
-tail -30 /tmp/deploy-build.log
+tail -30 /tmp/arc-build.log
 ```
+If `BUILD_EXIT` is non-zero, print the log and fix the error before continuing — never deploy
+a failing build. Confirm the export landed: `PORTAL_DIR/out/index.html` must exist.
 
-With `output: 'export'`, Next 14 writes the static site to `out/` as part of `next build` (no separate `next export` step). If `BUILD_EXIT` is non-zero, print the full log and stop:
-```
-ERROR: [deploy] BUILD_FAILED next build exited <code> — see log above. Common cause: a dynamic route without getStaticPaths (see notes).
-```
+> Static export pre-renders every page at build time. A CKAN/`getStaticPaths` portal must use
+> `fallback: false` (the templates do). If the build complains about a dynamic route, that's
+> the cause.
 
-### B3. Verify `out/`
+### 4. Package + upload
+
+Tar the export (gzip; exclude macOS AppleDouble files) and POST it to the Arc API:
 
 ```bash
-[ -d out ] && [ -f out/index.html ] || {
-  echo "ERROR: [deploy] EXPORT_EMPTY out/ not produced — confirm output: 'export' is set in next.config.js."
-  exit 1
-}
+cd PORTAL_DIR
+COPYFILE_DISABLE=1 tar czf /tmp/arc-deploy.tgz -C out .
+API="${PORTALJS_ARC_API:-https://api.arc.portaljs.com}"
+HTTP=$(curl -s -o /tmp/arc-resp.json -w "%{http_code}" -m 120 \
+  -X POST "$API/v1/deploy?slug=SLUG" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-binary @/tmp/arc-deploy.tgz)
+echo "HTTP $HTTP"; cat /tmp/arc-resp.json
 ```
 
-### B4. Handle dynamic routes (if present)
+Handle the response:
+- **200** — parse `url` from the JSON; that's the live portal.
+- **401** — token invalid/expired → tell the user to re-auth (step 2).
+- **409** — the slug is taken by another account → ask for a different `--slug`.
+- **400 / 413** — bad slug or upload too large → surface the JSON `error`.
+- anything else — print the body and stop; don't claim success.
 
-If `pages/` contains a dynamic route like `[slug].tsx`, static export requires `getStaticPaths` returning `{ fallback: false }`. If the build failed with a `getStaticPaths` error, this is why. PortalJS's `/add-dataset` skill writes one file per dataset specifically to avoid this — prefer that pattern. Report the offending route and stop rather than guessing paths.
+### 5. Report
 
-### B5. Publish (optional) or report
-
-By default, stop after producing `out/` and report how to upload. Only publish automatically if the user named a host:
-
-- **GitHub Pages** (user asked for it and the repo has a remote):
-  ```bash
-  npx gh-pages -d out -t true > /tmp/deploy-ghpages.log 2>&1 || {
-    echo "ERROR: [deploy] GHPAGES_FAILED gh-pages publish failed — see log; ensure the repo has a GitHub remote and push access."
-    exit 1
-  }
-  ```
-- **Netlify / Cloudflare Pages / S3:** do not run third-party CLIs unprompted. Report the `out/` path and the one-line command for their host.
-
-Report:
 ```
-✓ Static site built: out/  (<N> pages)
-  Preview locally: npx serve out
-  Upload out/ to any static host. Examples:
-    - GitHub Pages:   npx gh-pages -d out
-    - Netlify:        netlify deploy --dir=out --prod
-    - Cloudflare:     npx wrangler pages deploy out
+✓ Deployed to PortalJS Arc
+  - URL:   https://SLUG.arc.portaljs.com
+  - Files: <n>   (<bytes> uploaded)
+  - Slug:  SLUG  (re-run /deploy to update)
+
+Open the URL to view your live portal.
 ```
-
----
-
-## Output expectations
-
-- **Vercel:** no files changed; a deployment is created; a live URL is printed.
-- **Static:** `next.config.js` may be edited (adds `output`/`images`/`basePath`); an `out/` directory is created; nothing is uploaded unless a host was named.
-- On any failure, an `ERROR: [deploy] …` block is printed and the skill stops — never a success message over a failing build or deploy.
 
 ## Notes
 
-- **First Vercel deploy** prompts to link a project; `--yes` accepts the defaults (project name = directory name, current dir as root). To control these, the user can run `vercel link` once beforehand.
-- **Environment variables** (e.g. `DMS` for CKAN portals): set them in the Vercel dashboard or with `vercel env add` before deploying — they are not read from a local `.env` by the build on Vercel. For static export, client-side env vars must be inlined at build time via `NEXT_PUBLIC_*`.
-- **CKAN / SSR portals cannot use `static`** if they rely on API routes or `getServerSideProps` — those need a server. Use `vercel` for them.
-- **`out/` is build output** — add it to `.gitignore` if not already there; do not commit it.
-
-Next: after a Vercel preview deploy, run `/deploy --prod` to promote to production.
+- **Idempotent.** Deploying the same slug again replaces the site in place. Pick the slug once;
+  it's your portal's permanent address.
+- **Auth lives outside the repo.** The token is read from `PORTALJS_TOKEN` or
+  `~/.portaljs/credentials` — never commit it. `https://arc.portaljs.com` is where you sign in
+  and manage tokens.
+- **Self-hosting.** Arc is optional. The build output in `out/` is a plain static site you can
+  host anywhere; this skill just automates the Arc path.
+- **Custom domains / SSR.** Not in v1. Arc serves `*.arc.portaljs.com` static sites today.

--- a/cloud/worker/src/index.ts
+++ b/cloud/worker/src/index.ts
@@ -30,7 +30,9 @@ export function resolveCandidates(slug: string, pathname: string): string[] {
   if (p.endsWith('/')) return [`${base}${p}index.html`]
   const last = p.split('/').pop() ?? ''
   if (last.includes('.')) return [`${base}${p}`] // looks like a file
-  return [`${base}${p}`, `${base}${p}/index.html`] // try as file, then as a directory
+  // Extensionless: exact file, then Next static-export's `<path>.html` (the default,
+  // no trailing slash), then a directory index (trailingSlash: true builds).
+  return [`${base}${p}`, `${base}${p}.html`, `${base}${p}/index.html`]
 }
 
 const TYPES: Record<string, string> = {

--- a/cloud/worker/src/index.ts
+++ b/cloud/worker/src/index.ts
@@ -27,7 +27,14 @@ export function resolveCandidates(slug: string, pathname: string): string[] {
   let p = decodeURIComponent(pathname)
   if (!p.startsWith('/')) p = '/' + p
   const base = `sites/${slug}`
-  if (p.endsWith('/')) return [`${base}${p}index.html`]
+  if (p.endsWith('/')) {
+    // Directory index, plus the trimmed `<path>.html` — a default Next export stores
+    // `/search` as `search.html`, so `/search/` must reach it too (not just index.html).
+    const trimmed = p.slice(0, -1)
+    const candidates = [`${base}${p}index.html`]
+    if (trimmed) candidates.push(`${base}${trimmed}.html`)
+    return candidates
+  }
   const last = p.split('/').pop() ?? ''
   if (last.includes('.')) return [`${base}${p}`] // looks like a file
   // Extensionless: exact file, then Next static-export's `<path>.html` (the default,

--- a/cloud/worker/test/router.test.ts
+++ b/cloud/worker/test/router.test.ts
@@ -46,6 +46,12 @@ describe('resolveCandidates', () => {
   it('maps root to index.html', () => {
     expect(resolveCandidates('acme', '/')).toEqual(['sites/acme/index.html'])
   })
+  it('trailing slash tries index.html then <path>.html', () => {
+    expect(resolveCandidates('acme', '/search/')).toEqual([
+      'sites/acme/search/index.html',
+      'sites/acme/search.html',
+    ])
+  })
   it('serves a file path directly', () => {
     expect(resolveCandidates('acme', '/data/x.csv')).toEqual(['sites/acme/data/x.csv'])
   })
@@ -87,6 +93,12 @@ describe('fetch handler', () => {
     const res = await worker.fetch(get('acme.staging.arc.portaljs.com', '/search'), env)
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toMatch(/text\/html/)
+    expect(await res.text()).toContain('Search')
+  })
+
+  it('serves <path>.html for the trailing-slash form too', async () => {
+    const res = await worker.fetch(get('acme.staging.arc.portaljs.com', '/search/'), env)
+    expect(res.status).toBe(200)
     expect(await res.text()).toContain('Search')
   })
 

--- a/cloud/worker/test/router.test.ts
+++ b/cloud/worker/test/router.test.ts
@@ -49,9 +49,10 @@ describe('resolveCandidates', () => {
   it('serves a file path directly', () => {
     expect(resolveCandidates('acme', '/data/x.csv')).toEqual(['sites/acme/data/x.csv'])
   })
-  it('tries extensionless as file then directory index', () => {
+  it('tries extensionless as file, then <path>.html, then directory index', () => {
     expect(resolveCandidates('acme', '/about')).toEqual([
       'sites/acme/about',
+      'sites/acme/about.html',
       'sites/acme/about/index.html',
     ])
   })
@@ -77,8 +78,16 @@ describe('fetch handler', () => {
   const env = envWith({
     'sites/acme/index.html': '<h1>Acme</h1>',
     'sites/acme/data/pop.csv': 'a,b\n1,2',
+    'sites/acme/search.html': '<h1>Search</h1>', // Next export: /search → search.html
     'sites/acme/about/index.html': '<h1>About</h1>',
     'sites/acme/404.html': '<h1>custom 404</h1>',
+  })
+
+  it('serves a Next-export <path>.html for an extensionless route', async () => {
+    const res = await worker.fetch(get('acme.staging.arc.portaljs.com', '/search'), env)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toMatch(/text\/html/)
+    expect(await res.text()).toContain('Search')
   })
 
   it('serves the home page', async () => {


### PR DESCRIPTION
Rewrites `/deploy` to the **single PortalJS Arc target** (epic po-x8x, bead po-4yq), and fixes a router bug found while dogfooding it.

## /deploy skill
One target: PortalJS Arc. Flow — derive slug → resolve token (`PORTALJS_TOKEN` or `~/.portaljs/credentials`) → ensure `output:'export'` → `npm run build` → tar `out/` → `POST api.arc.portaljs.com/v1/deploy?slug=` → print `https://<slug>.arc.portaljs.com`. Handles 401/409/400/413 and build failures; never reports success on a failing build. Vercel/static branching removed (with a self-host note). `PORTALJS_ARC_API` overrides the endpoint for staging.

## Router fix (from dogfooding)
Next's static export writes `<path>.html` (e.g. `search.html`, `@reference/country-codes.html`), **not** `<path>/index.html`. The router's `resolveCandidates` now tries `<path>.html` between the exact file and the directory index — so `/search` and showcase routes resolve. (Without this, only the home page served.)

## Dogfooded end-to-end on staging
Scaffolded the catalog template → `output:'export'` build (44 files) → uploaded via the skill's flow → **home, `/search`, and `/@reference/country-codes` all serve 200** at `dogfood.staging.arc.portaljs.com`. Worker tests **17** pass; `tsc` clean; router redeployed to staging.

## Remaining (separate beads)
- **po-5vk** — auth/signup at `arc.portaljs.com` so tokens are self-serve (today: seeded/manual).
- **po-xqq** — update the user-facing `/deploy` docs page to the single Arc target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy command now publishes to PortalJS Arc with token-based authentication
  * Added slug validation with reserved slug checks and auth error guidance
  
* **Documentation**
  * Updated deploy command documentation for Arc-specific workflow and constraints
  
* **Improvements**
  * Enhanced URL routing to properly resolve trailing-slash paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->