### PR TITLE
docs(cloud): /deploy + PortalJS Arc docs (po-xqq)

### DIFF
--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -125,6 +125,10 @@
       {
         "title": "Backends",
         "href": "/docs/backends"
+      },
+      {
+        "title": "PortalJS Arc (hosting)",
+        "href": "/docs/arc"
       }
     ]
   },

--- a/site/content/docs/arc.md
+++ b/site/content/docs/arc.md
@@ -1,0 +1,51 @@
+---
+metatitle: PortalJS Arc – Managed Hosting for PortalJS Portals
+metadescription: PortalJS Arc is Datopian-managed static hosting on Cloudflare. Run /deploy to publish a PortalJS portal to a live <slug>.arc.portaljs.com URL — no infrastructure to run.
+title: PortalJS Arc
+description: Datopian-managed static hosting for PortalJS portals — /deploy to a live <slug>.arc.portaljs.com URL.
+---
+
+**PortalJS Arc** is managed hosting for PortalJS portals, run by Datopian on Cloudflare. You
+build a portal, run [`/deploy`](/docs/skills/deploy), and it goes live at
+`https://<slug>.arc.portaljs.com` — no servers, no infrastructure to set up.
+
+> [!info] One command
+> ```
+> /deploy
+> → builds a static export of your portal
+> → uploads it to PortalJS Arc
+> ✓ Live at https://my-portal.arc.portaljs.com
+> ```
+
+## How it works
+
+A PortalJS portal static-exports to plain HTML/CSS/JS (the catalog template, `/add-dataset`,
+`/migrate`, and `/connect-ckan` all pre-render with `getStaticPaths`). `/deploy` builds that
+export and uploads it to Arc, which serves it from object storage behind Cloudflare's edge.
+The deploy is **idempotent** — the slug is your portal's permanent address, and re-deploying
+replaces the site in place.
+
+## Auth
+
+Sign in at [arc.portaljs.com](https://arc.portaljs.com) with GitHub and generate an API
+token. `/deploy` reads it from `PORTALJS_TOKEN` or `~/.portaljs/credentials`; it's never
+committed to your repo. See the [`/deploy` skill](/docs/skills/deploy) for the exact setup.
+
+## Scope today
+
+- **Static only.** Arc hosts static exports. A portal that relies on `getServerSideProps`
+  (SSR) isn't on Arc yet.
+- **`*.arc.portaljs.com` URLs.** Custom domains aren't available in this version.
+
+## Self-hosting instead
+
+Arc is optional. Because a portal is a standard static Next.js export, you can host it
+yourself anywhere — run `npm run build` and upload the `out/` directory to Vercel, your own
+Cloudflare, Netlify, S3, or any static host. `/deploy` simply automates the Arc path.
+
+## Where to go next
+
+- **[`/deploy`](/docs/skills/deploy)** — publish your portal.
+- **[Backends](/docs/backends)** — connect a live data backend before deploying.
+
+<DocsPagination prev="/docs/backends" next="/docs/skills/deploy" />

--- a/site/content/docs/backends.md
+++ b/site/content/docs/backends.md
@@ -92,4 +92,4 @@ you can model a new backend skill on [`/connect-ckan`](/docs/skills/connect-ckan
 - **[Authoring skills](/docs/authoring-skills)** — package your backend integration as
   a reusable skill.
 
-<DocsPagination prev="/docs/authoring-skills" />
+<DocsPagination prev="/docs/authoring-skills" next="/docs/arc" />

--- a/site/content/docs/guides/deploy.md
+++ b/site/content/docs/guides/deploy.md
@@ -1,46 +1,38 @@
 ---
-metatitle: Deploy a PortalJS Portal – Vercel or Static Hosting
-metadescription: Publish your PortalJS portal with /deploy — to Vercel for SSR/ISR, or as a fully static site for GitHub Pages, Netlify, Cloudflare, S3, or nginx. Or deploy by hand.
+metatitle: Deploy a PortalJS Portal – PortalJS Arc or Self-Hosted
+metadescription: Publish your PortalJS portal with /deploy to PortalJS Arc (managed hosting on Cloudflare, a live <slug>.arc.portaljs.com URL), or self-host the static export on Vercel, Netlify, Cloudflare, S3, or nginx.
 title: Deploy
-description: Publish to Vercel or any static host — with /deploy, or by hand.
+description: Publish to PortalJS Arc with /deploy, or self-host the static export anywhere.
 ---
 
-**Goal:** take the portal live. Two targets: **Vercel** (handles SSR/ISR natively) or
-a **fully static** export you can host anywhere.
+**Goal:** take the portal live. The fast path is [`/deploy`](/docs/skills/deploy) to
+[**PortalJS Arc**](/docs/arc) — Datopian-managed hosting. Or self-host the static export on
+any host you like.
 
-> [!info] Which target?
-> Use **Vercel** for portals that may grow server-side features, or any CKAN/SSR portal
-> that relies on `getServerSideProps`. Use **static** for fully client-rendered portals
-> — GitHub Pages, Netlify, Cloudflare Pages, S3 + CloudFront, or plain nginx.
-
-## The AI path — `/deploy`
+## The AI path — `/deploy` → PortalJS Arc
 
 ```
 /deploy
 ```
 
-[`/deploy`](/docs/skills/deploy) auto-detects the target (a `.vercel/` link or
-`output: 'export'` in `next.config.js`), builds, verifies the build passes, and either
-publishes to Vercel or produces a ready-to-upload `out/` directory. It **never reports
-success on a failing build**.
+[`/deploy`](/docs/skills/deploy) builds a static export, uploads it to
+[PortalJS Arc](/docs/arc), and prints a live `https://<slug>.arc.portaljs.com` URL. It
+**never reports success on a failing build**, and re-running redeploys the same slug in
+place.
 
-Force a target if you want:
+You need a PortalJS Arc token — sign in at [arc.portaljs.com](https://arc.portaljs.com),
+generate one, and set `PORTALJS_TOKEN` (or save it to `~/.portaljs/credentials`). See the
+[`/deploy` skill](/docs/skills/deploy) for details.
 
-```
-/deploy --target static
-```
+> [!info] Static only (for now)
+> Arc serves static exports. The catalog template, `/add-dataset`, `/migrate`, and
+> `/connect-ckan` (SSG) all export cleanly. A portal that relies on `getServerSideProps`
+> (SSR) isn't hosted on Arc yet — self-host it (below).
 
-## The by-hand path
+## The self-host path
 
-**Vercel** — Vercel builds on its own infrastructure, so no local build is needed:
-
-```bash
-npx vercel        # preview
-npx vercel --prod # production
-```
-
-**Static export** — set `output: 'export'` and `images: { unoptimized: true }` in
-`next.config.js`, then build:
+Arc is optional — a portal is a standard static Next.js export you can host anywhere. Set
+`output: 'export'` and `images: { unoptimized: true }` in `next.config.js`, then build:
 
 ```bash
 npm run build     # writes the static site to out/
@@ -50,27 +42,28 @@ npx serve out     # preview locally
 Upload `out/` to any static host:
 
 ```bash
-npx gh-pages -d out                      # GitHub Pages
+npx vercel --prod                        # Vercel
+npx wrangler pages deploy out            # your own Cloudflare Pages
 netlify deploy --dir=out --prod          # Netlify
-npx wrangler pages deploy out            # Cloudflare Pages
+npx gh-pages -d out                      # GitHub Pages
 ```
+
+(For an SSR/CKAN portal that needs a server, deploy to Vercel with `npx vercel` instead of a
+static export, and set env vars like `DMS` in the Vercel dashboard.)
 
 ## Notes
 
 - **Dynamic routes under static export** need `getStaticPaths` returning
-  `{ fallback: false }`. `/add-dataset` writes one file per dataset specifically to
-  avoid this; the [catalog template](/docs/templates) pre-renders every manifest entry.
-- **CKAN / SSR portals can't use static** if they rely on API routes or
-  `getServerSideProps` — use Vercel.
-- **Environment variables** (e.g. `DMS` for CKAN portals) must be set in the Vercel
-  dashboard or via `vercel env add`; for static export, inline client-side values at
-  build time with `NEXT_PUBLIC_*`.
+  `{ fallback: false }`. The [catalog template](/docs/templates) pre-renders every manifest
+  entry, so `/add-dataset` and `/migrate` portals export cleanly.
+- **Environment variables:** for static export, inline client-side values at build time with
+  `NEXT_PUBLIC_*`; for a Vercel/SSR deploy, set them in the Vercel dashboard.
 - **GitHub Pages subpath:** if deploying to `https://user.github.io/repo/`, also set
   `basePath` and `assetPrefix` in `next.config.js`.
 
 ## Where to go next
 
+- **[PortalJS Arc](/docs/arc)** — how the managed hosting works.
 - **[Theming](/docs/guides/theming)** — brand the portal before you ship it.
-- **[Templates](/docs/templates)** — the single-page vs. catalog template.
 
 <DocsPagination prev="/docs/guides/connect-a-ckan-backend" next="/docs/guides/theming" />

--- a/site/content/docs/skills/deploy.md
+++ b/site/content/docs/skills/deploy.md
@@ -1,41 +1,31 @@
 ---
-metatitle: /deploy – Publish a PortalJS Portal to Vercel or Static Hosting
-metadescription: The /deploy skill detects your target, builds the portal, and publishes it to Vercel or any static host — never reporting success on a failing build, with a live URL at the end.
+metatitle: /deploy – Publish a PortalJS Portal to PortalJS Arc
+metadescription: The /deploy skill builds a static export of your portal and publishes it to PortalJS Arc — Datopian-managed hosting on Cloudflare — returning a live <slug>.arc.portaljs.com URL. One command, one target.
 title: /deploy
-description: Build and publish the portal to Vercel or any static host — with a live URL at the end.
+description: Build a static export and publish it to PortalJS Arc — a live <slug>.arc.portaljs.com URL in one command.
 ---
 
-`/deploy` takes a PortalJS portal live in one shot. It detects the target, builds,
-verifies the build passes, and either publishes (Vercel) or produces a ready-to-
-upload `out/` directory (static hosting). It never reports success on a failing
-build.
+`/deploy` takes a PortalJS portal live on [**PortalJS Arc**](/docs/arc) — Datopian's
+managed static hosting on Cloudflare. It builds a static export, uploads it, and prints a
+live `https://<slug>.arc.portaljs.com` URL. Re-running redeploys the same portal in place.
+
+It is a **single-target** skill: it publishes to PortalJS Arc only. If you'd rather host
+the portal yourself, the build output in `out/` is a plain static site you can upload to any
+host (Vercel, your own Cloudflare, Netlify, S3, …) — you don't need this skill for that.
 
 ## When to use it
 
-Run it once the portal looks right locally. It's the last step in the typical flow
-after [`/new-portal`](/docs/skills/new-portal),
-[`/add-dataset`](/docs/skills/add-dataset), and any enrichment skills.
+Run it once the portal looks right locally — the last step after
+[`/new-portal`](/docs/skills/new-portal), [`/add-dataset`](/docs/skills/add-dataset) /
+[`/migrate`](/docs/skills/migrate), and any enrichment skills.
 
 ## Inputs
 
 | Input | Required | Notes |
 | ----- | -------- | ----- |
-| Portal directory | No | Path to the portal project. Defaults to the current directory; must contain a Next.js `package.json`. |
-| Target | No | `vercel` or `static`. If omitted, the skill auto-detects and tells you what it chose. |
-
-**Two targets:**
-
-- **`vercel`** — pushes to Vercel via the `vercel` CLI. Handles SSR/ISR natively
-  and gives a live `*.vercel.app` URL (or your custom domain). Best default for
-  portals that may grow server-side features. Requires the CLI installed and logged
-  in (`vercel login`).
-- **`static`** — builds a fully static site (`output: 'export'` → `out/`) suitable
-  for any static host: GitHub Pages, Netlify, S3 + CloudFront, Cloudflare Pages, or
-  plain nginx. No server required.
-
-Auto-detection prefers Vercel if a `.vercel/` link exists, static if
-`next.config.js` already sets `output: 'export'`, and otherwise Vercel when its CLI
-is available (falling back to static).
+| Portal directory | No | Path to the portal project. Defaults to the current directory; must be a Next.js portal. |
+| Slug | No | The subdomain to publish under (`<slug>.arc.portaljs.com`). Defaults to the project name; override with `--slug <name>`. |
+| Arc token | Yes | A PortalJS Arc token, read from `PORTALJS_TOKEN` or `~/.portaljs/credentials`. Get one by signing in at [arc.portaljs.com](https://arc.portaljs.com). |
 
 ## Example
 
@@ -43,39 +33,49 @@ is available (falling back to static).
 /deploy
 ```
 
-Force a target, or promote a preview to production:
+Publish under a specific slug:
 
 ```
-/deploy --static
-/deploy --prod
+/deploy --slug auckland-open-data
 ```
 
 ## What it produces
 
-- **Vercel:** no files changed; a deployment is created and a live URL printed.
+The skill ensures a static export (`output: 'export'`), builds and verifies it (never
+reporting success on a failing build), uploads `out/` to Arc, and reports:
 
-  ```
-  ✓ Deployed to Vercel
-    URL: https://auckland-council-open-data.vercel.app
-  ```
+```
+✓ Deployed to PortalJS Arc
+  - URL:   https://auckland-open-data.arc.portaljs.com
+  - Files: 44   (820 KB uploaded)
+  - Slug:  auckland-open-data  (re-run /deploy to update)
+```
 
-- **Static:** `next.config.js` may be edited (to add `output: 'export'`,
-  `images: { unoptimized: true }`, and a base path if needed); an `out/` directory
-  of static HTML is produced. Nothing is uploaded unless you name a host.
+## Auth
 
-  ```
-  ✓ Static site built: out/  (12 pages)
-    Preview locally: npx serve out
-  ```
+Deploying needs a PortalJS Arc token. Sign in at [arc.portaljs.com](https://arc.portaljs.com)
+with GitHub, generate a token, and either:
 
-> CKAN or SSR portals that rely on `getServerSideProps` need a server — use the
-> `vercel` target for those. Set env vars (e.g. `DMS`) in the Vercel dashboard
-> before deploying.
+```bash
+export PORTALJS_TOKEN=<token>
+# …or save it for re-use:
+mkdir -p ~/.portaljs && printf '{"token":"<token>"}\n' > ~/.portaljs/credentials
+```
+
+The token is never committed to your repo.
+
+## Notes
+
+- **Static only (for now).** Arc serves static exports — the catalog template,
+  `/add-dataset`, `/migrate`, and `/connect-ckan` (SSG) all export cleanly. A portal that
+  relies on `getServerSideProps` (SSR) isn't hosted on Arc yet; self-host it instead.
+- **Idempotent.** The slug is your portal's permanent address; re-deploying replaces the
+  site in place.
 
 ## Where to go next
 
-- **[Skills reference](/docs/skills)** — the full set of skills.
-- **[`/connect-ckan`](/docs/skills/connect-ckan)** — point the portal at a live
-  backend before deploying.
+- **[PortalJS Arc](/docs/arc)** — what the managed hosting is and how it works.
+- **[`/connect-ckan`](/docs/skills/connect-ckan)** — point the portal at a live backend
+  before deploying.
 
 <DocsPagination prev="/docs/skills/define-schema" />


### PR DESCRIPTION
Final code-side bead of the PortalJS Arc epic (po-x8x) — docs to match the shipped `/deploy` skill.

- **`skills/deploy.md`** — rewritten from the old Vercel/static multi-target to the **single PortalJS Arc target**: slug, token auth (`PORTALJS_TOKEN` / `~/.portaljs/credentials`), `<slug>.arc.portaljs.com`, static-only + self-host notes.
- **`docs/arc.md`** (new) — PortalJS Arc concept page: what it is, how it works, auth, scope (static-only, `*.arc.portaljs.com`), and the self-hosting escape hatch.
- **`guides/deploy.md`** — realigned so it no longer describes `/deploy` as multi-target: `/deploy` → Arc is the fast path, Vercel/static is the by-hand self-host path.
- **Sidebar + pagination** — 'PortalJS Arc (hosting)' under *Templates & extending*; backends → arc chain.

Docs-only; Vercel preview build verifies. Closes po-xqq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive PortalJS Arc hosting documentation covering deployment workflow, authentication, and capabilities.
  * Updated deployment guides to prioritize Arc as the primary managed hosting solution.
  * Added Arc documentation link to navigation menu.
  * Refined deployment documentation to focus on Arc workflow with token-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->