### PR TITLE
fix(cloud): pin staging GITHUB_CLIENT_ID + correct INFRA.md secrets

### DIFF
--- a/cloud/INFRA.md
+++ b/cloud/INFRA.md
@@ -64,21 +64,28 @@ complete the live sign-in. Create one (Settings → Developer settings → OAuth
   (`SESSION_SECRET` is already set on staging).
 - Scope needed: `read:user` (just to identify the GitHub account).
 
-## Secrets (via `wrangler secret put`, not in the repo)
-- Deploys: I authenticate with `wrangler login` (OAuth) — **no `CLOUDFLARE_API_TOKEN` needed**.
-  Only needed for headless CI, and then via a local gitignored env file, never in chat.
-- `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` (auth worker).
-- A signing secret for API tokens (`TOKEN_SIGNING_KEY`).
+## Config + secrets
+Naming matches what the workers actually read (`cloud/{auth,api,worker}/src`):
+- **Deploys**: authenticate with `wrangler login` (OAuth) — **no `CLOUDFLARE_API_TOKEN` needed**.
+  Only for headless CI, and then via a local gitignored env file, never in chat.
+- `GITHUB_CLIENT_ID` — a committed `[vars]` value, **not a secret** (it rides in the OAuth
+  redirect URL). Per-environment: staging is pinned in `cloud/auth/wrangler.toml`; production
+  gets its own OAuth app + ID.
+- `GITHUB_CLIENT_SECRET` — secret (`wrangler secret put`), auth worker.
+- `SESSION_SECRET` — secret, auth worker; signs the dashboard session cookie. Auto-generated.
+- **API tokens have no signing key.** They are random `arc_…` strings stored as a SHA-256
+  hash in D1 (`tokens.hash`); the deploy API validates by hashing the bearer token and
+  matching the row. Nothing to provision.
 
 ## Suggested order
 1. R2 bucket + D1 db (staging) → unblocks API/Worker staging tests. ✅ done
 2. Wildcard `*.staging.arc.portaljs.com` (proxied) → staging router. ✅ done
-3. **Enable ACM + order a `*.staging.arc.portaljs.com` cert** → unblocks HTTPS on staging
-   tenant URLs (currently blocked by the TLS handshake failure). ← **next**
-4. (+ `api.staging.arc.portaljs.com` → staging deploy API) → end-to-end staging.
-5. GitHub OAuth app (`arc.portaljs.com`) → real auth.
-6. Production: R2/D1 (`portaljs-arc`) + ACM cert for `*.arc.portaljs.com` + flip the
-   `*.arc.portaljs.com` wildcard → router, and `api.arc.portaljs.com` → deploy API.
+3. ACM cert covering `*.staging.arc.portaljs.com` (+ `*.arc.portaljs.com`, `arc.portaljs.com`). ✅ done
+4. GitHub OAuth app + auth/api/router deployed → **end-to-end staging verified 2026-06-17**
+   (deploy → R2 → router serves HTTPS; OAuth → dashboard → token issuance). ✅ done
+5. Production: R2/D1 (`portaljs-arc`) + ACM cert for `*.arc.portaljs.com` + flip the
+   `*.arc.portaljs.com` wildcard → router, `api.arc.portaljs.com` → deploy API, and a
+   production GitHub OAuth app (callback `https://arc.portaljs.com/auth/callback`). ← **next**
 
 Auth: I use `wrangler login` (OAuth) for deploys — no API token needed. If a token is ever
 required (CI), provide it via a local gitignored env file, never in chat.

--- a/cloud/auth/wrangler.toml
+++ b/cloud/auth/wrangler.toml
@@ -9,7 +9,7 @@ workers_dev = true
 BASE_URL = "https://arc-auth-staging.datopian.workers.dev"
 # GITHUB_CLIENT_ID is set per-environment; GITHUB_CLIENT_SECRET + SESSION_SECRET
 # are secrets (wrangler secret put), never committed.
-GITHUB_CLIENT_ID = "REPLACE_AT_DEPLOY"
+GITHUB_CLIENT_ID = "Ov23liXuXnCuAnyuIucc"
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## What

The Arc auth worker (`cloud/auth/wrangler.toml`) had `GITHUB_CLIENT_ID = "REPLACE_AT_DEPLOY"`. A clean redeploy from `main` would ship that placeholder and break GitHub sign-in on staging.

This pins the staging OAuth app's client ID.

## Why it's safe to commit

The GitHub OAuth **client ID** is not a secret — it's exposed in every OAuth redirect URL (`github.com/login/oauth/authorize?client_id=…`). The **client secret** and **SESSION_SECRET** stay as `wrangler secret put` secrets, never in the repo.

## Context

Arc staging is deployed and verified end-to-end (deploy API → R2 → router serves `*.staging.arc.portaljs.com` over HTTPS; auth `/auth/login` → GitHub OAuth). This was the one durability gap: the deployed worker had the ID baked in, but the repo didn't.

Production will get its own OAuth app + client ID at go-live (separate `[env]` / config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the staging authentication configuration with a concrete GitHub OAuth client ID.
  * Refreshed infrastructure documentation to clarify required worker environment variables and the staging/prod setup order, including GitHub OAuth end-to-end verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->