### PR TITLE
fix(seo): site-wide SEO audit — canonical consistency, titles & structured data

### DIFF
--- a/site/components/schema/BlogStructuredData.tsx
+++ b/site/components/schema/BlogStructuredData.tsx
@@ -12,19 +12,19 @@ export function BlogStructuredData({ blogs }) {
       />
       <Head>
         {generateNextSeo({
-          title: "Blog",
-          description: "Discover insights, updates and stories about PortalJS Cloud. Stay informed about open data solutions and enhance your data portal skills.",
+          title: "Blog | PortalJS — Open Data Portal Insights & Updates",
+          description: "Discover insights, tutorials, and updates about PortalJS Cloud and open data portals. Stay informed about open data solutions, AI integration, and best practices.",
           canonical: "https://www.portaljs.com/blog",
           openGraph: {
           url: 'https://www.portaljs.com/blog',
-          title: 'Blog',
-          description: 'Discover insights, updates and stories about PortalJS Cloud. Stay informed about open data solutions and enhance your data portal skills.',
+          title: 'Blog | PortalJS — Open Data Portal Insights & Updates',
+          description: 'Discover insights, tutorials, and updates about PortalJS Cloud and open data portals. Stay informed about open data solutions, AI integration, and best practices.',
           site_name: 'PortalJS',
           type: 'website',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
-              alt: 'PortalJS Cloud',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
+              alt: 'PortalJS Blog — Open Data Insights',
               width: 1280,
               height: 720,
               type: 'image/webp',

--- a/site/components/schema/CaseStudiesStructuredData.tsx
+++ b/site/components/schema/CaseStudiesStructuredData.tsx
@@ -12,19 +12,19 @@ export function CaseStudiesStructuredData({ casestudies }) {
       />
       <Head>
         {generateNextSeo({
-          title: "Showcase of Case Studies",
-          description: "See our client stories.",
-          canonical: "https://www.portaljs.com/showcase",
+          title: "Case Studies | PortalJS — Real Open Data Portal Implementations",
+          description: "Discover how governments, research institutions, and enterprises worldwide build powerful open data portals with PortalJS. Real client stories and proven outcomes.",
+          canonical: "https://www.portaljs.com/case-studies",
           openGraph: {
-            url: 'https://www.portaljs.com/showcase',
-            title: 'Showcase of Case Studies',
-            description: 'See our client stories.',
+            url: 'https://www.portaljs.com/case-studies',
+            title: 'Case Studies | PortalJS — Real Open Data Portal Implementations',
+            description: 'Discover how governments, research institutions, and enterprises worldwide build powerful open data portals with PortalJS. Real client stories and proven outcomes.',
             site_name: 'PortalJS',
             type: 'website',
             images: [
               {
-                url: 'https://portaljs.com/static/img/seo.webp',
-                alt: 'PortalJS Cloud',
+                url: 'https://www.portaljs.com/static/img/seo.webp',
+                alt: 'PortalJS — Open Data Portal Case Studies',
                 width: 1280,
                 height: 720,
                 type: 'image/webp',
@@ -32,9 +32,9 @@ export function CaseStudiesStructuredData({ casestudies }) {
             ],
           },
           twitter: {
-          cardType: 'summary_large_image',
-          site: '@PortalJS_',
-        },
+            cardType: 'summary_large_image',
+            site: '@PortalJS_',
+          },
         })}
       </Head>
       <BreadcrumbJsonLd
@@ -44,8 +44,8 @@ export function CaseStudiesStructuredData({ casestudies }) {
             item: 'https://www.portaljs.com',
           },
           {
-            name: 'Showcase',
-            item: 'https://www.portaljs.com/showcase',
+            name: 'Case Studies',
+            item: 'https://www.portaljs.com/case-studies',
           },
         ]}
       />

--- a/site/components/schema/DataPortalStructuredData.tsx
+++ b/site/components/schema/DataPortalStructuredData.tsx
@@ -14,19 +14,19 @@ export function DataPortalsStructuredData() {
       />
       <Head>
         {generateNextSeo({
-          title: "Showcase of Data Portals",
-          description: "Discover data portals powered by PortalJS.",
-          canonical: "https://www.portaljs.com/showcase",
+          title: "Data Portals Showcase | PortalJS — Live Open Data Implementations",
+          description: "Explore live open data portals built with PortalJS. Government, research, and enterprise implementations from organisations worldwide.",
+          canonical: "https://www.portaljs.com/data-portals",
           openGraph: {
-            url: 'https://www.portaljs.com/showcase',
-            title: 'Showcase of Data Portals',
-            description: 'Discover data portals powered by PortalJS.',
+            url: 'https://www.portaljs.com/data-portals',
+            title: 'Data Portals Showcase | PortalJS — Live Open Data Implementations',
+            description: 'Explore live open data portals built with PortalJS. Government, research, and enterprise implementations from organisations worldwide.',
             site_name: 'PortalJS',
             type: 'website',
             images: [
               {
-                url: 'https://portaljs.com/static/img/seo.webp',
-                alt: 'PortalJS Cloud',
+                url: 'https://www.portaljs.com/static/img/seo.webp',
+                alt: 'PortalJS — Live Data Portal Examples',
                 width: 1280,
                 height: 720,
                 type: 'image/webp',
@@ -34,9 +34,9 @@ export function DataPortalsStructuredData() {
             ],
           },
           twitter: {
-          cardType: 'summary_large_image',
-          site: '@PortalJS_',
-        },
+            cardType: 'summary_large_image',
+            site: '@PortalJS_',
+          },
         })}
       </Head>
       <BreadcrumbJsonLd
@@ -46,8 +46,8 @@ export function DataPortalsStructuredData() {
             item: 'https://www.portaljs.com',
           },
           {
-            name: 'Showcase',
-            item: 'https://www.portaljs.com/showcase',
+            name: 'Data Portals',
+            item: 'https://www.portaljs.com/data-portals',
           },
         ]}
       />

--- a/site/components/schema/FaqStructuredData.tsx
+++ b/site/components/schema/FaqStructuredData.tsx
@@ -24,19 +24,19 @@ export function FaqStructuredData() {
       />
       <Head>
         {generateNextSeo({
-          title: "FAQ",
-          description: "Frequently Asked Questions about PortalJS Cloud. Get answers about pricing, features, deployment, and more.",
+          title: "FAQ | PortalJS Cloud — Pricing, Features & Deployment",
+          description: "Frequently Asked Questions about PortalJS Cloud. Get answers about pricing, features, deployment, migration, security, and more.",
           canonical: "https://www.portaljs.com/faq",
           openGraph: {
           url: 'https://www.portaljs.com/faq',
-          title: 'FAQ',
-          description: 'Frequently Asked Questions about PortalJS Cloud. Get answers about pricing, features, deployment, and more.',
+          title: 'FAQ | PortalJS Cloud — Pricing, Features & Deployment',
+          description: 'Frequently Asked Questions about PortalJS Cloud. Get answers about pricing, features, deployment, migration, security, and more.',
           site_name: 'PortalJS',
           type: 'website',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
-              alt: 'PortalJS Cloud',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
+              alt: 'PortalJS Cloud FAQ',
               width: 1280,
               height: 720,
               type: 'image/webp',

--- a/site/components/schema/HomePageStructuredData.tsx
+++ b/site/components/schema/HomePageStructuredData.tsx
@@ -33,8 +33,8 @@ export function HomePageStructuredData() {
           type: 'website',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
-              alt: 'PortalJS Cloud',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
+              alt: 'PortalJS — Modern Open Data Portals',
               width: 1280,
               height: 720,
               type: 'image/webp',

--- a/site/content/config.js
+++ b/site/content/config.js
@@ -161,6 +161,7 @@ const config = {
   ],
   nextSeo: {
     openGraph: {
+      site_name: 'PortalJS',
       additionalLinkTags: [
         { rel: 'icon', href: '/favicon.ico' },
         { rel: 'apple-touch-icon', href: '/icon.png', sizes: '120x120' },
@@ -169,8 +170,8 @@ const config = {
       ],
       images: [
         {
-          url: 'https://portaljs.com/static/img/seo.webp',
-          alt: 'PortalJS Cloud',
+          url: 'https://www.portaljs.com/static/img/seo.webp',
+          alt: 'PortalJS — Modern Open Data Portals',
           width: 1280,
           height: 720,
           type: 'image/webp',
@@ -180,8 +181,8 @@ const config = {
         'PortalJS Cloud is the easiest way to get started with Open Data. Perfect for governments, non-profits, academics, and companies of all sizes.',
     },
     twitter: {
-      handle: '@datopian',
-      site: 'https://datopian.com/',
+      handle: '@PortalJS_',
+      site: '@PortalJS_',
       cardType: 'summary_large_image',
     },
   },

--- a/site/next-sitemap.config.js
+++ b/site/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: process.env.SITE_URL || 'https://portaljs.com',
+  siteUrl: process.env.SITE_URL || 'https://www.portaljs.com',
   generateRobotsTxt: true,
   robotsTxtOptions: {
     policies: [

--- a/site/pages/case-studies.tsx
+++ b/site/pages/case-studies.tsx
@@ -1,8 +1,6 @@
 import Layout from '@/components/Layout'
 import computeFields from '@/lib/computeFields'
 import clientPromise from '@/lib/mddb'
-import { generateNextSeo } from 'next-seo/pages';
-import Head from 'next/head';
 import fs from 'fs'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -12,13 +10,6 @@ import { CaseStudiesStructuredData } from '@/components/schema/CaseStudiesStruct
 export default function CaseStudiesPage(casestudies) {
   return (
     <Layout isHomePage={true}>
-      <Head>
-        {generateNextSeo({
-          title: "Case Studies | PortalJS",
-          description: "Discover how organizations worldwide build powerful data portals with PortalJS. Real client stories, implementations, and success stories.",
-          canonical: "https://portaljs.org/case-studies",
-        })}
-      </Head>
       <CaseStudiesStructuredData casestudies={casestudies.casestudies} />
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12 w-full">

--- a/site/pages/ckan.tsx
+++ b/site/pages/ckan.tsx
@@ -15,17 +15,17 @@ export default function CKAN() {
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
           <OrganizationJsonLd
-            url="https://portaljs.com"
-            logo="https://portaljs.com/icon.png"
+            url="https://www.portaljs.com"
+            logo="https://www.portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
           <Head>
             {generateNextSeo({
               title: "CKAN Data Management System Integration | Decoupled Open Data Frontend",
               description: "Build a modern, headless UI for CKAN with PortalJS. Enjoy copy-&-paste components, server-side rendering for SEO, and full branding control.",
-              canonical: "https://portaljs.com/ckan",
+              canonical: "https://www.portaljs.com/ckan",
               openGraph: {
-              url: 'https://portaljs.com/ckan',
+              url: 'https://www.portaljs.com/ckan',
               title: 'CKAN Data Management System Integration | Decoupled Open Data Frontend',
               description: 'Build a modern, headless UI for CKAN with PortalJS. Enjoy copy-&-paste components, server-side rendering for SEO, and full branding control.',
               site_name: 'PortalJS',
@@ -41,7 +41,7 @@ export default function CKAN() {
               },
               {
                 name: 'CKAN',
-                item: 'https://portaljs.com/ckan',
+                item: 'https://www.portaljs.com/ckan',
               },
             ]}
           />

--- a/site/pages/compare/arcgis-hub.tsx
+++ b/site/pages/compare/arcgis-hub.tsx
@@ -192,21 +192,21 @@ export default function PortalJSvsArcGISHub() {
     <Layout isHomePage={true}>
       {/* SEO */}
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Head>
         {generateNextSeo({
           title: "PortalJS vs ArcGIS Hub | Open Source Data Portal Comparison",
           description: "Compare PortalJS with ArcGIS Hub: See how our open source data portal platform offers more flexibility, better cost control, and freedom from vendor lock-in.",
-          canonical: "https://portaljs.com/compare/arcgis-hub",
+          canonical: "https://www.portaljs.com/compare/arcgis-hub",
           openGraph: {
-          url: 'https://portaljs.com/compare/arcgis-hub',
+          url: 'https://www.portaljs.com/compare/arcgis-hub',
           title: 'PortalJS vs ArcGIS Hub | Open Source Data Portal Comparison',
           description: 'Compare PortalJS with ArcGIS Hub: See how our open source data portal platform offers more flexibility, better cost control, and freedom from vendor lock-in.',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
               width: 1200,
               height: 630,
               alt: 'PortalJS vs ArcGIS Hub Comparison',
@@ -225,11 +225,11 @@ export default function PortalJSvsArcGISHub() {
           },
           {
             name: 'Compare',
-            item: 'https://portaljs.com/compare',
+            item: 'https://www.portaljs.com/compare',
           },
           {
             name: 'ArcGIS Hub',
-            item: 'https://portaljs.com/compare/arcgis-hub',
+            item: 'https://www.portaljs.com/compare/arcgis-hub',
           }
         ]}
       />

--- a/site/pages/compare/ckan.tsx
+++ b/site/pages/compare/ckan.tsx
@@ -192,21 +192,21 @@ export default function PortalJSvsCKAN() {
     <Layout isHomePage={true}>
       {/* SEO */}
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Head>
         {generateNextSeo({
           title: "PortalJS vs CKAN Classic | Modern Frontend vs Monolithic Architecture",
           description: "Compare PortalJS with CKAN Classic: See how our decoupled frontend approach delivers better performance, developer experience, and user experience than monolithic CKAN.",
-          canonical: "https://portaljs.com/compare/ckan",
+          canonical: "https://www.portaljs.com/compare/ckan",
           openGraph: {
-          url: 'https://portaljs.com/compare/ckan',
+          url: 'https://www.portaljs.com/compare/ckan',
           title: 'PortalJS vs CKAN Classic | Modern Frontend vs Monolithic Architecture',
           description: 'Compare PortalJS with CKAN Classic: See how our decoupled frontend approach delivers better performance, developer experience, and user experience than monolithic CKAN.',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
               width: 1200,
               height: 630,
               alt: 'PortalJS vs CKAN Classic Comparison',
@@ -225,11 +225,11 @@ export default function PortalJSvsCKAN() {
           },
           {
             name: 'Compare',
-            item: 'https://portaljs.com/compare',
+            item: 'https://www.portaljs.com/compare',
           },
           {
             name: 'CKAN Classic',
-            item: 'https://portaljs.com/compare/ckan',
+            item: 'https://www.portaljs.com/compare/ckan',
           }
         ]}
       />

--- a/site/pages/compare/custom-solution.tsx
+++ b/site/pages/compare/custom-solution.tsx
@@ -192,21 +192,21 @@ export default function PortalJSvsCustomSolution() {
     <Layout isHomePage={true}>
       {/* SEO */}
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Head>
         {generateNextSeo({
           title: "PortalJS vs Custom Data Portal Development | Build vs Buy Comparison",
           description: "Compare PortalJS with building a custom data portal from scratch: See how our platform delivers faster time-to-market, lower costs, and reduced risk vs custom development.",
-          canonical: "https://portaljs.com/compare/custom-solution",
+          canonical: "https://www.portaljs.com/compare/custom-solution",
           openGraph: {
-          url: 'https://portaljs.com/compare/custom-solution',
+          url: 'https://www.portaljs.com/compare/custom-solution',
           title: 'PortalJS vs Custom Data Portal Development | Build vs Buy Comparison',
           description: 'Compare PortalJS with building a custom data portal from scratch: See how our platform delivers faster time-to-market, lower costs, and reduced risk vs custom development.',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
               width: 1200,
               height: 630,
               alt: 'PortalJS vs Custom Solution Comparison',
@@ -225,11 +225,11 @@ export default function PortalJSvsCustomSolution() {
           },
           {
             name: 'Compare',
-            item: 'https://portaljs.com/compare',
+            item: 'https://www.portaljs.com/compare',
           },
           {
             name: 'Custom Solution',
-            item: 'https://portaljs.com/compare/custom-solution',
+            item: 'https://www.portaljs.com/compare/custom-solution',
           }
         ]}
       />

--- a/site/pages/compare/dataverse.tsx
+++ b/site/pages/compare/dataverse.tsx
@@ -192,21 +192,21 @@ export default function PortalJSvsDataverse() {
     <Layout isHomePage={true}>
       {/* SEO */}
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Head>
         {generateNextSeo({
           title: "PortalJS vs Dataverse | Open Data Portal vs Research Data Repository",
           description: "Compare PortalJS with Dataverse research data repository: See how our open data portal approach delivers better public engagement and user experience for sharing research data.",
-          canonical: "https://portaljs.com/compare/dataverse",
+          canonical: "https://www.portaljs.com/compare/dataverse",
           openGraph: {
-          url: 'https://portaljs.com/compare/dataverse',
+          url: 'https://www.portaljs.com/compare/dataverse',
           title: 'PortalJS vs Dataverse | Open Data Portal vs Research Data Repository',
           description: 'Compare PortalJS with Dataverse research data repository: See how our open data portal approach delivers better public engagement and user experience for sharing research data.',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
               width: 1200,
               height: 630,
               alt: 'PortalJS vs Dataverse Comparison',
@@ -225,11 +225,11 @@ export default function PortalJSvsDataverse() {
           },
           {
             name: 'Compare',
-            item: 'https://portaljs.com/compare',
+            item: 'https://www.portaljs.com/compare',
           },
           {
             name: 'Dataverse',
-            item: 'https://portaljs.com/compare/dataverse',
+            item: 'https://www.portaljs.com/compare/dataverse',
           }
         ]}
       />

--- a/site/pages/compare/dkan.tsx
+++ b/site/pages/compare/dkan.tsx
@@ -192,21 +192,21 @@ export default function PortalJSvsDKAN() {
     <Layout isHomePage={true}>
       {/* SEO */}
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Head>
         {generateNextSeo({
           title: "PortalJS vs DKAN | Modern React vs Drupal-based Data Portal",
           description: "Compare PortalJS with DKAN: See how our modern React frontend delivers better performance, easier maintenance, and lower costs than Drupal-based DKAN.",
-          canonical: "https://portaljs.com/compare/dkan",
+          canonical: "https://www.portaljs.com/compare/dkan",
           openGraph: {
-          url: 'https://portaljs.com/compare/dkan',
+          url: 'https://www.portaljs.com/compare/dkan',
           title: 'PortalJS vs DKAN | Modern React vs Drupal-based Data Portal',
           description: 'Compare PortalJS with DKAN: See how our modern React frontend delivers better performance, easier maintenance, and lower costs than Drupal-based DKAN.',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
               width: 1200,
               height: 630,
               alt: 'PortalJS vs DKAN Comparison',
@@ -225,11 +225,11 @@ export default function PortalJSvsDKAN() {
           },
           {
             name: 'Compare',
-            item: 'https://portaljs.com/compare',
+            item: 'https://www.portaljs.com/compare',
           },
           {
             name: 'DKAN',
-            item: 'https://portaljs.com/compare/dkan',
+            item: 'https://www.portaljs.com/compare/dkan',
           }
         ]}
       />

--- a/site/pages/compare/index.tsx
+++ b/site/pages/compare/index.tsx
@@ -62,7 +62,7 @@ export default function CompareIndex() {
 
   const title = "Compare PortalJS | Open Source Data Portal Comparisons"
   const description = "Compare PortalJS with other data portals: OpenDataSoft, CKAN, Socrata and more. See the advantages of our open source approach.";
-  const canonical = "https://portaljs.com/compare";
+  const canonical = "https://www.portaljs.com/compare";
 
 
   return (
@@ -71,8 +71,8 @@ export default function CompareIndex() {
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* SEO */}
           <OrganizationJsonLd
-            url="https://portaljs.com"
-            logo="https://portaljs.com/icon.png"
+            url="https://www.portaljs.com"
+            logo="https://www.portaljs.com/icon.png"
           />
           <Head>
             {generateNextSeo({
@@ -80,12 +80,12 @@ export default function CompareIndex() {
               description: description,
               canonical: canonical,
               openGraph: {
-              url: 'https://portaljs.com/compare',
+              url: 'https://www.portaljs.com/compare',
               title,
               description,
               images: [
                 {
-                  url: 'https://portaljs.com/static/img/seo.webp',
+                  url: 'https://www.portaljs.com/static/img/seo.webp',
                   width: 1200,
                   height: 630,
                   alt: 'PortalJS Comparisons',
@@ -104,7 +104,7 @@ export default function CompareIndex() {
               },
               {
                 name: 'Compare',
-                item: 'https://portaljs.com/compare',
+                item: 'https://www.portaljs.com/compare',
               }
             ]}
           />

--- a/site/pages/compare/opendatasoft.tsx
+++ b/site/pages/compare/opendatasoft.tsx
@@ -167,21 +167,21 @@ export default function PortalJSvsOpenDataSoft() {
     <Layout isHomePage={true}>
       {/* SEO */}
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Head>
         {generateNextSeo({
           title: "PortalJS vs OpenDataSoft | Open Source Data Portal Comparison",
           description: "Compare PortalJS with OpenDataSoft: See how our open source data portal platform stacks up against proprietary solutions in features, flexibility, and cost.",
-          canonical: "https://portaljs.com/compare/opendatasoft",
+          canonical: "https://www.portaljs.com/compare/opendatasoft",
           openGraph: {
-          url: 'https://portaljs.com/compare/opendatasoft',
+          url: 'https://www.portaljs.com/compare/opendatasoft',
           title: 'PortalJS vs OpenDataSoft | Open Source Data Portal Comparison',
           description: 'Compare PortalJS with OpenDataSoft: See how our open source data portal platform stacks up against proprietary solutions in features, flexibility, and cost.',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
               width: 1200,
               height: 630,
               alt: 'PortalJS vs OpenDataSoft Comparison',
@@ -200,11 +200,11 @@ export default function PortalJSvsOpenDataSoft() {
           },
           {
             name: 'Compare',
-            item: 'https://portaljs.com/compare',
+            item: 'https://www.portaljs.com/compare',
           },
           {
             name: 'OpenDataSoft',
-            item: 'https://portaljs.com/compare/opendatasoft',
+            item: 'https://www.portaljs.com/compare/opendatasoft',
           }
         ]}
       />

--- a/site/pages/compare/socrata.tsx
+++ b/site/pages/compare/socrata.tsx
@@ -192,21 +192,21 @@ export default function PortalJSvsSocrata() {
     <Layout isHomePage={true}>
       {/* SEO */}
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Head>
         {generateNextSeo({
           title: "PortalJS vs Socrata | Open Source Data Portal Comparison",
           description: "Compare PortalJS with Socrata: See how our open source data portal platform delivers more flexibility, control, and cost savings than Socrata's proprietary solution.",
-          canonical: "https://portaljs.com/compare/socrata",
+          canonical: "https://www.portaljs.com/compare/socrata",
           openGraph: {
-          url: 'https://portaljs.com/compare/socrata',
+          url: 'https://www.portaljs.com/compare/socrata',
           title: 'PortalJS vs Socrata | Open Source Data Portal Comparison',
           description: 'Compare PortalJS with Socrata: See how our open source data portal platform delivers more flexibility, control, and cost savings than Socrata\'s proprietary solution.',
           images: [
             {
-              url: 'https://portaljs.com/static/img/seo.webp',
+              url: 'https://www.portaljs.com/static/img/seo.webp',
               width: 1200,
               height: 630,
               alt: 'PortalJS vs Socrata Comparison',
@@ -225,11 +225,11 @@ export default function PortalJSvsSocrata() {
           },
           {
             name: 'Compare',
-            item: 'https://portaljs.com/compare',
+            item: 'https://www.portaljs.com/compare',
           },
           {
             name: 'Socrata',
-            item: 'https://portaljs.com/compare/socrata',
+            item: 'https://www.portaljs.com/compare/socrata',
           }
         ]}
       />

--- a/site/pages/data-portals.tsx
+++ b/site/pages/data-portals.tsx
@@ -1,19 +1,10 @@
 import Layout from '@/components/Layout'
 import Showcases from '@/components/Showcases'
-import { generateNextSeo } from 'next-seo/pages';
-import Head from 'next/head';
 import { DataPortalsStructuredData } from '@/components/schema/DataPortalStructuredData'
 
 export default function DataPortalsPage() {
   return (
     <Layout isHomePage={true}>
-      <Head>
-        {generateNextSeo({
-          title: "Data Portals Showcase | PortalJS",
-          description: "Explore live data portals built with PortalJS. Government, research, and enterprise data portals showcasing real-world implementations.",
-          canonical: "https://portaljs.org/data-portals",
-        })}
-      </Head>
       <DataPortalsStructuredData />
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12 w-full">

--- a/site/pages/datahub.tsx
+++ b/site/pages/datahub.tsx
@@ -38,16 +38,16 @@ export default function DataHub() {
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           <OrganizationJsonLd
-            url="https://portaljs.com"
-            logo="https://portaljs.com/icon.png"
+            url="https://www.portaljs.com"
+            logo="https://www.portaljs.com/icon.png"
           />
           <Head>
             {generateNextSeo({
               title: "Turn DataHub into a Business-Friendly Data Catalog",
               description: "Transform DataHub's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single DataHub instance.",
-              canonical: "https://portaljs.com/datahub",
+              canonical: "https://www.portaljs.com/datahub",
               openGraph: {
-              url: 'https://portaljs.com/datahub',
+              url: 'https://www.portaljs.com/datahub',
               title: 'Turn DataHub into a Business-Friendly Data Catalog',
               description: 'Transform DataHub\'s technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single DataHub instance.',
               site_name: 'PortalJS',
@@ -62,7 +62,7 @@ export default function DataHub() {
               },
               {
                 name: 'DataHub',
-                item: 'https://portaljs.com/datahub',
+                item: 'https://www.portaljs.com/datahub',
               },
             ]}
           />

--- a/site/pages/faq.tsx
+++ b/site/pages/faq.tsx
@@ -2,8 +2,6 @@ import { Disclosure, Tab } from '@headlessui/react'
 import ReactMarkdown from 'react-markdown'
 import Layout from '@/components/Layout'
 import React from 'react'
-import { generateNextSeo } from 'next-seo/pages';
-import Head from 'next/head';
 import { FaqStructuredData } from '@/components/schema/FaqStructuredData'
 
 export const questions = [
@@ -238,12 +236,6 @@ See more details on our [pricing page](https://portaljs.com/pricing).`,
 export default function FAQ() {
   return (
     <Layout isHomePage={true}>
-      <Head>
-        {generateNextSeo({
-          title: "FAQ",
-          description: "Frequently Asked Questions about PortalJS Cloud.",
-        })}
-      </Head>
       <FaqStructuredData />
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12 w-full">

--- a/site/pages/features.tsx
+++ b/site/pages/features.tsx
@@ -16,6 +16,8 @@ import { TiCloudStorage } from "react-icons/ti";
 import { AiOutlineDatabase } from "react-icons/ai";
 import { MdVerified } from "react-icons/md";
 import { FaSyncAlt } from "react-icons/fa";
+import Head from "next/head";
+import { generateNextSeo } from "next-seo/pages";
 
 import Layout from "@/components/Layout";
 
@@ -141,6 +143,33 @@ const statsData = [
 const StatsPage = () => {
   return (
     <Layout>
+      <Head>
+        {generateNextSeo({
+          title: "Features | PortalJS Cloud — Open Data Portal Capabilities",
+          description: "Explore all PortalJS Cloud features: 5-minute deployment, 99.9% uptime, unlimited datasets, built-in search, API access, security compliance, and managed infrastructure.",
+          canonical: "https://www.portaljs.com/features",
+          openGraph: {
+            url: 'https://www.portaljs.com/features',
+            title: 'Features | PortalJS Cloud — Open Data Portal Capabilities',
+            description: 'Explore all PortalJS Cloud features: 5-minute deployment, 99.9% uptime, unlimited datasets, built-in search, API access, security compliance, and managed infrastructure.',
+            site_name: 'PortalJS',
+            type: 'website',
+            images: [
+              {
+                url: 'https://www.portaljs.com/static/img/seo.webp',
+                alt: 'PortalJS Cloud Features',
+                width: 1280,
+                height: 720,
+                type: 'image/webp',
+              },
+            ],
+          },
+          twitter: {
+            cardType: 'summary_large_image',
+            site: '@PortalJS_',
+          },
+        })}
+      </Head>
       <div>
         <h1
           className="text-4xl font-bold text-center text-primary dark:text-primary-dark"

--- a/site/pages/git.tsx
+++ b/site/pages/git.tsx
@@ -17,17 +17,17 @@ export default function Git() {
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
           <OrganizationJsonLd
-            url="https://portaljs.com"
-            logo="https://portaljs.com/icon.png"
+            url="https://www.portaljs.com"
+            logo="https://www.portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
           <Head>
             {generateNextSeo({
               title: "Git-Backed Data Portals | Version-Controlled Data with PortalJS",
               description: "Build modern data portals using Git as your data source. Leverage GitHub, GitLab, or any Git repository for version-controlled, collaborative data management with PortalJS.",
-              canonical: "https://portaljs.com/git",
+              canonical: "https://www.portaljs.com/git",
               openGraph: {
-              url: 'https://portaljs.com/git',
+              url: 'https://www.portaljs.com/git',
               title: 'Git-Backed Data Portals | Version-Controlled Data with PortalJS',
               description: 'Build modern data portals using Git as your data source. Leverage GitHub, GitLab, or any Git repository for version-controlled, collaborative data management with PortalJS.',
               site_name: 'PortalJS',
@@ -43,7 +43,7 @@ export default function Git() {
               },
               {
                 name: 'Git Integration',
-                item: 'https://portaljs.com/git',
+                item: 'https://www.portaljs.com/git',
               },
             ]}
           />

--- a/site/pages/learn/index.tsx
+++ b/site/pages/learn/index.tsx
@@ -62,9 +62,9 @@ const LearnPage = () => {
         {generateNextSeo({
           title: "Learn Data Management",
           description: "Master the fundamentals of data management through our comprehensive learning paths. Choose a topic below to explore in-depth guides and best practices.",
-          canonical: "https://portaljs.com/learn",
+          canonical: "https://www.portaljs.com/learn",
           openGraph: {
-          url: 'https://portaljs.com/learn',
+          url: 'https://www.portaljs.com/learn',
           title: 'Learn Data Management',
           description: 'Master the fundamentals of data management through our comprehensive learning paths. Choose a topic below to explore in-depth guides and best practices.',
           site_name: 'PortalJS',

--- a/site/pages/learn/metadata.tsx
+++ b/site/pages/learn/metadata.tsx
@@ -38,9 +38,9 @@ const MetadataLearnPage = () => {
         {generateNextSeo({
           title: "Metadata Fundamentals | Learn Data Management",
           description: "Master the fundamentals of metadata—what it is, how it works, and why it's essential for data discovery and management. Learn about metadata schemas, standards, and best practices.",
-          canonical: "https://portaljs.com/learn/metadata",
+          canonical: "https://www.portaljs.com/learn/metadata",
           openGraph: {
-          url: 'https://portaljs.com/learn/metadata',
+          url: 'https://www.portaljs.com/learn/metadata',
           title: 'Metadata Fundamentals | Learn Data Management',
           description: 'Master the fundamentals of metadata—what it is, how it works, and why it\'s essential for data discovery and management. Learn about metadata schemas, standards, and best practices.',
           site_name: 'PortalJS',

--- a/site/pages/openmetadata.tsx
+++ b/site/pages/openmetadata.tsx
@@ -40,17 +40,17 @@ export default function OpenMetadata() {
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
           <OrganizationJsonLd
-            url="https://portaljs.com"
-            logo="https://portaljs.com/icon.png"
+            url="https://www.portaljs.com"
+            logo="https://www.portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
           <Head>
             {generateNextSeo({
               title: "Turn OpenMetadata into a Business-Friendly Data Catalog",
               description: "Transform OpenMetadata's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single OpenMetadata instance.",
-              canonical: "https://portaljs.com/openmetadata",
+              canonical: "https://www.portaljs.com/openmetadata",
               openGraph: {
-              url: 'https://portaljs.com/openmetadata',
+              url: 'https://www.portaljs.com/openmetadata',
               title: 'Turn OpenMetadata into a Business-Friendly Data Catalog',
               description: 'Transform OpenMetadata\'s technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single OpenMetadata instance.',
               site_name: 'PortalJS',
@@ -66,7 +66,7 @@ export default function OpenMetadata() {
               },
               {
                 name: 'OpenMetadata',
-                item: 'https://portaljs.com/openmetadata',
+                item: 'https://www.portaljs.com/openmetadata',
               },
             ]}
           />

--- a/site/pages/opensource.tsx
+++ b/site/pages/opensource.tsx
@@ -12,13 +12,34 @@ export default function OSS() {
     <>
       <Head>
         {generateNextSeo({
-          title: "The JavaScript framework for data portals",
-          description: "Rapidly build rich data portals using a modern frontend framework. Native support for CKAN backend and more.",
+          title: "PortalJS Open Source | JavaScript Framework for Data Portals",
+          description: "Rapidly build rich open data portals using PortalJS — the modern, headless JavaScript framework. Native support for CKAN, OpenMetadata, and more.",
+          canonical: "https://www.portaljs.com/opensource",
+          openGraph: {
+            url: 'https://www.portaljs.com/opensource',
+            title: 'PortalJS Open Source | JavaScript Framework for Data Portals',
+            description: 'Rapidly build rich open data portals using PortalJS — the modern, headless JavaScript framework. Native support for CKAN, OpenMetadata, and more.',
+            site_name: 'PortalJS',
+            type: 'website',
+            images: [
+              {
+                url: 'https://www.portaljs.com/static/img/seo.webp',
+                alt: 'PortalJS Open Source',
+                width: 1280,
+                height: 720,
+                type: 'image/webp',
+              },
+            ],
+          },
+          twitter: {
+            cardType: 'summary_large_image',
+            site: '@PortalJS_',
+          },
         })}
       </Head>
       <OrganizationJsonLd
-        url="https://portaljs.org"
-        logo="https://portaljs.org/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
       <Layout>
         <Hero />

--- a/site/pages/partners.tsx
+++ b/site/pages/partners.tsx
@@ -75,14 +75,14 @@ export default function Partners() {
         {generateNextSeo({
           title: "PortalJS Partnership Program | Collaborate on Open Data Portals",
           description: "Join the PortalJS Partnership Program to deliver innovative open data solutions across governments, non-profits, academia, and businesses.",
-          canonical: "https://portaljs.com/partners",
+          canonical: "https://www.portaljs.com/partners",
           openGraph: {
-            url: 'https://portaljs.com/partners',
+            url: 'https://www.portaljs.com/partners',
             title: 'PortalJS Partnership Program | Collaborate on Open Data Portals',
             description: 'Join the PortalJS Partnership Program to deliver innovative open data solutions across governments, non-profits, academia, and businesses.',
             images: [
               {
-                url: 'https://portaljs.com/static/img/seo.webp',
+                url: 'https://www.portaljs.com/static/img/seo.webp',
                 width: 1200,
                 height: 630,
                 alt: 'PortalJS Partnerships',
@@ -93,8 +93,8 @@ export default function Partners() {
         })}
       </Head>
       <OrganizationJsonLd
-        url="https://portaljs.com"
-        logo="https://portaljs.com/icon.png"
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
       />
 
       {/* Hero */}

--- a/site/pages/pricing.tsx
+++ b/site/pages/pricing.tsx
@@ -9,8 +9,29 @@ export default function Pricing() {
     <Layout>
       <Head>
         {generateNextSeo({
-          title: "Pricing",
-          description: "Find the best plan for you, our plans cover all ranges of budgets and needs. Leverage your Open Data Portal with optional add-ons.",
+          title: "Pricing | PortalJS Cloud — Open Data Portal Plans",
+          description: "Simple, transparent pricing for PortalJS Cloud. Managed open data portals for governments, nonprofits, and enterprises — pay-as-you-go with no infrastructure overhead.",
+          canonical: "https://www.portaljs.com/pricing",
+          openGraph: {
+            url: 'https://www.portaljs.com/pricing',
+            title: 'Pricing | PortalJS Cloud — Open Data Portal Plans',
+            description: 'Simple, transparent pricing for PortalJS Cloud. Managed open data portals for governments, nonprofits, and enterprises — pay-as-you-go with no infrastructure overhead.',
+            site_name: 'PortalJS',
+            type: 'website',
+            images: [
+              {
+                url: 'https://www.portaljs.com/static/img/seo.webp',
+                alt: 'PortalJS Cloud Pricing',
+                width: 1280,
+                height: 720,
+                type: 'image/webp',
+              },
+            ],
+          },
+          twitter: {
+            cardType: 'summary_large_image',
+            site: '@PortalJS_',
+          },
         })}
       </Head>
       <div className="overflow-hidden">

--- a/site/pages/purview.tsx
+++ b/site/pages/purview.tsx
@@ -39,17 +39,17 @@ export default function Purview() {
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           {/* 1. Your logo structured data */}
           <OrganizationJsonLd
-            url="https://portaljs.com"
-            logo="https://portaljs.com/icon.png"
+            url="https://www.portaljs.com"
+            logo="https://www.portaljs.com/icon.png"
           />
           {/* 2. Base SEO tags */}
           <Head>
             {generateNextSeo({
               title: "Turn Microsoft Purview into a Business-Friendly Data Catalog",
               description: "Transform Microsoft Purview's technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single Microsoft Purview instance.",
-              canonical: "https://portaljs.com/purview",
+              canonical: "https://www.portaljs.com/purview",
               openGraph: {
-              url: 'https://portaljs.com/purview',
+              url: 'https://www.portaljs.com/purview',
               title: 'Turn Microsoft Purview into a Business-Friendly Data Catalog',
               description: 'Transform Microsoft Purview\'s technical interface into intuitive data catalogs for business users. Create multiple user-specific portals from a single Microsoft Purview instance.',
               site_name: 'PortalJS',
@@ -65,7 +65,7 @@ export default function Purview() {
               },
               {
                 name: 'Microsoft Purview',
-                item: 'https://portaljs.com/purview',
+                item: 'https://www.portaljs.com/purview',
               },
             ]}
           />

--- a/site/pages/solutions/open-data.tsx
+++ b/site/pages/solutions/open-data.tsx
@@ -15,12 +15,51 @@ import { Security } from '@/components/home/Security'
 import FAQ from '@/components/home/FAQ'
 import Community from '@/components/home/community'
 import UserJourney from '@/components/home/UserJourney'
-import { HomePageStructuredData } from '@/components/schema/HomePageStructuredData'
+import Head from 'next/head'
+import { generateNextSeo } from 'next-seo/pages'
+import { BreadcrumbJsonLd, OrganizationJsonLd } from 'next-seo'
 
 export default function OpenDataSolutionsPage() {
   return (
     <Layout isHomePage={true}>
-      <HomePageStructuredData />
+      <Head>
+        {generateNextSeo({
+          title: "Open Data Portal Solutions | PortalJS Cloud for Governments & Nonprofits",
+          description: "PortalJS Cloud is the managed open data portal solution for governments, nonprofits, and research institutions. Launch in minutes, zero infrastructure overhead.",
+          canonical: "https://www.portaljs.com/solutions/open-data",
+          openGraph: {
+            url: 'https://www.portaljs.com/solutions/open-data',
+            title: 'Open Data Portal Solutions | PortalJS Cloud for Governments & Nonprofits',
+            description: 'PortalJS Cloud is the managed open data portal solution for governments, nonprofits, and research institutions. Launch in minutes, zero infrastructure overhead.',
+            site_name: 'PortalJS',
+            type: 'website',
+            images: [
+              {
+                url: 'https://www.portaljs.com/static/img/seo.webp',
+                alt: 'PortalJS Cloud — Open Data Solutions',
+                width: 1280,
+                height: 720,
+                type: 'image/webp',
+              },
+            ],
+          },
+          twitter: {
+            cardType: 'summary_large_image',
+            site: '@PortalJS_',
+          },
+        })}
+      </Head>
+      <OrganizationJsonLd
+        url="https://www.portaljs.com"
+        logo="https://www.portaljs.com/icon.png"
+      />
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', item: 'https://www.portaljs.com' },
+          { name: 'Solutions', item: 'https://www.portaljs.com/solutions' },
+          { name: 'Open Data', item: 'https://www.portaljs.com/solutions/open-data' },
+        ]}
+      />
       <div className="flex justify-center">
         <div className="max-w-8xl px-4 sm:px-8 xl:px-12">
           <Hero />


### PR DESCRIPTION
## Summary

Site-wide SEO audit addressing canonical fragmentation, duplicate meta injection, stale structured data, and missing SEO on several pages. No UI or logic changes — purely meta/SEO layer.

### What was broken

- **Wrong canonical domains**: 2 pages used `portaljs.org` (not the real domain), 18 pages used non-www `portaljs.com` while structured data components used `www.portaljs.com` — Google sees these as different URLs
- **Duplicate SEO injection**: `case-studies.tsx`, `data-portals.tsx`, and `faq.tsx` each had both an inline `generateNextSeo` AND a structured data component injecting conflicting canonicals into the same page
- **Stale structured data**: `CaseStudiesStructuredData` and `DataPortalStructuredData` both pointed to `/showcase` (URL no longer exists), with placeholder-quality titles ("See our client stories.")
- **Missing SEO entirely**: `features.tsx` and `solutions/open-data.tsx` had no title/description/canonical at all; `solutions/open-data.tsx` was using `HomePageStructuredData` (homepage canonical on a different page)
- **Thin titles**: "FAQ", "Blog", "Pricing", "Showcase of Case Studies" — bare words that waste title tag real estate
- **Global defaults**: Twitter handle `@datopian` (not the product handle), no `og:site_name`, non-www OG image URL

### Changes

| Area | What changed |
|------|-------------|
| `next-sitemap.config.js` | Base URL → `https://www.portaljs.com` |
| `content/config.js` | Twitter `@datopian` → `@PortalJS_`; add `og:site_name`; fix OG image URL |
| `CaseStudiesStructuredData` | Fix `/showcase` → `/case-studies`; proper title + description |
| `DataPortalStructuredData` | Fix `/showcase` → `/data-portals`; proper title + description |
| `BlogStructuredData`, `FaqStructuredData`, `HomePageStructuredData` | Fix OG image URLs; improve titles |
| `case-studies.tsx`, `data-portals.tsx`, `faq.tsx` | Remove duplicate inline `generateNextSeo` (schema components handle it) |
| `features.tsx` | Add full SEO block (was completely missing) |
| `solutions/open-data.tsx` | Replace `HomePageStructuredData` with page-specific SEO + correct breadcrumb |
| `opensource.tsx` | Fix `portaljs.org` → `www.portaljs.com`; add canonical + full OG |
| 16× pages (`compare/*`, `git`, `ckan`, `openmetadata`, `purview`, `datahub`, `partners`, `learn/*`) | Non-www → www on all canonical, OG url, and OrganizationJsonLd urls |

### No conflicts with open PRs
- PR #1597 (`feat/case-study-layout-redesign`) — touches `layouts/casestudy.tsx` only, no overlap
- PR #1598 (`feat/case-study-faq-content`) — touches `.md` content files only, no overlap

## Test plan

- [ ] Build passes (`next build`)
- [ ] Verify no duplicate `<link rel="canonical">` tags appear on `/case-studies`, `/data-portals`, `/faq`
- [ ] Check Google Rich Results Test on homepage, `/case-studies`, `/faq` for valid structured data
- [ ] Confirm `/solutions/open-data` canonical is `https://www.portaljs.com/solutions/open-data` (not the homepage)
- [ ] Confirm `/features` now has a title tag and canonical
- [ ] Spot-check Twitter card meta shows `@PortalJS_` not `@datopian`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **SEO Enhancements**
  * Standardized domain to www.portaljs.com across the platform
  * Updated page metadata, titles, and descriptions for improved search discoverability
  * Enhanced Open Graph and Twitter card information for social sharing
  * Refined structured data for comparison pages, features, and pricing documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->