### PR TITLE
fix(footer): simplify to 3 columns × 4 items each

### DIFF
--- a/site/components/custom/Footer.tsx
+++ b/site/components/custom/Footer.tsx
@@ -3,25 +3,21 @@ import { NavbarTitle } from '../Nav'
 import { RiDiscordFill } from 'react-icons/ri'
 
 const navigation = {
-  resources: [
+  product: [
+    { name: 'Pricing', href: '/pricing' },
     { name: 'Case Studies', href: '/case-studies' },
     { name: 'Data Portals', href: '/data-portals' },
-    { name: 'Learn', href: '/learn' },
-    { name: 'Documentation', href: '/docs' },
-    { name: 'Blog', href: '/blog' },
     { name: 'FAQ', href: '/faq' },
-    { name: 'Open Source', href: '/opensource' },
   ],
-  integrations: [
-    { name: 'CKAN Integration', href: '/ckan' },
-    { name: 'OpenMetadata Integration', href: '/openmetadata' },
-    { name: 'Comparison Overview', href: '/compare' },
-    { name: 'PortalJS vs OpenDataSoft', href: '/compare/opendatasoft' },
+  resources: [
+    { name: 'Blog', href: '/blog' },
+    { name: 'Documentation', href: '/docs' },
+    { name: 'Learn', href: '/learn' },
+    { name: 'Open Source', href: '/opensource' },
   ],
   companyLegal: [
     { name: 'About Us', href: 'https://www.datopian.com/about' },
     { name: 'Contact', href: 'https://www.datopian.com/contact' },
-    { name: 'Pricing', href: '/pricing' },
     { name: 'Privacy Policy', href: 'https://www.datopian.com/privacy' },
     { name: 'Terms of Use', href: 'https://www.datopian.com/terms' },
   ],
@@ -132,9 +128,9 @@ export default function Footer() {
           </div>
           <div className="mt-16 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 xl:col-span-2 xl:mt-0">
             <div className="mt-10 md:mt-0">
-              <h3 className="text-sm font-semibold leading-6">Resources</h3>
+              <h3 className="text-sm font-semibold leading-6">Product</h3>
               <ul role="list" className="mt-6 space-y-4">
-                {navigation.resources.map((item) => (
+                {navigation.product.map((item) => (
                   <li key={item.name}>
                     <a
                       href={item.href}
@@ -148,13 +144,12 @@ export default function Footer() {
               </ul>
             </div>
             <div className="mt-10 md:mt-0">
-              <h3 className="text-sm font-semibold leading-6">Integrations & Comparisons</h3>
+              <h3 className="text-sm font-semibold leading-6">Resources</h3>
               <ul role="list" className="mt-6 space-y-4">
-                {navigation.integrations.map((item: any) => (
+                {navigation.resources.map((item: any) => (
                   <li key={item.name}>
                     <a
                       href={item.href}
-                      target={item.target || '_self'}
                       className="text-sm leading-6 opacity-75 hover:opacity-100"
                     >
                       {item.name}

--- a/site/components/custom/Footer.tsx
+++ b/site/components/custom/Footer.tsx
@@ -151,6 +151,7 @@ export default function Footer() {
                     <a
                       href={item.href}
                       className="text-sm leading-6 opacity-75 hover:opacity-100"
+                      aria-label={`link to ${item.name}`}
                     >
                       {item.name}
                     </a>
@@ -167,6 +168,7 @@ export default function Footer() {
                       href={item.href}
                       target={item.target || '_self'}
                       className="text-sm leading-6 opacity-75 hover:opacity-100"
+                      aria-label={`link to ${item.name}`}
                     >
                       {item.name}
                     </a>


### PR DESCRIPTION
## Summary

Cleans up the footer from an overloaded 3-column layout to a clear, scannable structure: 3 columns, 4 items each.

| Before | After |
|--------|-------|
| Resources (7 items) | **Product** — Pricing, Case Studies, Data Portals, FAQ |
| Integrations & Comparisons (4 items) | **Resources** — Blog, Documentation, Learn, Open Source |
| Company & Legal (5 items) | **Company & Legal** — About Us, Contact, Privacy Policy, Terms of Use |

The Integrations & Comparisons column is removed — those pages are discoverable via the "Explore more" strips on each integration/compare page (added in #1600).

## No conflicts

Only touches `components/custom/Footer.tsx`. Independent of all open PRs (#1597, #1598, #1599, #1600, #1601) — targets `main` directly.

## Test plan

- [ ] Footer renders 3 columns with 4 items each
- [ ] All links resolve correctly
- [ ] Dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the footer navigation layout by introducing a **Product** link group (including Pricing, Case Studies, Data Portals, and FAQ).
  * Reordered the footer columns so **Resources** appears in a new position.
  * Removed the **Integrations & Comparisons** section from the footer.
* **Accessibility**
  * Improved footer link accessibility by adding descriptive labeling to “Company & Legal” items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->