### PR TITLE
feat(cloud): PortalJS Arc production config + go-live runbook

### DIFF
--- a/cloud/GO-LIVE.md
+++ b/cloud/GO-LIVE.md
@@ -1,0 +1,60 @@
+# PortalJS Arc — production go-live runbook
+
+Staging is live and verified. This is the checklist to take Arc to production at
+`*.arc.portaljs.com`. Prod wrangler configs live in each worker's `[env.production]` block
+(deploy with `--env production`).
+
+## Already done (by prep)
+- ✅ R2 bucket `portaljs-arc` created.
+- ✅ D1 database `portaljs-arc` created (`ce13c71f-d039-45f3-95d0-f8005ed986e4`) + migrations applied (`users`, `tokens`, `projects`, `deployments`, `device_codes`).
+- ✅ ACM certs cover `*.arc.portaljs.com`, `arc.portaljs.com`, `*.staging.arc.portaljs.com`, `portaljs.com`.
+- ✅ `[env.production]` blocks in `cloud/{worker,api,auth}/wrangler.toml` (names `arc-router` / `arc-api` / `arc-auth`, prod bucket/DB/routes).
+
+## Human steps remaining
+
+### 1. DNS records (proxied) on the `portaljs.com` zone
+Workers routes need a matching proxied DNS record. Add:
+- `*.arc.portaljs.com` → e.g. `AAAA 100::` **proxied** (mirrors the staging `*.staging.arc` record). Covers tenant sites via the router.
+- `arc.portaljs.com` → `AAAA 100::` **proxied** (dashboard/auth).
+- `api.arc.portaljs.com` → `AAAA 100::` **proxied** (deploy API).
+
+### 2. Production GitHub OAuth app
+Create a NEW OAuth app (separate from staging):
+- Homepage: `https://arc.portaljs.com`
+- Callback: `https://arc.portaljs.com/auth/callback`
+- Scope used: `read:user`
+
+Put its **client ID** into `cloud/auth/wrangler.toml` → `[env.production.vars] GITHUB_CLIENT_ID`
+(replacing `REPLACE_WITH_PROD_OAUTH_CLIENT_ID`). Client ID is not a secret.
+
+### 3. Deploy the three workers
+```bash
+cd cloud/worker && npx wrangler deploy --env production   # arc-router → *.arc.portaljs.com
+cd ../api       && npx wrangler deploy --env production   # arc-api    → api.arc.portaljs.com
+cd ../auth      && npx wrangler deploy --env production   # arc-auth   → arc.portaljs.com
+```
+
+### 4. Production secrets (auth worker)
+```bash
+cd cloud/auth
+npx wrangler secret put GITHUB_CLIENT_SECRET --env production   # from the prod OAuth app
+npx wrangler secret put SESSION_SECRET --env production         # openssl rand -hex 32
+```
+(Router + API need no secrets.)
+
+### 5. Smoke test (mirror the staging verification)
+```bash
+curl -s https://api.arc.portaljs.com/healthz                 # {"ok":true}
+curl -s -o /dev/null -w "%{http_code}\n" https://api.arc.portaljs.com/v1/whoami   # 401
+curl -s -o /dev/null -w "%{http_code}\n" https://arc.portaljs.com/auth/login      # 302 → github
+```
+Then a real end-to-end deploy (prod defaults, no `PORTALJS_ARC_*` overrides):
+```bash
+cd /tmp && npm create portaljs@latest prod-smoke && cd prod-smoke
+/portaljs-deploy        # sign in → authorize → live at https://<slug>.arc.portaljs.com
+```
+Clean up the smoke portal afterwards (delete its R2 objects under `sites/<slug>/` + its D1 rows).
+
+## Notes
+- The `/portaljs-deploy` skill already defaults to prod (`arc.portaljs.com` / `api.arc.portaljs.com`); no override env vars needed once prod is live.
+- Staging stays as-is — bare `wrangler deploy` (no `--env`) still targets the `-staging` workers.

--- a/cloud/api/wrangler.toml
+++ b/cloud/api/wrangler.toml
@@ -23,3 +23,27 @@ database_id = "9727b25f-471b-4942-8b16-b9da2391122a"
 # [[routes]]
 # pattern = "api.staging.arc.portaljs.com/*"
 # zone_name = "portaljs.com"
+
+# --- Production --- deploy with: wrangler deploy --env production
+# Prereq: proxied DNS record for api.arc.portaljs.com + ACM cert (covered by *.arc).
+[env.production]
+name = "arc-api"
+workers_dev = false
+
+[env.production.vars]
+ARC_HOST = "arc.portaljs.com"
+MAX_FILES = "5000"
+MAX_BYTES = "104857600"
+
+[[env.production.r2_buckets]]
+binding = "ASSETS"
+bucket_name = "portaljs-arc"
+
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "portaljs-arc"
+database_id = "ce13c71f-d039-45f3-95d0-f8005ed986e4"
+
+[[env.production.routes]]
+pattern = "api.arc.portaljs.com/*"
+zone_name = "portaljs.com"

--- a/cloud/auth/wrangler.toml
+++ b/cloud/auth/wrangler.toml
@@ -16,7 +16,24 @@ binding = "DB"
 database_name = "portaljs-arc-staging"
 database_id = "9727b25f-471b-4942-8b16-b9da2391122a"
 
-# Production route (added with the GitHub OAuth app at go-live):
-# [[routes]]
-# pattern = "arc.portaljs.com/*"
-# zone_name = "portaljs.com"
+# --- Production --- deploy with: wrangler deploy --env production
+# Prereq: proxied DNS record for arc.portaljs.com + ACM cert (already enabled) + a
+# PRODUCTION GitHub OAuth app (callback https://arc.portaljs.com/auth/callback). Set
+# GITHUB_CLIENT_ID below to that app's client ID before first prod deploy; set
+# GITHUB_CLIENT_SECRET + SESSION_SECRET via `wrangler secret put --env production`.
+[env.production]
+name = "arc-auth"
+workers_dev = false
+
+[env.production.vars]
+BASE_URL = "https://arc.portaljs.com"
+GITHUB_CLIENT_ID = "REPLACE_WITH_PROD_OAUTH_CLIENT_ID"
+
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "portaljs-arc"
+database_id = "ce13c71f-d039-45f3-95d0-f8005ed986e4"
+
+[[env.production.routes]]
+pattern = "arc.portaljs.com/*"
+zone_name = "portaljs.com"

--- a/cloud/worker/wrangler.toml
+++ b/cloud/worker/wrangler.toml
@@ -17,3 +17,19 @@ bucket_name = "portaljs-arc-staging"
 [[routes]]
 pattern = "*.staging.arc.portaljs.com/*"
 zone_name = "portaljs.com"
+
+# --- Production --- deploy with: wrangler deploy --env production
+# Prereq: proxied DNS record for *.arc.portaljs.com (e.g. AAAA 100:: proxied) + ACM cert
+# for *.arc.portaljs.com (already enabled). Named envs do NOT inherit top-level bindings/
+# routes — everything is redeclared below.
+[env.production]
+name = "arc-router"
+workers_dev = false
+
+[[env.production.r2_buckets]]
+binding = "ASSETS"
+bucket_name = "portaljs-arc"
+
+[[env.production.routes]]
+pattern = "*.arc.portaljs.com/*"
+zone_name = "portaljs.com"


### PR DESCRIPTION
## What
Prep for taking PortalJS Arc to production (`*.arc.portaljs.com`). Follow-on to the verified staging deploy.

- `[env.production]` blocks in `cloud/{worker,api,auth}/wrangler.toml` — workers `arc-router` / `arc-api` / `arc-auth`, prod routes (`*.arc`, `api.arc`, `arc.portaljs.com`), prod R2 bucket `portaljs-arc`, prod D1 `portaljs-arc` (`ce13c71f-d039-45f3-95d0-f8005ed986e4`).
- `cloud/GO-LIVE.md` — the remaining human runbook.

## Already provisioned by this prep
- ✅ R2 bucket `portaljs-arc`
- ✅ D1 `portaljs-arc` + migrations applied (users/tokens/projects/deployments/device_codes)

## Still needs a human (see GO-LIVE.md)
1. Proxied DNS records for `*.arc`, `arc`, `api.arc`.portaljs.com
2. Production GitHub OAuth app → put client ID into `[env.production.vars] GITHUB_CLIENT_ID`
3. `wrangler deploy --env production` (×3)
4. `wrangler secret put GITHUB_CLIENT_SECRET / SESSION_SECRET --env production`
5. Smoke test + real `/portaljs-deploy`

## Safety
Staging untouched: bare `wrangler deploy` still targets `-staging`. No prod worker is deployed by this PR (needs secrets + DNS first), and no DNS is modified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added production go-live checklist and deployment runbook.

* **Chores**
  * Configured production environment settings for API, authentication, and routing services across core infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->