### PR TITLE
fix(cloud/auth): pin production GITHUB_CLIENT_ID

### DIFF
--- a/cloud/auth/wrangler.toml
+++ b/cloud/auth/wrangler.toml
@@ -27,7 +27,7 @@ workers_dev = false
 
 [env.production.vars]
 BASE_URL = "https://arc.portaljs.com"
-GITHUB_CLIENT_ID = "REPLACE_WITH_PROD_OAUTH_CLIENT_ID"
+GITHUB_CLIENT_ID = "Ov23liIIMttPpNtaa9o7"
 
 [[env.production.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
Prod Arc is live and verified end-to-end. The deployed `arc-auth` worker has the production OAuth app's client ID, but `main` still had `REPLACE_WITH_PROD_OAUTH_CLIENT_ID` — a clean `wrangler deploy --env production` would ship the placeholder and break sign-in. Client ID is not a secret. Mirrors #1592 (staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration with updated authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->