### PR TITLE
docs: align skills reference with the actual skill suite (Arc audit)

### DIFF
--- a/site/content/docs/authoring-skills.md
+++ b/site/content/docs/authoring-skills.md
@@ -99,7 +99,7 @@ with a "next step" pointer if another skill naturally follows.
 
 ## Where to go next
 
-- **[Skills reference](/docs/skills)** — the six skills to model yours on.
+- **[Skills reference](/docs/skills)** — the full skill suite to model yours on.
 - **[The PortalJS vision](https://github.com/datopian/portaljs/blob/main/VISION.md)** —
   the roadmap of upcoming skill families.
 

--- a/site/content/docs/skills.md
+++ b/site/content/docs/skills.md
@@ -1,6 +1,6 @@
 ---
 metatitle: PortalJS Skills – Agentic Commands That Build Your Portal
-metadescription: The six PortalJS skills — composable Claude Code commands that scaffold, load data, visualize, connect a backend, and deploy. Each produces plain, editable code you own.
+metadescription: The PortalJS agentic skills — composable Claude Code commands that recommend an architecture, scaffold, load and migrate data, visualize, connect a backend, and deploy to PortalJS Arc. Each produces plain, editable code you own.
 title: Skills reference
 description: PortalJS skills are first-class, composable commands that do the repetitive assembly — and produce plain, editable code with no lock-in.
 ---
@@ -14,9 +14,11 @@ portal. You describe intent; the skill writes the code.
 - **First-class.** Skills live in the repo alongside the template, are documented,
   and are tested end to end. They are not hidden helpers — they are the product's
   primary path.
-- **Composable.** Each skill does one job and hands off to the next: scaffold with
+- **Composable.** Each skill does one job and hands off to the next: plan with
+  [`/portaljs-architect`](/docs/skills/architect), scaffold with
   [`/portaljs-new-portal`](/docs/skills/new-portal), load data with
-  [`/portaljs-add-dataset`](/docs/skills/add-dataset), enrich with
+  [`/portaljs-add-dataset`](/docs/skills/add-dataset) or migrate a whole catalog with
+  [`/portaljs-migrate`](/docs/skills/migrate), enrich with
   [`/portaljs-add-chart`](/docs/skills/add-chart) or [`/portaljs-add-map`](/docs/skills/add-map),
   describe it with [`/portaljs-define-schema`](/docs/skills/define-schema), swap the data
   source with [`/portaljs-connect-ckan`](/docs/skills/connect-ckan), and go live with
@@ -30,14 +32,17 @@ portal. You describe intent; the skill writes the code.
 
 | Skill | What it does |
 | ----- | ------------ |
+| [`/portaljs-architect`](/docs/skills/architect) | Advisory — turns your needs (data, scale, governance) into a recommended architecture before you build. Start here if you're unsure of the stack. |
 | [`/portaljs-new-portal`](/docs/skills/new-portal) | Scaffold a new portal from a brief — copies the template, substitutes your project name and description, installs deps, verifies the build. |
 | [`/portaljs-add-dataset`](/docs/skills/add-dataset) | Add a CSV, TSV, JSON, or GeoJSON dataset — copies the data in, generates a dataset page, and registers it on the home page catalog. |
+| [`/portaljs-migrate`](/docs/skills/migrate) | Harvest or migrate a whole catalog into the portal from CKAN, Socrata, OpenDataSoft, ArcGIS, or DCAT-US, over a canonical Frictionless/DCAT model. |
 | [`/portaljs-add-resource`](/docs/skills/add-resource) | Attach another file (data dictionary, methodology, extra data) to an existing dataset — it becomes multi-resource and the showcase renders a section per file. |
 | [`/portaljs-add-chart`](/docs/skills/add-chart) | Add a line, bar, area, pie, or scatter chart to a dataset page using `recharts`. |
 | [`/portaljs-add-map`](/docs/skills/add-map) | Render a GeoJSON dataset on an interactive Leaflet map and register it on the home page. |
 | [`/portaljs-connect-ckan`](/docs/skills/connect-ckan) | Wire the portal to a [CKAN](/ckan) backend over its API instead of static files. |
 | [`/portaljs-define-schema`](/docs/skills/define-schema) | Infer a Frictionless Table Schema from a dataset's data, add license/source/keyword metadata, and surface a typed field table on its showcase. |
-| [`/portaljs-deploy`](/docs/skills/deploy) | Build and publish the portal to Vercel or any static host — with a live URL at the end. |
+| `/portaljs-check-data-quality` | Validate a dataset against its schema and flag quality issues (type mismatches, missing values, constraint violations). |
+| [`/portaljs-deploy`](/docs/skills/deploy) | Build a static export and publish it to [PortalJS Arc](/docs/arc) — Datopian-managed hosting — with a live `<slug>.arc.portaljs.com` URL. Or self-host the export anywhere. |
 
 ## Author your own
 


### PR DESCRIPTION
## Why
Audit of PortalJS Arc docs (website `site/content/docs` vs repo README) for consistency + alignment with the shipped state. **Substance was already aligned** — README, quickstart, `arc.md`, and the deploy skill + guide all use the `/portaljs-*` names, "Arc is live" language, one-click device auth, and the `arc.portaljs.com` hosts. No `/login` references. No command-prose drift.

This PR fixes the **one real gap found** — the skills index (`skills.md`) had drifted from the actual suite:

- "**The six PortalJS skills**" → there are **11**. Fixed the metadescription and the "six skills" line in `authoring-skills.md`.
- Table was **missing** `/portaljs-architect`, `/portaljs-migrate`, `/portaljs-check-data-quality`. Added them (architect + migrate link to their existing pages; check-data-quality is listed unlinked — see below).
- `/portaljs-deploy` row said "**publish to Vercel or any static host**" (stale multi-target) → corrected to **single-target PortalJS Arc** + self-host alternative, matching `arc.md` / `guides/deploy` / `skills/deploy`.

## Known follow-ups (not in this PR)
- **`/portaljs-check-data-quality` has no website doc page** (the command exists; `site/content/docs/skills/check-data-quality.md` is missing). Listed unlinked for now.
- **Skill doc URL slugs are still bare** (`/docs/skills/deploy` for the `/portaljs-deploy` page). Functional and internally consistent (titles/links are correct); renaming the URLs would need redirects and should be coordinated with the in-flight SEO work (#1599/#1600). Left as-is intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Skills documentation with expanded descriptions of how skills compose and hand off across the lifecycle.
  * Enhanced Skills reference table with new entries including data-quality validation and architecture advisory guidance.
  * Clarified deployment options documentation to highlight modern hosting and self-hosting alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->