### PR TITLE
feat(blog): civic article slug → civic-data-portal-examples + featured position 1

### DIFF
--- a/site/content/blog/civic-data-portal-examples.md
+++ b/site/content/blog/civic-data-portal-examples.md
@@ -11,7 +11,7 @@ tags:
 keywords: civic data portal examples, open data portal examples, open data portal research, civic portal design, government data portal UX, researcher field guide, open data portal software, open data portal best practices, city government open data, civic tech portal, best open data portals 2026
 description: "Discover 12 real civic data portals — what they do well, how they're built, and what the best ones share. A practical guide for researchers and portal builders."
 authors: ['Yoana Popova']
-canonical: https://www.portaljs.com/blog/we-looked-at-civic-data-portals-so-you-dont-have-to
+canonical: https://www.portaljs.com/blog/civic-data-portal-examples
 image: /static/img/blog/2026-06-17-civic-data-portal-research/civic-data-portal-featured.png
 filetype: 'blog'
 ---

--- a/site/pages/blog.tsx
+++ b/site/pages/blog.tsx
@@ -25,10 +25,10 @@ const GRID_PAGE_SIZE = 9
 // All other posts appear in the grid below the hero cluster as usual.
 // ─────────────────────────────────────────────────────────────────────────────
 const FEATURED_SLUGS = [
-  'talk-to-your-data-portal-in-plain-english-introducing-queryless-ai', // Position 1 — large card
-  'portaljs-cloud-apis',                                                 // Position 2 — mini top
-  'portaljs-cloud-geospatial',                                           // Position 3 — mini middle
-  'keep-your-portal-data-fresh-a-hands-on-guide-to-the-portaljs-cloud-api', // Position 4 — mini bottom
+  'civic-data-portal-examples',                                          // Position 1 — large card
+  'talk-to-your-data-portal-in-plain-english-introducing-queryless-ai', // Position 2 — mini top
+  'portaljs-cloud-apis',                                                 // Position 3 — mini middle
+  'portaljs-cloud-geospatial',                                           // Position 4 — mini bottom
 ]
 
 // Human-readable label for each segment ID (no hyphens, proper casing)


### PR DESCRIPTION
Closes #1611

## Summary

- Rename slug: `we-looked-at-civic-data-portals-so-you-dont-have-to` → `civic-data-portal-examples` (topic-first, SEO best practice)
- Update `canonical` URL in frontmatter to match
- Promote civic article to **Featured Position 1** (large hero card)
- New featured order: civic(1) → queryless(2) → APIs(3) → geospatial(4)
- `keep-your-portal-data-fresh` drops to unfeatured grid

## Test plan

- [ ] `/blog` hero cluster shows civic article as the large card
- [ ] Queryless, APIs, geospatial appear as the three mini cards
- [ ] `/blog/civic-data-portal-examples` resolves correctly (no 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized featured blog posts displayed on the blog page with updated article selection and arrangement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->