### PR TITLE
fix(arc-api,giftless): harden LFS token issuer per security review (po-g9y.13)

### DIFF
--- a/.claude/commands/portaljs-add-dataset.md
+++ b/.claude/commands/portaljs-add-dataset.md
@@ -160,8 +160,10 @@ credentialed `lfs_url`:
 ```bash
 API="${PORTALJS_ARC_API:-https://api.arc.portaljs.com}"
 ARC_TOKEN="${PORTALJS_TOKEN:-$(node -e "try{process.stdout.write(JSON.parse(require('fs').readFileSync(process.env.HOME+'/.portaljs/credentials','utf8')).token||'')}catch{}")}"
-# read,write,verify by default; add ?actions=read for a pull-only token, ?ttl=<secs> to tune.
-LFS_URL=$(curl -fsS -X POST "$API/v1/repos/<project-slug>/lfs-token" \
+# Pushing data needs write: request ?actions=read,write,verify (default is read-only,
+# pull). ?ttl=<secs> to tune. The slug must already exist (deploy it first); the
+# endpoint will NOT create it. 404 = deploy first; 403 = owned by another account.
+LFS_URL=$(curl -fsS -X POST "$API/v1/repos/<project-slug>/lfs-token?actions=read,write,verify" \
   -H "Authorization: Bearer $ARC_TOKEN" \
   | node -e "process.stdin.on('data',d=>process.stdout.write(JSON.parse(d).lfs_url))")
 git config lfs.url "$LFS_URL"     # local only — carries the token, never committed

--- a/cloud/api/src/db.ts
+++ b/cloud/api/src/db.ts
@@ -80,6 +80,29 @@ export async function ensureProject(
   return { ok: true, projectId: row.id }
 }
 
+export type OwnedProjectResult =
+  | { ok: true; projectId: string }
+  | { ok: false; reason: 'not_found' | 'conflict' }
+
+// Look up an EXISTING project owned by userId. Unlike ensureProject, this NEVER
+// creates a row — minting an LFS token must not allocate ownership (po-g9y.13
+// security fix: prevents an authenticated caller squatting an unclaimed slug, esp.
+// one that already has objects in R2). 'not_found' = no project with that slug;
+// 'conflict' = it exists but belongs to another account.
+export async function getOwnedProject(
+  db: D1Database,
+  userId: string,
+  slug: string
+): Promise<OwnedProjectResult> {
+  const row = await db
+    .prepare('SELECT id, user_id FROM projects WHERE slug = ?')
+    .bind(slug)
+    .first<{ id: string; user_id: string }>()
+  if (!row) return { ok: false, reason: 'not_found' }
+  if (row.user_id !== userId) return { ok: false, reason: 'conflict' }
+  return { ok: true, projectId: row.id }
+}
+
 export async function recordDeployment(
   db: D1Database,
   projectId: string,

--- a/cloud/api/src/index.ts
+++ b/cloud/api/src/index.ts
@@ -7,7 +7,7 @@
 // Served at api.arc.portaljs.com (api.staging.arc.portaljs.com on staging).
 
 import { untar } from './untar'
-import { userForToken, loginForToken, userRowForToken, ensureProject, recordDeployment, getDeployment } from './db'
+import { userForToken, loginForToken, userRowForToken, ensureProject, getOwnedProject, recordDeployment, getDeployment } from './db'
 import { mintLfsToken, normalizeActions, normalizeTtl, LFS_ORG } from './lfs'
 
 export interface Env {
@@ -122,10 +122,11 @@ export async function handleDeploy(request: Request, env: Env): Promise<Response
 
 // POST /v1/repos/:slug/lfs-token — mint a scoped RS256 Giftless LFS token for the
 // authenticated Arc user. Guarded by the Arc API bearer token (device-flow
-// PORTALJS_TOKEN); 401 otherwise. The slug must be owned by the caller (or unclaimed,
-// in which case it's claimed) — so user A can't mint a write token for user B's repo.
-//   ?actions=read   → read-only (pull) token; default read,write,verify
-//   ?ttl=<seconds>  → lifetime, capped at 24h; default 3600
+// PORTALJS_TOKEN); 401 otherwise. The slug must ALREADY exist and be owned by the
+// caller (404 if it doesn't exist, 403 if another account owns it) — minting never
+// claims a slug, so user A can't mint for user B's repo or squat an unclaimed one.
+//   ?actions=write,verify → push token; DEFAULT is read-only (pull), least privilege
+//   ?ttl=<seconds>        → lifetime, capped at 24h; default 3600
 export async function handleLfsToken(request: Request, env: Env, slug: string): Promise<Response> {
   const auth = request.headers.get('authorization') ?? ''
   const token = auth.startsWith('Bearer ') ? auth.slice(7).trim() : ''
@@ -143,12 +144,18 @@ export async function handleLfsToken(request: Request, env: Env, slug: string): 
 
   const url = new URL(request.url)
   const actions = normalizeActions(url.searchParams.get('actions'))
-  if (actions === null) return json({ error: 'invalid actions (use read,write,verify or *)' }, 400)
+  if (actions === null) return json({ error: 'invalid actions (use a subset of read,write,verify)' }, 400)
   const ttl = normalizeTtl(Number(url.searchParams.get('ttl')) || undefined)
 
-  // Ownership: claim the slug for this user (or confirm they already own it).
-  const project = await ensureProject(env.DB, user.id, slug)
-  if (!project.ok) return json({ error: `slug "${slug}" is taken by another account` }, 409)
+  // Ownership: the project must ALREADY exist and belong to the caller. Minting a
+  // token must never create/claim a slug (po-g9y.13 security fix) — deploy the
+  // portal first (/portaljs-deploy), the only path that allocates a slug.
+  const project = await getOwnedProject(env.DB, user.id, slug)
+  if (!project.ok) {
+    return project.reason === 'not_found'
+      ? json({ error: `repo "${slug}" not found — deploy it first to claim the slug` }, 404)
+      : json({ error: `repo "${slug}" belongs to another account` }, 403)
+  }
 
   let minted
   try {

--- a/cloud/api/src/lfs.ts
+++ b/cloud/api/src/lfs.ts
@@ -5,8 +5,8 @@
 // raw RS256 private key.
 //
 // Mirrors giftless/mint-token.py's RS256 path EXACTLY in claim shape:
-//   header  {"alg":"RS256","typ":"JWT"}
-//   payload {sub, iat, nbf, exp, scopes:["obj:datopian/<slug>/*:<actions>"]}
+//   header  {"alg":"RS256","typ":"JWT","kid":"<key id>"}
+//   payload {sub, iss, iat, nbf, exp, scopes:["obj:datopian/<slug>/*:<actions>"]}
 // signed with RSASSA-PKCS1-v1_5 over SHA-256 (== Python's PKCS1v15 + SHA256).
 //
 // Signs with the GIFTLESS_JWT_PRIVATE_KEY Worker secret (a PKCS#8 PEM, the format
@@ -18,13 +18,26 @@
 // the Giftless object key is lfs/datopian/<slug>/<oid>.
 export const LFS_ORG = 'datopian'
 
-// git-lfs scope actions Giftless understands. The minted scope is a subset of these
-// (or the literal "*"); anything else is rejected so a caller can't inject arbitrary
-// text into the scope claim.
+// git-lfs scope actions Giftless understands. A minted scope is a subset of these.
+// The "*" wildcard is NOT accepted — a caller must name the actions it needs — and
+// anything outside the set is rejected, so a caller can't inject arbitrary scope text.
 const VALID_ACTIONS = new Set(['read', 'write', 'verify'])
-const DEFAULT_ACTIONS = 'read,write,verify'
+// Least privilege (po-g9y.13): default to read-only (pull). Write/verify must be
+// requested explicitly (e.g. the push side of /portaljs-add-dataset).
+const DEFAULT_ACTIONS = 'read'
 const DEFAULT_TTL = 3600
 const MAX_TTL = 86400 // cap so a mis-set ttl can't mint a long-lived token
+
+// JWT key id (header `kid`) + issuer (`iss`). Giftless enforces `kid` when its
+// key_id is configured (giftless.yaml) — that is what lets us rotate the signing
+// key (mint under a new kid, trust both during the overlap).
+// NOTE: `aud` is intentionally NOT set. giftless 1.7.1's verifier calls
+// jwt.decode() WITHOUT audience=, and PyJWT 1.7.1 raises InvalidAudienceError on
+// ANY token carrying an aud claim (including giftless's own verify callbacks), so
+// an aud claim would break auth. Adding it needs a giftless patch (pass audience=
+// to decode) or a PyJWT upgrade — tracked as a follow-up.
+const KEY_ID = 'giftless-rs256-1'
+const ISSUER = 'arc.portaljs.com'
 
 const enc = new TextEncoder()
 
@@ -66,7 +79,7 @@ async function importPrivateKey(pem: string): Promise<CryptoKey> {
 export function normalizeActions(raw: string | null | undefined): string | null {
   const v = (raw ?? '').trim()
   if (!v) return DEFAULT_ACTIONS
-  if (v === '*') return '*'
+  // No "*" wildcard: a caller must name the exact actions it needs (least privilege).
   const parts = v.split(',').map((p) => p.trim()).filter(Boolean)
   if (parts.length === 0 || !parts.every((p) => VALID_ACTIONS.has(p))) return null
   return parts.join(',')
@@ -100,9 +113,10 @@ export async function mintLfsToken(privateKeyPem: string, opts: MintOptions): Pr
   if (actions === null) throw new Error('invalid actions')
   const scope = `obj:${LFS_ORG}/${opts.slug}/*:${actions}`
 
-  const header = { alg: 'RS256', typ: 'JWT' }
+  const header = { alg: 'RS256', typ: 'JWT', kid: KEY_ID }
   const payload = {
     sub: opts.sub || 'lfs-client',
+    iss: ISSUER,
     iat: now,
     nbf: now,
     exp: now + ttl,

--- a/cloud/api/src/lfs.ts
+++ b/cloud/api/src/lfs.ts
@@ -93,7 +93,7 @@ export function normalizeTtl(raw: number | undefined): number {
 
 export interface MintOptions {
   slug: string
-  actions?: string // comma-separated subset of read,write,verify — or "*"
+  actions?: string // comma-separated subset of read,write,verify; defaults to read (no "*")
   ttl?: number // seconds; clamped to MAX_TTL (default 3600)
   sub?: string // subject claim, for audit (default "lfs-client")
   now?: number // unix seconds — injectable for deterministic tests

--- a/cloud/api/test/lfs.test.ts
+++ b/cloud/api/test/lfs.test.ts
@@ -42,9 +42,9 @@ beforeAll(async () => {
 })
 
 describe('normalizeActions', () => {
-  it('defaults to full access', () => expect(normalizeActions(null)).toBe('read,write,verify'))
-  it('passes the wildcard', () => expect(normalizeActions('*')).toBe('*'))
-  it('accepts a valid subset', () => expect(normalizeActions('read')).toBe('read'))
+  it('defaults to read-only (least privilege)', () => expect(normalizeActions(null)).toBe('read'))
+  it('rejects the wildcard', () => expect(normalizeActions('*')).toBeNull())
+  it('accepts a valid subset', () => expect(normalizeActions('read,write,verify')).toBe('read,write,verify'))
   it('trims and rejoins', () => expect(normalizeActions(' read , write ')).toBe('read,write'))
   it('rejects unknown actions', () => expect(normalizeActions('read,delete')).toBeNull())
 })
@@ -58,12 +58,17 @@ describe('normalizeTtl', () => {
 
 describe('mintLfsToken', () => {
   it('mints a verifiable RS256 JWT with the mint-token.py claim shape', async () => {
-    const { token, scope, expiresIn } = await mintLfsToken(privatePem, { slug: 'my-catalog', now: 1000 })
+    const { token, scope, expiresIn } = await mintLfsToken(privatePem, {
+      slug: 'my-catalog',
+      actions: 'read,write,verify',
+      now: 1000,
+    })
     const { header, payload, signingInput, sig } = decodeJwt(token)
 
-    expect(header).toEqual({ alg: 'RS256', typ: 'JWT' })
+    expect(header).toEqual({ alg: 'RS256', typ: 'JWT', kid: 'giftless-rs256-1' })
     expect(payload.scopes).toEqual([`obj:${LFS_ORG}/my-catalog/*:read,write,verify`])
     expect(scope).toBe(`obj:${LFS_ORG}/my-catalog/*:read,write,verify`)
+    expect(payload.iss).toBe('arc.portaljs.com')
     expect(payload.iat).toBe(1000)
     expect(payload.nbf).toBe(1000)
     expect(payload.exp).toBe(1000 + 3600)
@@ -181,22 +186,39 @@ describe('handleLfsToken', () => {
     expect(res.status).toBe(400)
   })
 
-  it('mints a token for an authenticated owner', async () => {
+  it('404 when the repo does not exist (minting never claims a slug)', async () => {
+    const env = await seededEnv() // no project seeded
+    const res = await handleLfsToken(req('arc_good'), env, 'my-catalog')
+    expect(res.status).toBe(404)
+    // Crucially: the call did NOT create/claim the slug.
+    expect(env.DB.projects.some((p: any) => p.slug === 'my-catalog')).toBe(false)
+  })
+
+  it('mints a read-only token by default for an existing owner', async () => {
     const env = await seededEnv()
+    env.DB.projects.push({ id: 'p1', user_id: 'u1', slug: 'my-catalog' })
     const res = await handleLfsToken(req('arc_good'), env, 'my-catalog')
     expect(res.status).toBe(200)
     const body = (await res.json()) as any
-    expect(body.scope).toBe(`obj:${LFS_ORG}/my-catalog/*:read,write,verify`)
+    // Least privilege: no ?actions ⇒ read-only.
+    expect(body.scope).toBe(`obj:${LFS_ORG}/my-catalog/*:read`)
     expect(body.expires_in).toBe(3600)
     expect(body.lfs_url).toBe(`https://_jwt:${body.token}@lfs.portaljs.com/${LFS_ORG}/my-catalog`)
-    // Claims the slug for the user.
-    expect(env.DB.projects.some((p: any) => p.slug === 'my-catalog' && p.user_id === 'u1')).toBe(true)
   })
 
-  it('409 when the slug is owned by another account', async () => {
+  it('honors explicit write actions for an existing owner', async () => {
+    const env = await seededEnv()
+    env.DB.projects.push({ id: 'p1', user_id: 'u1', slug: 'my-catalog' })
+    const res = await handleLfsToken(req('arc_good', '?actions=read,write,verify'), env, 'my-catalog')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as any
+    expect(body.scope).toBe(`obj:${LFS_ORG}/my-catalog/*:read,write,verify`)
+  })
+
+  it('403 when the slug is owned by another account', async () => {
     const env = await seededEnv()
     env.DB.projects.push({ id: 'p9', user_id: 'someone-else', slug: 'my-catalog' })
     const res = await handleLfsToken(req('arc_good'), env, 'my-catalog')
-    expect(res.status).toBe(409)
+    expect(res.status).toBe(403)
   })
 })

--- a/giftless/giftless.yaml
+++ b/giftless/giftless.yaml
@@ -26,6 +26,14 @@ AUTH_PROVIDERS:
       # client tokens (issuer-signed) and Giftless's own verify callbacks.
       public_key_file: /etc/giftless/jwt_public_key
       leeway: 60
+      # Enforce the signing key id (po-g9y.13). A token's `kid` header must equal
+      # this; lets us rotate keys (mint under a new kid, trust both during overlap)
+      # and rejects tokens minted for a different key id. Giftless stamps the same
+      # kid on its own verify callbacks (PRE_AUTHORIZED_ACTION_PROVIDER below), so
+      # the check passes for them too. NB: aud/iss are NOT enforced — giftless
+      # 1.7.1's verifier doesn't pass audience= to jwt.decode (PyJWT then rejects
+      # ANY aud claim, including the callbacks), so we bind on kid only.
+      key_id: giftless-rs256-1
 
 # Giftless mints its own pre-authorized token for the post-upload "verify" action.
 # Same keypair — sign with the PRIVATE key; AUTH_PROVIDERS above verifies the
@@ -37,6 +45,9 @@ PRE_AUTHORIZED_ACTION_PROVIDER:
     private_key_file: /etc/giftless/jwt_private_key
     public_key_file: /etc/giftless/jwt_public_key
     default_lifetime: 900
+    # Stamp the same kid on the verify callbacks so the AUTH_PROVIDER above
+    # accepts them under key_id enforcement (po-g9y.13).
+    key_id: giftless-rs256-1
 
 # basic transfer: Giftless hands the client presigned R2 URLs (direct-to-R2
 # upload/download). Sufficient for files < ~5 GB; multipart deferred (po-e24).

--- a/giftless/mint-token.py
+++ b/giftless/mint-token.py
@@ -33,6 +33,12 @@ import json
 import os
 import time
 
+# Must match giftless.yaml `key_id` and the Arc issuer (cloud/api/src/lfs.ts), so
+# tokens minted here pass Giftless's kid enforcement (po-g9y.13). `aud` is NOT set:
+# giftless 1.7.1's verifier rejects any aud claim (see lfs.ts note).
+KEY_ID = "giftless-rs256-1"
+ISSUER = "arc.portaljs.com"
+
 
 def _b64url(raw: bytes) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
@@ -59,13 +65,14 @@ def mint(
     key: str, org: str, repo: str, actions: str, ttl: int, sub: str, algorithm: str
 ) -> str:
     now = int(time.time())
-    header = {"alg": algorithm, "typ": "JWT"}
+    header = {"alg": algorithm, "typ": "JWT", "kid": KEY_ID}
     payload = {
         "sub": sub,
+        "iss": ISSUER,
         "iat": now,
         "nbf": now,
         "exp": now + ttl,
-        # Full access to every object (oid wildcard) in this one repo.
+        # Access to every object (oid wildcard) in this one repo.
         "scopes": [f"obj:{org}/{repo}/*:{actions}"],
     }
     signing_input = (


### PR DESCRIPTION
Addresses the codex pre-go-live security review (3 P1s) on the LFS auth system.

## Fixes
- **#2 claim-on-mint (P1)** — `/v1/repos/:slug/lfs-token` no longer creates/claims a slug as a side effect of minting. New `getOwnedProject()` requires the project to already exist and be owned by the caller: **404** if absent, **403** if another account owns it. Kills authenticated slug-squatting (esp. slugs with pre-existing R2 objects).
- **#1 caller-chosen actions (P1)** — default is now **read-only** (least privilege); the `*` wildcard is rejected; write/verify must be requested explicitly (`?actions=read,write,verify`).
- **#3 kid/iss (P1-adjacent hardening)** — minted tokens carry a `kid` header + `iss` claim; giftless enforces `key_id` on both the verifier and the verify-callback signer (enables key rotation, binds tokens to a key id). **`aud` intentionally deferred**: giftless 1.7.1's verifier doesn't pass `audience=` to `jwt.decode`, and PyJWT 1.7.1 raises on any `aud` claim (would break verification incl. callbacks) — needs a giftless/PyJWT bump.

## Not changed
- **#5 CORS `*`** — intentional for the future DuckDB-Wasm browser query tier.
- **#6 .gitignore** — codex false positive; `giftless/.gitignore` already ignores the key files (`git check-ignore` confirmed).

## Verified live
arc-api deployed + verified in prod: 404-no-claim, `*`→400, default scope `:read`. giftless image with `key_id` deployed; kid enforcement rolling in as the warm container (sleepAfter=10m) recycles. 21 unit tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LFS token requests now support explicit access scopes (e.g., `read,write,verify`); default is read-only, and wildcard scopes are no longer accepted.
  * RS256 token verification now includes required signing metadata for better compatibility.

* **Bug Fixes**
  * LFS tokens are only issued when the repository slug already exists and is owned by the signed-in account (deploy-first behavior).
  * More accurate error responses: missing repo returns 404, and repos owned by another account return 403.

* **Documentation**
  * Updated the dataset upload/token generation instructions to reflect the new LFS token request requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->