### PR TITLE
feat(arc-api): claim endpoint to restore seamless LFS DX (po-g9y.13)

### DIFF
--- a/.claude/commands/portaljs-add-dataset.md
+++ b/.claude/commands/portaljs-add-dataset.md
@@ -160,9 +160,13 @@ credentialed `lfs_url`:
 ```bash
 API="${PORTALJS_ARC_API:-https://api.arc.portaljs.com}"
 ARC_TOKEN="${PORTALJS_TOKEN:-$(node -e "try{process.stdout.write(JSON.parse(require('fs').readFileSync(process.env.HOME+'/.portaljs/credentials','utf8')).token||'')}catch{}")}"
+# Claim the slug under your Arc account (idempotent; safe to re-run). Minting never
+# creates a slug (po-g9y.13), so claim once before the FIRST push on a portal that
+# hasn't been deployed yet — this is what makes create → add-data → deploy seamless.
+# 403 = the slug belongs to another account.
+curl -fsS -X POST "$API/v1/repos/<project-slug>/claim" -H "Authorization: Bearer $ARC_TOKEN" >/dev/null
 # Pushing data needs write: request ?actions=read,write,verify (default is read-only,
-# pull). ?ttl=<secs> to tune. The slug must already exist (deploy it first); the
-# endpoint will NOT create it. 404 = deploy first; 403 = owned by another account.
+# pull). ?ttl=<secs> to tune.
 LFS_URL=$(curl -fsS -X POST "$API/v1/repos/<project-slug>/lfs-token?actions=read,write,verify" \
   -H "Authorization: Bearer $ARC_TOKEN" \
   | node -e "process.stdin.on('data',d=>process.stdout.write(JSON.parse(d).lfs_url))")

--- a/cloud/api/src/index.ts
+++ b/cloud/api/src/index.ts
@@ -179,6 +179,25 @@ export async function handleLfsToken(request: Request, env: Env, slug: string): 
   })
 }
 
+// POST /v1/repos/:slug/claim — allocate the slug to the authenticated Arc user (or
+// confirm they already own it). Idempotent; 403 if another account owns it. This is
+// the EXPLICIT counterpart to the claim-on-mint side effect removed in po-g9y.13:
+// /portaljs-add-dataset calls this once before its first LFS push so a brand-new
+// (not-yet-deployed) portal can push data without hitting a 404 from /lfs-token.
+// Minting still NEVER claims. Same allocate-or-confirm semantics as /v1/deploy.
+export async function handleClaim(request: Request, env: Env, slug: string): Promise<Response> {
+  const auth = request.headers.get('authorization') ?? ''
+  const token = auth.startsWith('Bearer ') ? auth.slice(7).trim() : ''
+  if (!token) return json({ error: 'missing bearer token' }, 401)
+  const user = await userRowForToken(env.DB, token)
+  if (!user) return json({ error: 'invalid token' }, 401)
+  if (!validSlug(slug)) return json({ error: `invalid slug "${slug}"` }, 400)
+
+  const project = await ensureProject(env.DB, user.id, slug)
+  if (!project.ok) return json({ error: `repo "${slug}" belongs to another account` }, 403)
+  return json({ ok: true, slug, owner: user.login })
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url)
@@ -201,6 +220,8 @@ export default {
       return login ? json({ login }) : json({ error: 'invalid token' }, 401)
     }
     if (url.pathname === '/v1/deploy' && request.method === 'POST') return handleDeploy(request, env)
+    const claimM = url.pathname.match(/^\/v1\/repos\/([a-z0-9-]+)\/claim$/)
+    if (claimM && request.method === 'POST') return handleClaim(request, env, claimM[1])
     const lfsM = url.pathname.match(/^\/v1\/repos\/([a-z0-9-]+)\/lfs-token$/)
     if (lfsM && request.method === 'POST') return handleLfsToken(request, env, lfsM[1])
     const m = url.pathname.match(/^\/v1\/deploy\/([\w-]+)$/)

--- a/cloud/api/src/index.ts
+++ b/cloud/api/src/index.ts
@@ -220,9 +220,11 @@ export default {
       return login ? json({ login }) : json({ error: 'invalid token' }, 401)
     }
     if (url.pathname === '/v1/deploy' && request.method === 'POST') return handleDeploy(request, env)
-    const claimM = url.pathname.match(/^\/v1\/repos\/([a-z0-9-]+)\/claim$/)
+    // Match any non-empty segment and let the handler's validSlug() return a clean
+    // 400 for a malformed slug (e.g. "Bad_Slug") instead of falling through to 404.
+    const claimM = url.pathname.match(/^\/v1\/repos\/([^/]+)\/claim$/)
     if (claimM && request.method === 'POST') return handleClaim(request, env, claimM[1])
-    const lfsM = url.pathname.match(/^\/v1\/repos\/([a-z0-9-]+)\/lfs-token$/)
+    const lfsM = url.pathname.match(/^\/v1\/repos\/([^/]+)\/lfs-token$/)
     if (lfsM && request.method === 'POST') return handleLfsToken(request, env, lfsM[1])
     const m = url.pathname.match(/^\/v1\/deploy\/([\w-]+)$/)
     if (m && request.method === 'GET') {

--- a/cloud/api/test/lfs.test.ts
+++ b/cloud/api/test/lfs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest'
 import { mintLfsToken, normalizeActions, normalizeTtl, LFS_ORG } from '../src/lfs'
-import { handleLfsToken, handleClaim } from '../src/index'
+import worker, { handleLfsToken, handleClaim } from '../src/index'
 import { sha256Hex } from '../src/db'
 
 // Generate a throwaway RS256 keypair and export the private half as a PKCS#8 PEM —
@@ -252,5 +252,25 @@ describe('handleClaim', () => {
     const env = await seededEnv()
     env.DB.projects.push({ id: 'p9', user_id: 'someone-else', slug: 'my-catalog' })
     expect((await handleClaim(req('arc_good'), env, 'my-catalog')).status).toBe(403)
+  })
+})
+
+describe('router slug validation', () => {
+  // The route regex matches any non-empty segment so a malformed slug reaches the
+  // handler and gets a clean 400 (not a fall-through 404). coderabbit on #1623.
+  it('a malformed slug → 400 (claim)', async () => {
+    const r = new Request('https://api.arc.portaljs.com/v1/repos/Bad_Slug/claim', {
+      method: 'POST',
+      headers: { authorization: 'Bearer arc_good' },
+    })
+    expect((await worker.fetch(r, await seededEnv())).status).toBe(400)
+  })
+
+  it('a malformed slug → 400 (lfs-token)', async () => {
+    const r = new Request('https://api.arc.portaljs.com/v1/repos/Bad_Slug/lfs-token', {
+      method: 'POST',
+      headers: { authorization: 'Bearer arc_good' },
+    })
+    expect((await worker.fetch(r, await seededEnv())).status).toBe(400)
   })
 })

--- a/cloud/api/test/lfs.test.ts
+++ b/cloud/api/test/lfs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest'
 import { mintLfsToken, normalizeActions, normalizeTtl, LFS_ORG } from '../src/lfs'
-import { handleLfsToken } from '../src/index'
+import { handleLfsToken, handleClaim } from '../src/index'
 import { sha256Hex } from '../src/db'
 
 // Generate a throwaway RS256 keypair and export the private half as a PKCS#8 PEM —
@@ -220,5 +220,37 @@ describe('handleLfsToken', () => {
     env.DB.projects.push({ id: 'p9', user_id: 'someone-else', slug: 'my-catalog' })
     const res = await handleLfsToken(req('arc_good'), env, 'my-catalog')
     expect(res.status).toBe(403)
+  })
+})
+
+describe('handleClaim', () => {
+  it('401 without a token', async () => {
+    expect((await handleClaim(req(), await seededEnv(), 'my-catalog')).status).toBe(401)
+  })
+
+  it('400 on a bad slug', async () => {
+    expect((await handleClaim(req('arc_good'), await seededEnv(), 'Bad_Slug')).status).toBe(400)
+  })
+
+  it('claims an unclaimed slug for the caller', async () => {
+    const env = await seededEnv()
+    const res = await handleClaim(req('arc_good'), env, 'my-catalog')
+    expect(res.status).toBe(200)
+    expect(env.DB.projects.some((p: any) => p.slug === 'my-catalog' && p.user_id === 'u1')).toBe(true)
+  })
+
+  it('is idempotent — re-claiming your own slug succeeds', async () => {
+    const env = await seededEnv()
+    env.DB.projects.push({ id: 'p1', user_id: 'u1', slug: 'my-catalog' })
+    const res = await handleClaim(req('arc_good'), env, 'my-catalog')
+    expect(res.status).toBe(200)
+    // No duplicate row created.
+    expect(env.DB.projects.filter((p: any) => p.slug === 'my-catalog').length).toBe(1)
+  })
+
+  it('403 when the slug is owned by another account', async () => {
+    const env = await seededEnv()
+    env.DB.projects.push({ id: 'p9', user_id: 'someone-else', slug: 'my-catalog' })
+    expect((await handleClaim(req('arc_good'), env, 'my-catalog')).status).toBe(403)
   })
 })


### PR DESCRIPTION
Follow-up to the security fix (#1622). The claim-on-mint removal meant a brand-new portal's first LFS push hit a 404 (slug not yet claimed until deploy). This adds an explicit **`POST /v1/repos/:slug/claim`** — auth'd, idempotent, same allocate-or-confirm semantics as `/v1/deploy` (403 if another account owns it). Minting still **never** claims.

`/portaljs-add-dataset` now calls claim once before its first push, so **create → add-data → deploy** is seamless again for users who've never deployed (and never need to know what LFS is).

Verified live: mint-before-claim→404, claim→200, idempotent re-claim→200, mint-after-claim→200. 26 unit tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “slug claim” step to the API and setup flow before requesting LFS access or uploading data.
* **Bug Fixes**
  * Improved slug handling and ownership semantics, including idempotent re-claims and clearer status codes for missing auth (401), invalid slugs (400), and ownership conflicts (403).
  * Ensured malformed slug requests return 400 (not 404) on related endpoints.
* **Documentation**
  * Updated the Arc API “Arc API” setup instructions to reflect the claim-first process and the meaning of 403 conflicts.
* **Tests**
  * Expanded test coverage for claim behavior and endpoint routing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->