### PR TITLE
blog: set Giftless post publish date to July 1

### DIFF
--- a/site/content/blog/scaling-portaljs-data-with-giftless-and-r2.md
+++ b/site/content/blog/scaling-portaljs-data-with-giftless-and-r2.md
@@ -1,7 +1,7 @@
 ---
 title: "Big data, small repo: scaling PortalJS data with Giftless and Cloudflare R2"
 description: "Real datasets outgrow git. Here's how PortalJS keeps authoring git-native while the bytes live in object storage — using Giftless (an open-source Git LFS server) backed by Cloudflare R2, wired so your agent handles it for you."
-created: 2026-06-30
+created: 2026-07-01
 authors: ['anuveyatsu']
 tags:
   - PortalJS


### PR DESCRIPTION
One-line frontmatter fix: `created: 2026-06-30` → `2026-07-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the publish date on a blog post to reflect the latest revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->