### PR TITLE
blog: embed add-dataset demo video (served from R2)

### DIFF
--- a/site/content/blog/scaling-portaljs-data-with-giftless-and-r2.md
+++ b/site/content/blog/scaling-portaljs-data-with-giftless-and-r2.md
@@ -47,6 +47,10 @@ Here's the part that matters for everyday use: **if you don't know what Git LFS 
 
 In PortalJS, you work with an AI agent. When you run `/portaljs-add-dataset` and point it at a local file, the skill decides where the bytes belong (big local files → R2 via LFS, bundled samples → inline, remote URLs → passthrough) and does the whole dance for you — tracking the file, getting a scoped upload token, pushing the bytes to R2, and registering the dataset in your catalog. No `git lfs track`, no credentials to copy, no manual config.
 
+<video autoplay loop muted playsinline controls width="100%" style="border-radius:8px;margin:1.5rem 0" src="https://pub-e2e69b5e239d44368bb32b91a4533c7f.r2.dev/blog/scaling-portaljs-data-with-giftless-and-r2/add-dataset.mp4"></video>
+
+*(This clip streams from a Cloudflare R2 bucket — the same object storage the datasets themselves live in.)*
+
 Then your deployed portal serves that data **straight from R2**. Pair it with DuckDB-Wasm over Parquet and you can query a large dataset right in the browser — no download, no server, range-requesting only the bytes a query needs.
 
 ## Auth: the signing key never leaves the server

--- a/site/content/blog/scaling-portaljs-data-with-giftless-and-r2.md
+++ b/site/content/blog/scaling-portaljs-data-with-giftless-and-r2.md
@@ -47,7 +47,7 @@ Here's the part that matters for everyday use: **if you don't know what Git LFS 
 
 In PortalJS, you work with an AI agent. When you run `/portaljs-add-dataset` and point it at a local file, the skill decides where the bytes belong (big local files → R2 via LFS, bundled samples → inline, remote URLs → passthrough) and does the whole dance for you — tracking the file, getting a scoped upload token, pushing the bytes to R2, and registering the dataset in your catalog. No `git lfs track`, no credentials to copy, no manual config.
 
-<video autoplay loop muted playsinline controls width="100%" style="border-radius:8px;margin:1.5rem 0" src="https://pub-e2e69b5e239d44368bb32b91a4533c7f.r2.dev/blog/scaling-portaljs-data-with-giftless-and-r2/add-dataset.mp4"></video>
+<video autoPlay loop muted playsInline controls width="100%" style={{ borderRadius: '8px', margin: '1.5rem 0' }} src="https://pub-e2e69b5e239d44368bb32b91a4533c7f.r2.dev/blog/scaling-portaljs-data-with-giftless-and-r2/add-dataset.mp4"></video>
 
 *(This clip streams from a Cloudflare R2 bucket — the same object storage the datasets themselves live in.)*
 


### PR DESCRIPTION
Adds a Remotion-rendered demo of `/portaljs-add-dataset` to the Giftless post via a native `<video autoplay loop muted playsinline controls>`. The mp4 is hosted on a new **portaljs-assets** R2 bucket (public), so the repo stays lean — and it's on-brand: the clip streams from the same R2 the post describes. No lfs.portaljs.com or raw endpoint URLs shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an embedded autoplaying muted video to the blog post, including a short caption noting it streams from Cloudflare R2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->