### PR TITLE
docs/site: fix OSS quickstart + docs discoverability (po-hqq P1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     Describe the portal you want — your agent helps you choose an architecture, scaffolds it, and loads your data.
     <br />
     <br />
-    <a href="https://www.portaljs.com/opensource">Docs</a>
+    <a href="https://www.portaljs.com/docs">Docs</a>
     ·
     <a href="https://github.com/datopian/portaljs/discussions">Discussions</a>
     ·
@@ -180,16 +180,17 @@ npm create portaljs@latest my-portal
 |-------|--------------|
 | [`/portaljs-architect`](.claude/commands/portaljs-architect.md) | Recommend an architecture (storage/compute/catalog/access/hosting/metadata) from your needs, then hand off — the advisory entry point |
 | [`/portaljs-new-portal`](.claude/commands/portaljs-new-portal.md) | Scaffold a new portal (Home + Catalog + Showcase) from a brief |
-| [`/portaljs-add-dataset`](.claude/commands/portaljs-add-dataset.md) | Add a CSV, TSV, JSON, or GeoJSON dataset — appends to the manifest; its showcase renders automatically |
+| [`/portaljs-add-dataset`](.claude/commands/portaljs-add-dataset.md) | Add a CSV, TSV, JSON, or GeoJSON dataset — appends to the manifest and renders its showcase automatically; large local files are pushed to Cloudflare R2 via Git LFS for you |
 | [`/portaljs-add-chart`](.claude/commands/portaljs-add-chart.md) | Add a chart to a dataset's showcase Views section |
 | [`/portaljs-add-map`](.claude/commands/portaljs-add-map.md) | Render GeoJSON on an interactive map in the showcase |
 | [`/portaljs-connect-ckan`](.claude/commands/portaljs-connect-ckan.md) | Feed the catalog and showcases from a CKAN backend |
-| [`/portaljs-deploy`](.claude/commands/portaljs-deploy.md) | Deploy to Cloudflare Pages, Vercel, or static hosting |
+| [`/portaljs-deploy`](.claude/commands/portaljs-deploy.md) | Deploy to PortalJS Arc — Datopian's managed hosting on Cloudflare — and get a live `<slug>.arc.portaljs.com` URL |
 | [`/portaljs-check-data-quality`](.claude/commands/portaljs-check-data-quality.md) | Audit a dataset for quality issues (schema, nulls, types) |
 
-More skill families — metadata schemas (Frictionless/DCAT), more backends (OpenMetadata,
-git-LFS+R2), a DuckDB data layer, and access control — are on the [roadmap](ROADMAP.md).
-Write your own — see [`.claude/AUTHORING.md`](.claude/AUTHORING.md).
+Large-data scaling — big files pushed to Cloudflare R2 via Git LFS — already ships in
+`/portaljs-add-dataset`. More skill families — metadata schemas (Frictionless/DCAT), more
+backends (OpenMetadata), a browser DuckDB query layer, and access control — are on the
+[roadmap](ROADMAP.md). Write your own — see [`.claude/AUTHORING.md`](.claude/AUTHORING.md).
 
 ## What's in this repo
 
@@ -234,7 +235,7 @@ Reference implementations live in [`examples/`](examples/):
 - 💬 **Discord** — live chat and help: [join the server](https://discord.gg/krmj5HM6He)
 - 🗣️ **Discussions** — questions, ideas, show-and-tell: [github.com/datopian/portaljs/discussions](https://github.com/datopian/portaljs/discussions)
 - 🐛 **Issues** — bugs and feature requests: [open an issue](https://github.com/datopian/portaljs/issues/new)
-- 📖 **Docs** — [portaljs.com/opensource](https://www.portaljs.com/opensource)
+- 📖 **Docs** — [portaljs.com/docs](https://www.portaljs.com/docs)
 
 ## Contributing
 

--- a/site/content/config.js
+++ b/site/content/config.js
@@ -139,8 +139,7 @@ const config = {
     },
     {
       name: 'Open source 🌐',
-      href: '/opensource',
-      target: '_blank',
+      href: '/docs',
       style: 'text-blue-400 ',
     },
   ],

--- a/site/content/opensource/docs/setup.md
+++ b/site/content/opensource/docs/setup.md
@@ -7,7 +7,10 @@ description: 'Getting started guide and tutorial about data portal-building with
 
 Welcome to the PortalJS documentation!
 
-If you have questions about anything related to PortalJS, you're always welcome to ask our community on [GitHub Discussions](https://github.com/datopian/datahub/discussions) or on [our chat channel on Discord](https://discord.gg/krmj5HM6He).
+If you have questions about anything related to PortalJS, you're always welcome to ask our community on [GitHub Discussions](https://github.com/datopian/portaljs/discussions) or on [our chat channel on Discord](https://discord.gg/krmj5HM6He).
+
+> [!tip] Prefer the AI-native path?
+> The fastest way to build a PortalJS portal is to describe it to your AI assistant and let the [agentic skills](/docs/skills) do the assembly — see the [Quickstart](/docs/quickstart). The manual guide below still works and is a good reference for how everything fits together.
 
 ## Setup
 
@@ -18,14 +21,16 @@ If you have questions about anything related to PortalJS, you're always welcome 
 
 ## Create a PortalJS app
 
-To create a PortalJS app, open your terminal, cd into the directory you’d like to create the app in, and run the following command:
+To create a PortalJS app, open your terminal, cd into the directory you’d like to create the app in, and run:
 
 ```bash
-npx create-next-app my-data-portal --example https://github.com/datopian/datahub/tree/main/examples/learn
+npm create portaljs@latest my-data-portal
 ```
 
+This scaffolds a portal from the official template. (Or grab the bare template with no prompts: `npx tiged datopian/portaljs/examples/portaljs-catalog my-data-portal`.)
+
 > [!tip]
-> You may have noticed we used the command create-next-app. That’s because PortalJS is built on the awesome NextJS react javascript framework. This means you can do everything you do with NextJS with PortalJS. Check out their docs to learn more.
+> PortalJS is built on Next.js + React + Tailwind, so everything the scaffolder writes is plain, editable code — anything you can do with Next.js, you can do with PortalJS.
 
 ## Run the development server
 


### PR DESCRIPTION
P1 quick-wins from the home/docs plan (po-hqq):
- **Fix stale OSS quickstart** — `opensource/docs/setup.md` used `npx create-next-app … datahub/examples/learn`; now `npm create portaljs@latest`, with a pointer to the AI-native `/docs/quickstart`. Also fixed a wrong `datahub` discussions link → `portaljs`.
- **Nav discoverability** — the top-level 'Open source 🌐' link pointed at the *classic* `/opensource` guide; now points at `/docs` (the current AI-native OSS framework). Classic stays reachable via Docs > Classic and the existing banner on /opensource.

Hero/features reframe (P2) comes next as a design mockup for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Open source” navigation link to point to the correct docs page and keep it opening in the same tab.

* **Documentation**
  * Refreshed setup guidance with updated community support links and an “AI-native path” onboarding tip.
  * Updated app creation commands (including a newer starter flow and an alternate template option).
  * Improved README docs links and expanded skill/deployment descriptions (including handling for large files and PortalJS Arc hosting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->