### PR TITLE
chore(docs): single-source the skills table (README + docs + sidebar) (po-hqq)

### DIFF
--- a/.github/workflows/skills-sync.yml
+++ b/.github/workflows/skills-sync.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/skills-sync.yml
+++ b/.github/workflows/skills-sync.yml
@@ -1,0 +1,23 @@
+name: Skills docs in sync
+
+# The README skills table, the /docs/skills table, and the docs sidebar are all
+# generated from scripts/skills-manifest.mjs. This fails the PR if someone edited a
+# generated block by hand (or the manifest) without running `npm run gen:skills`.
+on:
+  pull_request:
+    paths:
+      - scripts/skills-manifest.mjs
+      - scripts/gen-skills-docs.mjs
+      - README.md
+      - site/content/docs/skills.md
+      - site/content/assets/docs-sidebar.json
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/gen-skills-docs.mjs --check

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ npm create portaljs@latest my-portal
 ### Available skills
 
 <!-- BEGIN:skills-table -->
+
 | Skill | What it does |
 | ----- | ------------ |
 | [`/portaljs-architect`](.claude/commands/portaljs-architect.md) | Advisory — turns your needs (data, scale, governance) into a recommended architecture before you build. Start here if you're unsure of the stack. |
@@ -190,6 +191,7 @@ npm create portaljs@latest my-portal
 | [`/portaljs-check-data-quality`](.claude/commands/portaljs-check-data-quality.md) | Validate a dataset against its schema and flag quality issues (type mismatches, missing values, constraint violations). |
 | [`/portaljs-migrate`](.claude/commands/portaljs-migrate.md) | Harvest or migrate a whole catalog into the portal from CKAN, Socrata, OpenDataSoft, ArcGIS, or DCAT-US, over a canonical Frictionless/DCAT model. |
 | [`/portaljs-deploy`](.claude/commands/portaljs-deploy.md) | Build a static export and publish it to PortalJS Arc — Datopian-managed hosting on Cloudflare — with a live `<slug>.arc.portaljs.com` URL. |
+
 <!-- END:skills-table -->
 <!-- Generated from scripts/skills-manifest.mjs — edit there and run `npm run gen:skills`. -->
 

--- a/README.md
+++ b/README.md
@@ -176,16 +176,22 @@ npm create portaljs@latest my-portal
 
 ### Available skills
 
+<!-- BEGIN:skills-table -->
 | Skill | What it does |
-|-------|--------------|
-| [`/portaljs-architect`](.claude/commands/portaljs-architect.md) | Recommend an architecture (storage/compute/catalog/access/hosting/metadata) from your needs, then hand off — the advisory entry point |
-| [`/portaljs-new-portal`](.claude/commands/portaljs-new-portal.md) | Scaffold a new portal (Home + Catalog + Showcase) from a brief |
-| [`/portaljs-add-dataset`](.claude/commands/portaljs-add-dataset.md) | Add a CSV, TSV, JSON, or GeoJSON dataset — appends to the manifest and renders its showcase automatically; large local files are pushed to Cloudflare R2 via Git LFS for you |
-| [`/portaljs-add-chart`](.claude/commands/portaljs-add-chart.md) | Add a chart to a dataset's showcase Views section |
-| [`/portaljs-add-map`](.claude/commands/portaljs-add-map.md) | Render GeoJSON on an interactive map in the showcase |
-| [`/portaljs-connect-ckan`](.claude/commands/portaljs-connect-ckan.md) | Feed the catalog and showcases from a CKAN backend |
-| [`/portaljs-deploy`](.claude/commands/portaljs-deploy.md) | Deploy to PortalJS Arc — Datopian's managed hosting on Cloudflare — and get a live `<slug>.arc.portaljs.com` URL |
-| [`/portaljs-check-data-quality`](.claude/commands/portaljs-check-data-quality.md) | Audit a dataset for quality issues (schema, nulls, types) |
+| ----- | ------------ |
+| [`/portaljs-architect`](.claude/commands/portaljs-architect.md) | Advisory — turns your needs (data, scale, governance) into a recommended architecture before you build. Start here if you're unsure of the stack. |
+| [`/portaljs-new-portal`](.claude/commands/portaljs-new-portal.md) | Scaffold a new portal (Home + Catalog + Showcase) from a brief — copies the template, substitutes your project name and description, installs deps, verifies the build. |
+| [`/portaljs-add-dataset`](.claude/commands/portaljs-add-dataset.md) | Add a CSV, TSV, JSON, or GeoJSON dataset — registers it in the catalog and renders its showcase automatically; large local files are pushed to Cloudflare R2 via Git LFS for you. |
+| [`/portaljs-add-resource`](.claude/commands/portaljs-add-resource.md) | Attach another file (data dictionary, methodology, extra data) to an existing dataset — it becomes multi-resource and the showcase renders a section per file. |
+| [`/portaljs-add-chart`](.claude/commands/portaljs-add-chart.md) | Add a line, bar, area, pie, or scatter chart to a dataset's showcase. |
+| [`/portaljs-add-map`](.claude/commands/portaljs-add-map.md) | Render a GeoJSON dataset on an interactive map and register it on the home page. |
+| [`/portaljs-define-schema`](.claude/commands/portaljs-define-schema.md) | Infer a Frictionless Table Schema from a dataset's data, add license/source/keyword metadata, and surface a typed field table on its showcase. |
+| [`/portaljs-connect-ckan`](.claude/commands/portaljs-connect-ckan.md) | Wire the portal to a CKAN backend over its API instead of static files. |
+| [`/portaljs-check-data-quality`](.claude/commands/portaljs-check-data-quality.md) | Validate a dataset against its schema and flag quality issues (type mismatches, missing values, constraint violations). |
+| [`/portaljs-migrate`](.claude/commands/portaljs-migrate.md) | Harvest or migrate a whole catalog into the portal from CKAN, Socrata, OpenDataSoft, ArcGIS, or DCAT-US, over a canonical Frictionless/DCAT model. |
+| [`/portaljs-deploy`](.claude/commands/portaljs-deploy.md) | Build a static export and publish it to PortalJS Arc — Datopian-managed hosting on Cloudflare — with a live `<slug>.arc.portaljs.com` URL. |
+<!-- END:skills-table -->
+<!-- Generated from scripts/skills-manifest.mjs — edit there and run `npm run gen:skills`. -->
 
 Large-data scaling — big files pushed to Cloudflare R2 via Git LFS — already ships in
 `/portaljs-add-dataset`. More skill families — metadata schemas (Frictionless/DCAT), more

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "license": "MIT",
   "scripts": {
     "changeset": "changeset",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "gen:skills": "node scripts/gen-skills-docs.mjs",
+    "gen:skills:check": "node scripts/gen-skills-docs.mjs --check"
   },
   "private": true,
   "devDependencies": {

--- a/scripts/gen-skills-docs.mjs
+++ b/scripts/gen-skills-docs.mjs
@@ -43,7 +43,9 @@ function mdTable(hrefFor) {
 function replaceBlock(content, block, marker) {
   const re = new RegExp(`${escapeRe(marker.begin)}[\\s\\S]*?${escapeRe(marker.end)}`)
   if (!re.test(content)) throw new Error(`missing ${marker.begin} / ${marker.end} markers`)
-  return content.replace(re, `${marker.begin}\n${block}\n${marker.end}`)
+  // Blank lines around the block so the table parses in both GFM and MDX (an MDX
+  // table immediately adjacent to a {/* */} comment can fail to render).
+  return content.replace(re, `${marker.begin}\n\n${block}\n\n${marker.end}`)
 }
 
 // Build every target's desired content from the manifest.

--- a/scripts/gen-skills-docs.mjs
+++ b/scripts/gen-skills-docs.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Generate the skills table + sidebar from scripts/skills-manifest.mjs so the README
+// and the site never drift. Run `npm run gen:skills` after editing the manifest;
+// `npm run gen:skills:check` (CI) fails if any target is stale.
+//
+// Targets:
+//   README.md                          — skills table (repo-relative links), between markers
+//   site/content/docs/skills.md        — skills table (site-relative links), between markers
+//   site/content/assets/docs-sidebar.json — the "Skills" section's links array
+//
+// Usage: node scripts/gen-skills-docs.mjs [--check]
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { SKILLS } from './skills-manifest.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const CHECK = process.argv.includes('--check')
+
+const README = join(ROOT, 'README.md')
+const DOCS = join(ROOT, 'site/content/docs/skills.md')
+const SIDEBAR = join(ROOT, 'site/content/assets/docs-sidebar.json')
+
+const MARKER = 'skills-table'
+// Marker comment syntax differs by surface: README is GitHub-flavored markdown
+// (HTML comments are fine); the docs page is MDX, where HTML comments break the
+// build — it needs JSX comments `{/* */}`.
+const HTML = { begin: `<!-- BEGIN:${MARKER} -->`, end: `<!-- END:${MARKER} -->` }
+const MDX = { begin: `{/* BEGIN:${MARKER} */}`, end: `{/* END:${MARKER} */}` }
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function mdTable(hrefFor) {
+  const rows = SKILLS.map((s) => `| [\`/${s.id}\`](${hrefFor(s.id)}) | ${s.summary} |`)
+  return ['| Skill | What it does |', '| ----- | ------------ |', ...rows].join('\n')
+}
+
+// Replace the content between the begin/end markers (keeping the marker lines).
+// Throws if the markers are missing.
+function replaceBlock(content, block, marker) {
+  const re = new RegExp(`${escapeRe(marker.begin)}[\\s\\S]*?${escapeRe(marker.end)}`)
+  if (!re.test(content)) throw new Error(`missing ${marker.begin} / ${marker.end} markers`)
+  return content.replace(re, `${marker.begin}\n${block}\n${marker.end}`)
+}
+
+// Build every target's desired content from the manifest.
+const targets = []
+
+targets.push({
+  path: README,
+  next: replaceBlock(readFileSync(README, 'utf8'), mdTable((id) => `.claude/commands/${id}.md`), HTML),
+})
+
+targets.push({
+  path: DOCS,
+  next: replaceBlock(readFileSync(DOCS, 'utf8'), mdTable((id) => `/docs/skills/${id}`), MDX),
+})
+
+// Sidebar: replace the links of the section titled "Skills" (keep "Skills reference" first).
+const sidebar = JSON.parse(readFileSync(SIDEBAR, 'utf8'))
+const skillsSection = sidebar.find((s) => s.title === 'Skills')
+if (!skillsSection) throw new Error(`no "Skills" section in ${SIDEBAR}`)
+skillsSection.links = [
+  { title: 'Skills reference', href: '/docs/skills' },
+  ...SKILLS.map((s) => ({ title: `/${s.id}`, href: `/docs/skills/${s.id}` })),
+]
+targets.push({ path: SIDEBAR, next: JSON.stringify(sidebar, null, 2) + '\n' })
+
+// Apply or check.
+const stale = []
+for (const { path, next } of targets) {
+  const current = readFileSync(path, 'utf8')
+  if (current === next) continue
+  stale.push(path.replace(ROOT + '/', ''))
+  if (!CHECK) writeFileSync(path, next)
+}
+
+if (CHECK) {
+  if (stale.length) {
+    console.error('Skills docs are stale — run `npm run gen:skills`:\n  ' + stale.join('\n  '))
+    process.exit(1)
+  }
+  console.log('Skills docs are in sync ✓')
+} else {
+  console.log(stale.length ? 'Updated:\n  ' + stale.join('\n  ') : 'Already up to date ✓')
+}

--- a/scripts/skills-manifest.mjs
+++ b/scripts/skills-manifest.mjs
@@ -1,0 +1,66 @@
+// Single source of truth for the PortalJS skills list.
+//
+// The README skills table, the /docs/skills reference table, and the docs sidebar
+// are all GENERATED from this array by scripts/gen-skills-docs.mjs — run
+// `npm run gen:skills` after editing, and `npm run gen:skills:check` verifies they're
+// in sync (used in CI). This is what keeps the README and the site from drifting.
+//
+// Order here is the canonical order shown everywhere (roughly the build flow:
+// decide → scaffold → load data → enrich → describe → connect → validate → migrate → ship).
+// `summary` is plain, reader-facing one-liner copy. Keep any `<...>` in backticks so it
+// survives MDX (an un-fenced <slug> is parsed as a JSX tag and breaks the site build).
+
+export const SKILLS = [
+  {
+    id: 'portaljs-architect',
+    summary:
+      "Advisory — turns your needs (data, scale, governance) into a recommended architecture before you build. Start here if you're unsure of the stack.",
+  },
+  {
+    id: 'portaljs-new-portal',
+    summary:
+      'Scaffold a new portal (Home + Catalog + Showcase) from a brief — copies the template, substitutes your project name and description, installs deps, verifies the build.',
+  },
+  {
+    id: 'portaljs-add-dataset',
+    summary:
+      'Add a CSV, TSV, JSON, or GeoJSON dataset — registers it in the catalog and renders its showcase automatically; large local files are pushed to Cloudflare R2 via Git LFS for you.',
+  },
+  {
+    id: 'portaljs-add-resource',
+    summary:
+      'Attach another file (data dictionary, methodology, extra data) to an existing dataset — it becomes multi-resource and the showcase renders a section per file.',
+  },
+  {
+    id: 'portaljs-add-chart',
+    summary: "Add a line, bar, area, pie, or scatter chart to a dataset's showcase.",
+  },
+  {
+    id: 'portaljs-add-map',
+    summary: 'Render a GeoJSON dataset on an interactive map and register it on the home page.',
+  },
+  {
+    id: 'portaljs-define-schema',
+    summary:
+      "Infer a Frictionless Table Schema from a dataset's data, add license/source/keyword metadata, and surface a typed field table on its showcase.",
+  },
+  {
+    id: 'portaljs-connect-ckan',
+    summary: 'Wire the portal to a CKAN backend over its API instead of static files.',
+  },
+  {
+    id: 'portaljs-check-data-quality',
+    summary:
+      'Validate a dataset against its schema and flag quality issues (type mismatches, missing values, constraint violations).',
+  },
+  {
+    id: 'portaljs-migrate',
+    summary:
+      'Harvest or migrate a whole catalog into the portal from CKAN, Socrata, OpenDataSoft, ArcGIS, or DCAT-US, over a canonical Frictionless/DCAT model.',
+  },
+  {
+    id: 'portaljs-deploy',
+    summary:
+      'Build a static export and publish it to PortalJS Arc — Datopian-managed hosting on Cloudflare — with a live `<slug>.arc.portaljs.com` URL.',
+  },
+]

--- a/site/content/assets/docs-sidebar.json
+++ b/site/content/assets/docs-sidebar.json
@@ -61,20 +61,20 @@
         "href": "/docs/skills/portaljs-add-map"
       },
       {
-        "title": "/portaljs-connect-ckan",
-        "href": "/docs/skills/portaljs-connect-ckan"
-      },
-      {
-        "title": "/portaljs-migrate",
-        "href": "/docs/skills/portaljs-migrate"
-      },
-      {
         "title": "/portaljs-define-schema",
         "href": "/docs/skills/portaljs-define-schema"
       },
       {
+        "title": "/portaljs-connect-ckan",
+        "href": "/docs/skills/portaljs-connect-ckan"
+      },
+      {
         "title": "/portaljs-check-data-quality",
         "href": "/docs/skills/portaljs-check-data-quality"
+      },
+      {
+        "title": "/portaljs-migrate",
+        "href": "/docs/skills/portaljs-migrate"
       },
       {
         "title": "/portaljs-deploy",

--- a/site/content/docs/skills.md
+++ b/site/content/docs/skills.md
@@ -33,6 +33,7 @@ portal. You describe intent; the skill writes the code.
 {/* Generated from scripts/skills-manifest.mjs — edit there and run `npm run gen:skills`. */}
 
 {/* BEGIN:skills-table */}
+
 | Skill | What it does |
 | ----- | ------------ |
 | [`/portaljs-architect`](/docs/skills/portaljs-architect) | Advisory — turns your needs (data, scale, governance) into a recommended architecture before you build. Start here if you're unsure of the stack. |
@@ -46,6 +47,7 @@ portal. You describe intent; the skill writes the code.
 | [`/portaljs-check-data-quality`](/docs/skills/portaljs-check-data-quality) | Validate a dataset against its schema and flag quality issues (type mismatches, missing values, constraint violations). |
 | [`/portaljs-migrate`](/docs/skills/portaljs-migrate) | Harvest or migrate a whole catalog into the portal from CKAN, Socrata, OpenDataSoft, ArcGIS, or DCAT-US, over a canonical Frictionless/DCAT model. |
 | [`/portaljs-deploy`](/docs/skills/portaljs-deploy) | Build a static export and publish it to PortalJS Arc — Datopian-managed hosting on Cloudflare — with a live `<slug>.arc.portaljs.com` URL. |
+
 {/* END:skills-table */}
 
 ## Author your own

--- a/site/content/docs/skills.md
+++ b/site/content/docs/skills.md
@@ -30,19 +30,23 @@ portal. You describe intent; the skill writes the code.
 
 ## The skills
 
+{/* Generated from scripts/skills-manifest.mjs — edit there and run `npm run gen:skills`. */}
+
+{/* BEGIN:skills-table */}
 | Skill | What it does |
 | ----- | ------------ |
 | [`/portaljs-architect`](/docs/skills/portaljs-architect) | Advisory — turns your needs (data, scale, governance) into a recommended architecture before you build. Start here if you're unsure of the stack. |
-| [`/portaljs-new-portal`](/docs/skills/portaljs-new-portal) | Scaffold a new portal from a brief — copies the template, substitutes your project name and description, installs deps, verifies the build. |
-| [`/portaljs-add-dataset`](/docs/skills/portaljs-add-dataset) | Add a CSV, TSV, JSON, or GeoJSON dataset — copies the data in, generates a dataset page, and registers it on the home page catalog. |
-| [`/portaljs-migrate`](/docs/skills/portaljs-migrate) | Harvest or migrate a whole catalog into the portal from CKAN, Socrata, OpenDataSoft, ArcGIS, or DCAT-US, over a canonical Frictionless/DCAT model. |
+| [`/portaljs-new-portal`](/docs/skills/portaljs-new-portal) | Scaffold a new portal (Home + Catalog + Showcase) from a brief — copies the template, substitutes your project name and description, installs deps, verifies the build. |
+| [`/portaljs-add-dataset`](/docs/skills/portaljs-add-dataset) | Add a CSV, TSV, JSON, or GeoJSON dataset — registers it in the catalog and renders its showcase automatically; large local files are pushed to Cloudflare R2 via Git LFS for you. |
 | [`/portaljs-add-resource`](/docs/skills/portaljs-add-resource) | Attach another file (data dictionary, methodology, extra data) to an existing dataset — it becomes multi-resource and the showcase renders a section per file. |
-| [`/portaljs-add-chart`](/docs/skills/portaljs-add-chart) | Add a line, bar, area, pie, or scatter chart to a dataset page using `recharts`. |
-| [`/portaljs-add-map`](/docs/skills/portaljs-add-map) | Render a GeoJSON dataset on an interactive Leaflet map and register it on the home page. |
-| [`/portaljs-connect-ckan`](/docs/skills/portaljs-connect-ckan) | Wire the portal to a [CKAN](/ckan) backend over its API instead of static files. |
+| [`/portaljs-add-chart`](/docs/skills/portaljs-add-chart) | Add a line, bar, area, pie, or scatter chart to a dataset's showcase. |
+| [`/portaljs-add-map`](/docs/skills/portaljs-add-map) | Render a GeoJSON dataset on an interactive map and register it on the home page. |
 | [`/portaljs-define-schema`](/docs/skills/portaljs-define-schema) | Infer a Frictionless Table Schema from a dataset's data, add license/source/keyword metadata, and surface a typed field table on its showcase. |
+| [`/portaljs-connect-ckan`](/docs/skills/portaljs-connect-ckan) | Wire the portal to a CKAN backend over its API instead of static files. |
 | [`/portaljs-check-data-quality`](/docs/skills/portaljs-check-data-quality) | Validate a dataset against its schema and flag quality issues (type mismatches, missing values, constraint violations). |
-| [`/portaljs-deploy`](/docs/skills/portaljs-deploy) | Build a static export and publish it to [PortalJS Arc](/docs/arc) — Datopian-managed hosting — with a live `<slug>.arc.portaljs.com` URL. Or self-host the export anywhere. |
+| [`/portaljs-migrate`](/docs/skills/portaljs-migrate) | Harvest or migrate a whole catalog into the portal from CKAN, Socrata, OpenDataSoft, ArcGIS, or DCAT-US, over a canonical Frictionless/DCAT model. |
+| [`/portaljs-deploy`](/docs/skills/portaljs-deploy) | Build a static export and publish it to PortalJS Arc — Datopian-managed hosting on Cloudflare — with a live `<slug>.arc.portaljs.com` URL. |
+{/* END:skills-table */}
 
 ## Author your own
 


### PR DESCRIPTION
Kills README↔site drift on the skills list (the class of staleness we just fixed by hand). One manifest → three generated targets.

- **`scripts/skills-manifest.mjs`** — the source of truth (ordered id + one-line summary).
- **`scripts/gen-skills-docs.mjs`** — writes the README skills table (HTML-comment markers), the `/docs/skills` table (MDX `{/* */}` markers — HTML comments break MDX), and the `docs-sidebar.json` Skills section. `--check` mode for CI.
- **`npm run gen:skills`** / **`gen:skills:check`**; **`.github/workflows/skills-sync.yml`** fails a PR that hand-edits a generated block.
- Side benefits: normalizes skill order across all three surfaces, and completes the README table (was missing `add-resource`, `define-schema`, `migrate`).

To add/edit a skill's row now: edit the manifest, run `npm run gen:skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated generation and validation for the skills documentation across the site and README.
  * Expanded and refreshed the visible skills list with updated command entries and descriptions.

* **Bug Fixes**
  * Kept the README, skills docs page, and docs sidebar aligned to reduce outdated or mismatched skill information.

* **Chores**
  * Added a new CI workflow to fail pull requests when generated skills docs are out of sync.
  * Added package scripts to generate and check skills documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->