### PR TITLE
feat(skills): default R2_PUBLIC_BASE to data.portaljs.com (po-g9y.14)

### DIFF
--- a/.claude/commands/portaljs-add-dataset.md
+++ b/.claude/commands/portaljs-add-dataset.md
@@ -195,11 +195,12 @@ The Giftless object key is `lfs/datopian/<project-slug>/<oid>`, where `<oid>` is
 in the committed LFS pointer:
 ```bash
 OID=$(git cat-file -p :data/$DATASET_SLUG.$EXT | sed -n 's/^oid sha256://p')
-# MANIFEST_PATH = <R2_PUBLIC_BASE>/lfs/datopian/<project-slug>/$OID
+# MANIFEST_PATH = $R2_PUBLIC_BASE/lfs/datopian/<project-slug>/$OID
 ```
-`R2_PUBLIC_BASE` is the bucket's public base URL (custom domain or `r2.dev`). **If you don't
-know it, ask the user** — don't guess. (The staging public base is provisioned per
-deployment; see `giftless/README.md`.)
+`R2_PUBLIC_BASE` defaults to **`https://data.portaljs.com`** — the public read domain on the
+`portaljs-giftless` R2 bucket (GET/HEAD + range + CORS, edge-cached). So the browser fetches
+`https://data.portaljs.com/lfs/datopian/<project-slug>/<oid>` directly. Override it only for
+an OSS self-host with its own bucket/domain (`export R2_PUBLIC_BASE=…`).
 
 #### 4d. Local file — inline (FENCED exception only)
 

--- a/.claude/commands/portaljs-migrate.md
+++ b/.claude/commands/portaljs-migrate.md
@@ -297,10 +297,11 @@ Ensure `slug` is unique within its `namespace` (suffix `-2`, `-3`, … on collis
      `lfs/datopian/<portal-slug>/<oid>`:
      ```bash
      OID=$(git cat-file -p ":data/<namespace>/<slug>/<NN>-<file>" | sed -n 's/^oid sha256://p')
-     # path = <R2_PUBLIC_BASE>/lfs/datopian/<portal-slug>/<OID>
+     # path = $R2_PUBLIC_BASE/lfs/datopian/<portal-slug>/<OID>
      ```
-     `R2_PUBLIC_BASE` is the bucket's public base URL (custom domain or `r2.dev`) — **ask the
-     user if unknown**, don't guess.
+     `R2_PUBLIC_BASE` defaults to **`https://data.portaljs.com`** — the public read domain on
+     the `portaljs-giftless` R2 bucket (GET/HEAD + range + CORS, edge-cached), so the browser
+     fetches the data directly. Override only for an OSS self-host with its own bucket/domain.
 
   Self-contained portal, no runtime dependency on the source, and the repo stays tiny (only
   pointers) no matter how large the catalog — the bytes are in R2.


### PR DESCRIPTION
Public read path for Giftless/R2 data is live: **data.portaljs.com** is a public custom domain on the `portaljs-giftless` bucket — GET/HEAD + range + CORS, edge-cached, valid TLS (verified end-to-end: full GET 200, range 206, `access-control-allow-origin: *`).

Wires `R2_PUBLIC_BASE = https://data.portaljs.com` into `/portaljs-add-dataset` + `/portaljs-migrate` so they stop asking the user and emit browser-fetchable `https://data.portaljs.com/lfs/datopian/<slug>/<oid>` URLs (incl. DuckDB-Wasm range reads). Self-hosters override.

Closes the infra half of po-g9y.14 (public bucket, no Worker per the decision). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to set the public base URL when routing datasets through cloud storage.
  * Added a clear default value for the public read domain and explained when to override it for self-hosted setups.
  * Updated examples so direct browser access to dataset files is easier to configure and understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->