### PR TITLE
fix(ci): scaffold-e2e --namespace theme (po-7z5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           node packages/create-portaljs/index.mjs smoke-portal \
             --yes --no-git \
-            --namespace reference \
+            --namespace theme \
             --name "Smoke Portal" \
             --ref "${{ github.head_ref || github.ref_name }}"
           cd smoke-portal


### PR DESCRIPTION
Lands po-7z5: CI passed --namespace reference (a value) but --namespace is a mode selector (theme|owner). One-line ci.yml fix. Third of the stacked CI fixes (po-9en lint, po-yq5 react19 install, this). Should turn CI fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI smoke test setup to generate the portal with a different namespace, keeping the build verification aligned with the latest configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->