### PR TITLE
ci: build site/ on PRs so type-check regressions fail CI (po-8sd)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,28 @@ jobs:
           npm ci
           npm run build
 
+  # site/ is NOT a root workspace — it has its own package-lock.json and
+  # resolves @portaljs/* from the npm registry, so it builds standalone
+  # (same as its production deploy). Node 22 only: site targets a single
+  # runtime and its build (mddb + next build) is the slow path. See po-8sd.
+  site:
+    name: Build site (www.portaljs.com)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build site
+        working-directory: site
+        run: |
+          npm ci
+          npm run build
+
   scaffold:
     name: Scaffold end-to-end (Node ${{ matrix.node }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a **Build site (www.portaljs.com)** job to CI so `site/` regressions fail PRs (3-week type-check breakage went unnoticed — po-8sd).

Deviation from bead brief: `site/` is **not** a root workspace — it has its own `package-lock.json` and resolves `@portaljs/*` from the npm registry. So the job builds it standalone (`npm ci && npm run build` in `site/`), mirroring the production deploy, instead of root `npm ci` + `npm run build -w site` (which cannot work). No env vars needed: next-sitemap defaults to portaljs.com, feeds hardcode the URL. Node 22 only.

Verified locally on Node 22: full build green (mddb → next build → sitemap + feeds).

Draft — mayor lands after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated checks to include the standalone site package on Node.js 22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->