### PR TITLE
feat(skills): standard skills/<name>/SKILL.md format for crawler discovery (po-abr.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,16 +22,20 @@
     "./.claude/commands/portaljs-define-schema.md",
     "./.claude/commands/portaljs-deploy.md",
     "./.claude/commands/portaljs-check-data-quality.md",
-    "./.claude/commands/architect.md",
-    "./.claude/commands/new-portal.md",
-    "./.claude/commands/add-dataset.md",
-    "./.claude/commands/add-resource.md",
-    "./.claude/commands/add-chart.md",
-    "./.claude/commands/add-map.md",
-    "./.claude/commands/connect-ckan.md",
-    "./.claude/commands/migrate.md",
-    "./.claude/commands/define-schema.md",
-    "./.claude/commands/deploy.md",
-    "./.claude/commands/check-data-quality.md"
+    "./.claude/commands/portaljs-add-dcat.md"
+  ],
+  "skills": [
+    "./skills/portaljs-architect",
+    "./skills/portaljs-new-portal",
+    "./skills/portaljs-add-dataset",
+    "./skills/portaljs-add-resource",
+    "./skills/portaljs-add-chart",
+    "./skills/portaljs-add-map",
+    "./skills/portaljs-connect-ckan",
+    "./skills/portaljs-migrate",
+    "./skills/portaljs-define-schema",
+    "./skills/portaljs-deploy",
+    "./skills/portaljs-check-data-quality",
+    "./skills/portaljs-add-dcat"
   ]
 }

--- a/skills/portaljs-add-chart/SKILL.md
+++ b/skills/portaljs-add-chart/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-add-chart
+description: Add a chart (line, bar, area, pie, or scatter) to a dataset's showcase in a PortalJS portal. Installs recharts, writes a reusable Chart component, and renders it in the showcase Views section.
+---
+
+# PortalJS — Add Chart
+
+Add a chart (line, bar, area, pie, or scatter) to a dataset's showcase in a PortalJS portal. Installs recharts, writes a reusable Chart component, and renders it in the showcase Views section.
+
+## Usage
+
+Invoke as the `/portaljs-add-chart` slash command in Claude Code, or ask your agent to run the **portaljs-add-chart** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-add-chart.md`](../../.claude/commands/portaljs-add-chart.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-add-dataset/SKILL.md
+++ b/skills/portaljs-add-dataset/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-add-dataset
+description: Add a dataset (CSV, TSV, JSON, or GeoJSON) to an existing PortalJS portal. Appends an entry to datasets.json so the catalog and showcase render it automatically; routes the data by source (local file vs remote URL) — R2 via Git LFS by default, remote URLs by passthrough.
+---
+
+# PortalJS — Add Dataset
+
+Add a dataset (CSV, TSV, JSON, or GeoJSON) to an existing PortalJS portal. Appends an entry to datasets.json so the catalog and showcase render it automatically; routes the data by source (local file vs remote URL) — R2 via Git LFS by default, remote URLs by passthrough.
+
+## Usage
+
+Invoke as the `/portaljs-add-dataset` slash command in Claude Code, or ask your agent to run the **portaljs-add-dataset** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-add-dataset.md`](../../.claude/commands/portaljs-add-dataset.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-add-dcat/SKILL.md
+++ b/skills/portaljs-add-dcat/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-add-dcat
+description: Make a PortalJS portal harvestable by national/EU/US open-data portals — emit standards-compliant DCAT catalog feeds (DCAT 2/3, DCAT-AP, DCAT-US, national profiles) in JSON-LD, Turtle, and RDF/XML at build, with autodiscovery and per-profile conformance checking.
+---
+
+# PortalJS — Add DCAT
+
+Make a PortalJS portal harvestable by national/EU/US open-data portals — emit standards-compliant DCAT catalog feeds (DCAT 2/3, DCAT-AP, DCAT-US, national profiles) in JSON-LD, Turtle, and RDF/XML at build, with autodiscovery and per-profile conformance checking.
+
+## Usage
+
+Invoke as the `/portaljs-add-dcat` slash command in Claude Code, or ask your agent to run the **portaljs-add-dcat** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-add-dcat.md`](../../.claude/commands/portaljs-add-dcat.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-add-map/SKILL.md
+++ b/skills/portaljs-add-map/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-add-map
+description: Render a GeoJSON dataset on an interactive Leaflet map in the Views section of a dataset's showcase. Installs react-leaflet and a Map component, then renders the map for the chosen dataset.
+---
+
+# PortalJS — Add Map
+
+Render a GeoJSON dataset on an interactive Leaflet map in the Views section of a dataset's showcase. Installs react-leaflet and a Map component, then renders the map for the chosen dataset.
+
+## Usage
+
+Invoke as the `/portaljs-add-map` slash command in Claude Code, or ask your agent to run the **portaljs-add-map** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-add-map.md`](../../.claude/commands/portaljs-add-map.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-add-resource/SKILL.md
+++ b/skills/portaljs-add-resource/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-add-resource
+description: Add another file (resource) to an EXISTING dataset in a PortalJS portal — a data dictionary, methodology, or an additional data file. Turns a single-file dataset into a multi-resource one; the showcase renders a section per resource.
+---
+
+# PortalJS — Add Resource
+
+Add another file (resource) to an EXISTING dataset in a PortalJS portal — a data dictionary, methodology, or an additional data file. Turns a single-file dataset into a multi-resource one; the showcase renders a section per resource.
+
+## Usage
+
+Invoke as the `/portaljs-add-resource` slash command in Claude Code, or ask your agent to run the **portaljs-add-resource** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-add-resource.md`](../../.claude/commands/portaljs-add-resource.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-architect/SKILL.md
+++ b/skills/portaljs-architect/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-architect
+description: Recommend a data-portal architecture (storage, compute, catalog, access, hosting, metadata) from your needs, then hand off to the build skills. The advisory entry point.
+---
+
+# PortalJS — Architect
+
+Recommend a data-portal architecture (storage, compute, catalog, access, hosting, metadata) from your needs, then hand off to the build skills. The advisory entry point.
+
+## Usage
+
+Invoke as the `/portaljs-architect` slash command in Claude Code, or ask your agent to run the **portaljs-architect** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-architect.md`](../../.claude/commands/portaljs-architect.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-check-data-quality/SKILL.md
+++ b/skills/portaljs-check-data-quality/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-check-data-quality
+description: Audit a local or remote tabular file (CSV/TSV) for common data quality issues. Read-only. Use only when the user explicitly asks to check or audit data quality.
+---
+
+# PortalJS — Check Data Quality
+
+Audit a local or remote tabular file (CSV/TSV) for common data quality issues. Read-only. Use only when the user explicitly asks to check or audit data quality.
+
+## Usage
+
+Invoke as the `/portaljs-check-data-quality` slash command in Claude Code, or ask your agent to run the **portaljs-check-data-quality** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-check-data-quality.md`](../../.claude/commands/portaljs-check-data-quality.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-connect-ckan/SKILL.md
+++ b/skills/portaljs-connect-ckan/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-connect-ckan
+description: Wire a scaffolded PortalJS portal to a CKAN backend over its API. Generates a tiny server-side fetch client (no runtime dependency) and feeds the /search catalog and /@<namespace>/<slug> showcases from CKAN instead of datasets.json.
+---
+
+# PortalJS — Connect CKAN
+
+Wire a scaffolded PortalJS portal to a CKAN backend over its API. Generates a tiny server-side fetch client (no runtime dependency) and feeds the /search catalog and /@<namespace>/<slug> showcases from CKAN instead of datasets.json.
+
+## Usage
+
+Invoke as the `/portaljs-connect-ckan` slash command in Claude Code, or ask your agent to run the **portaljs-connect-ckan** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-connect-ckan.md`](../../.claude/commands/portaljs-connect-ckan.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-define-schema/SKILL.md
+++ b/skills/portaljs-define-schema/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-define-schema
+description: Define a dataset's metadata profile — infer a Frictionless Table Schema from its data, add Data Package metadata (license, sources, keywords), and write it into datasets.json so the showcase renders a typed field table. Extend or customize via the L0→L3 profile ladder.
+---
+
+# PortalJS — Define Schema
+
+Define a dataset's metadata profile — infer a Frictionless Table Schema from its data, add Data Package metadata (license, sources, keywords), and write it into datasets.json so the showcase renders a typed field table. Extend or customize via the L0→L3 profile ladder.
+
+## Usage
+
+Invoke as the `/portaljs-define-schema` slash command in Claude Code, or ask your agent to run the **portaljs-define-schema** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-define-schema.md`](../../.claude/commands/portaljs-define-schema.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-deploy/SKILL.md
+++ b/skills/portaljs-deploy/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-deploy
+description: Deploy a PortalJS portal to PortalJS Arc — Datopian-managed static hosting on Cloudflare. Builds a static export, uploads it, and returns a live <slug>.arc.portaljs.com URL. One command, one target.
+---
+
+# PortalJS — Deploy
+
+Deploy a PortalJS portal to PortalJS Arc — Datopian-managed static hosting on Cloudflare. Builds a static export, uploads it, and returns a live <slug>.arc.portaljs.com URL. One command, one target.
+
+## Usage
+
+Invoke as the `/portaljs-deploy` slash command in Claude Code, or ask your agent to run the **portaljs-deploy** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-deploy.md`](../../.claude/commands/portaljs-deploy.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-migrate/SKILL.md
+++ b/skills/portaljs-migrate/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-migrate
+description: Migrate (harvest) datasets between open-data platforms. Reads CKAN, a DCAT-US /data.json catalog (DKAN, ArcGIS Hub, data.gov), a DCAT / DCAT-AP RDF feed (JSON-LD, Turtle, or RDF/XML — data.europa.eu, national DCAT-AP portals, GeoDCAT-AP), Socrata, OpenDataSoft, or an ArcGIS FeatureServer, and writes them to a static PortalJS catalog (datasets.json, link-by-URL or download data files into Cloudflare R2 via Git LFS / Giftless) or pushes them into a CKAN instance over its API.
+---
+
+# PortalJS — Migrate
+
+Migrate (harvest) datasets between open-data platforms. Reads CKAN, a DCAT-US /data.json catalog (DKAN, ArcGIS Hub, data.gov), a DCAT / DCAT-AP RDF feed (JSON-LD, Turtle, or RDF/XML — data.europa.eu, national DCAT-AP portals, GeoDCAT-AP), Socrata, OpenDataSoft, or an ArcGIS FeatureServer, and writes them to a static PortalJS catalog (datasets.json, link-by-URL or download data files into Cloudflare R2 via Git LFS / Giftless) or pushes them into a CKAN instance over its API.
+
+## Usage
+
+Invoke as the `/portaljs-migrate` slash command in Claude Code, or ask your agent to run the **portaljs-migrate** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-migrate.md`](../../.claude/commands/portaljs-migrate.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.

--- a/skills/portaljs-new-portal/SKILL.md
+++ b/skills/portaljs-new-portal/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: portaljs-new-portal
+description: Scaffold a new PortalJS data portal from a brief. Copies the canonical template from examples/portaljs-catalog and substitutes project tokens.
+---
+
+# PortalJS — New Portal
+
+Scaffold a new PortalJS data portal from a brief. Copies the canonical template from examples/portaljs-catalog and substitutes project tokens.
+
+## Usage
+
+Invoke as the `/portaljs-new-portal` slash command in Claude Code, or ask your agent to run the **portaljs-new-portal** skill. The skill interviews you for any missing input rather than erroring.
+
+## Instructions
+
+The canonical, full step-by-step workflow for this skill lives in
+[`.claude/commands/portaljs-new-portal.md`](../../.claude/commands/portaljs-new-portal.md) in this repository —
+that file is the single source of truth. When executing this skill, read and follow it.


### PR DESCRIPTION
## Summary
- Add a top-level `skills/` directory with one `skills/<name>/SKILL.md` per PortalJS skill (12 total), each with standard Agent Skills frontmatter (`name:` + `description:`), so skill crawlers (skills.sh, SkillsMP, awesome-claude-plugins, claudemarketplaces.com) can index the repo.
- Each SKILL.md reuses the description from its `.claude/commands/portaljs-*.md` command file and points at that file as the canonical single source of truth — no duplicated workflow bodies to drift.
- Wire a `skills[]` array into `.claude-plugin/plugin.json` pointing at the new `skills/` directories.
- Dedupe `commands[]` in plugin.json: drop the bare-name alias entries (`architect.md`, `new-portal.md`, … — deprecation stubs slated for removal next minor release) and add the missing `portaljs-add-dcat.md`.

## Validation
- JSON valid; all 12 command paths and 12 skill dirs verified to exist on disk.
- SKILL.md frontmatter validated: `name` matches directory, `description` present.
- `npm run gen:skills:check` passes (skills docs in sync).
- No files touched by the `Build site` CI job or skills-sync workflow triggers.

Part of epic po-abr (skill/plugin directory indexing). Do not merge — mayor lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for several new PortalJS skills, including chart, map, dataset, resource, schema, migration, deployment, CKAN connection, data quality checks, and new portal setup.
  * Introduced a curated skill order and updated the available command list to reflect the supported workflow.

* **Documentation**
  * Added usage guidance for running each skill through Claude Code slash commands or by asking the agent to execute them.
  * Clarified where to find the canonical step-by-step workflow for each skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->