### PR TITLE
feat(blog): branded placeholder featured image for imageless posts (po-66l)

### DIFF
--- a/site/components/blog/BlogCard.tsx
+++ b/site/components/blog/BlogCard.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
 import Link from 'next/link'
+import { DEFAULT_FEATURED_IMAGE } from './defaultFeaturedImage'
 
 interface Author {
   name: string
@@ -48,15 +49,11 @@ export default function BlogCard({ blog, labels }: { blog: BlogPost; labels?: st
     >
       {/* Image */}
       <div className="relative aspect-video flex-none overflow-hidden">
-        {blog.image ? (
-          <img
-            src={blog.image}
-            alt={blog.title}
-            className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
-          />
-        ) : (
-          <div className="absolute inset-0 bg-gradient-to-br from-sky-400/15 to-blue-600/10" />
-        )}
+        <img
+          src={blog.image || DEFAULT_FEATURED_IMAGE}
+          alt={blog.title}
+          className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
+        />
       </div>
 
       {/* Content */}

--- a/site/components/blog/FeaturedBlogPost.tsx
+++ b/site/components/blog/FeaturedBlogPost.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
 import Link from 'next/link'
+import { DEFAULT_FEATURED_IMAGE } from './defaultFeaturedImage'
 
 interface Author {
   name: string
@@ -48,15 +49,11 @@ export default function FeaturedBlogPost({ blog, labels }: { blog: BlogPost; lab
     >
       {/* Image side */}
       <div className="relative aspect-video overflow-hidden lg:aspect-auto lg:w-[58%] lg:flex-none">
-        {blog.image ? (
-          <img
-            src={blog.image}
-            alt={blog.title}
-            className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.02]"
-          />
-        ) : (
-          <div className="absolute inset-0 bg-gradient-to-br from-sky-400/20 to-blue-600/15" />
-        )}
+        <img
+          src={blog.image || DEFAULT_FEATURED_IMAGE}
+          alt={blog.title}
+          className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.02]"
+        />
       </div>
 
       {/* Content side */}

--- a/site/components/blog/MiniCard.tsx
+++ b/site/components/blog/MiniCard.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { DEFAULT_FEATURED_IMAGE } from './defaultFeaturedImage'
 
 interface Author {
   name: string
@@ -38,15 +39,11 @@ export default function MiniCard({ blog, labels }: { blog: BlogPost; labels?: st
     >
       {/* Thumbnail */}
       <div className="relative w-[72px] flex-none overflow-hidden rounded-lg">
-        {blog.image ? (
-          <img
-            src={blog.image}
-            alt={blog.title}
-            className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-          />
-        ) : (
-          <div className="absolute inset-0 bg-gradient-to-br from-sky-400/20 to-blue-600/15" />
-        )}
+        <img
+          src={blog.image || DEFAULT_FEATURED_IMAGE}
+          alt={blog.title}
+          className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+        />
       </div>
 
       {/* Content */}

--- a/site/components/blog/defaultFeaturedImage.ts
+++ b/site/components/blog/defaultFeaturedImage.ts
@@ -1,0 +1,5 @@
+// Placeholder featured image used when a blog post has no `image` in its
+// frontmatter. A self-contained 1200×630 SVG (PortalJS cyclone mark + orbiting
+// composable-skill marks) so imageless posts still get a branded card on /blog.
+// Imported from a Claude Design project ("PortalJS blog featured images").
+export const DEFAULT_FEATURED_IMAGE = '/static/img/blog/default-featured.svg'

--- a/site/public/static/img/blog/default-featured.svg
+++ b/site/public/static/img/blog/default-featured.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="PortalJS">
+  <defs>
+    <linearGradient id="cyc" x1="15%" y1="0%" x2="85%" y2="100%">
+      <stop offset="0%" stop-color="#7dd3fc"></stop>
+      <stop offset="50%" stop-color="#38bdf8"></stop>
+      <stop offset="100%" stop-color="#2563eb"></stop>
+    </linearGradient>
+    <radialGradient id="lift" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#eff6ff" stop-opacity="0.9"></stop>
+      <stop offset="60%" stop-color="#eff6ff" stop-opacity="0.35"></stop>
+      <stop offset="100%" stop-color="#eff6ff" stop-opacity="0"></stop>
+    </radialGradient>
+    <pattern id="dots" width="27" height="27" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1.15" fill="#e2e8f0"></circle>
+    </pattern>
+    <path id="arm" fill="url(#cyc)" d="M 81.71 41.26 L 80.88 42.48 L 80.04 43.63 L 79.19 44.72 L 78.35 45.74 L 77.50 46.70 L 76.65 47.61 L 75.81 48.45 L 74.97 49.25 L 74.14 49.99 L 73.32 50.68 L 72.50 51.32 L 71.70 51.92 L 70.91 52.47 L 70.13 52.99 L 69.36 53.46 L 68.61 53.90 L 67.87 54.31 L 67.15 54.68 L 66.44 55.02 L 65.74 55.32 L 65.06 55.61 L 64.40 55.86 L 63.75 56.09 L 63.12 56.30 L 62.50 56.48 L 61.89 56.65 L 61.30 56.79 L 60.73 56.92 L 60.17 57.03 L 59.62 57.13 L 59.09 57.20 L 58.57 57.27 L 58.06 57.32 L 57.56 57.36 L 57.08 57.39 L 56.61 57.40 L 56.15 57.41 L 55.69 57.41 L 55.25 57.39 L 54.82 57.37 L 54.40 57.34 L 53.98 57.30 L 53.58 57.25 L 53.18 57.20 L 52.79 57.13 L 52.40 57.06 L 52.02 56.98 L 51.65 56.90 L 51.28 56.81 L 50.92 56.71 L 50.57 56.60 L 50.21 56.48 L 49.87 56.36 L 49.52 56.23 L 49.18 56.09 L 48.84 55.94 L 48.50 55.79 L 48.17 55.62 L 47.83 55.45 L 47.50 55.27 L 47.16 55.08 L 46.81 54.88 L 46.45 54.67 L 46.02 54.46 L 46.02 54.46 L 45.68 54.81 L 45.43 55.17 L 45.22 55.57 L 45.04 55.98 L 44.90 56.42 L 44.78 56.87 L 44.70 57.35 L 44.64 57.84 L 44.61 58.36 L 44.62 58.88 L 44.66 59.43 L 44.73 59.99 L 44.83 60.56 L 44.97 61.14 L 45.15 61.73 L 45.36 62.33 L 45.61 62.94 L 45.90 63.55 L 46.23 64.17 L 46.59 64.78 L 47.00 65.40 L 47.45 66.02 L 47.94 66.63 L 48.48 67.24 L 49.06 67.84 L 49.68 68.43 L 50.35 69.01 L 51.06 69.57 L 51.82 70.12 L 52.63 70.65 L 53.48 71.16 L 54.38 71.65 L 55.32 72.11 L 56.31 72.54 L 57.34 72.95 L 58.42 73.32 L 59.55 73.65 L 60.72 73.94 L 61.93 74.20 L 63.19 74.41 L 64.49 74.57 L 65.83 74.68 L 67.21 74.74 L 68.63 74.75 L 70.09 74.69 L 71.59 74.58 L 73.12 74.40 L 74.68 74.15 L 76.28 73.84 L 77.91 73.45 L 79.56 72.98 L 81.24 72.44 L 82.94 71.82 L 84.66 71.11 L 86.40 70.31 L 88.16 69.42 L 89.92 68.44 L 91.69 67.36 L 93.47 66.19 L 95.25 64.91 L 97.02 63.53 L 98.79 62.04 L 100.55 60.45 L 102.29 58.74 Z"></path>
+    <g id="mark">
+      <use href="#arm" transform="rotate(0 50 50)"></use>
+      <use href="#arm" transform="rotate(120 50 50)"></use>
+      <use href="#arm" transform="rotate(240 50 50)"></use>
+      <circle cx="50" cy="50" r="4.2" fill="#1e3a8a"></circle>
+    </g>
+    <g id="markcore">
+      <use href="#arm" transform="rotate(0 50 50)"></use>
+      <use href="#arm" transform="rotate(120 50 50)"></use>
+      <use href="#arm" transform="rotate(240 50 50)"></use>
+    </g>
+  </defs>
+
+  <!-- self-contained light background -->
+  <rect x="0" y="0" width="1200" height="630" fill="#fbfcfe"></rect>
+
+  <!-- background texture -->
+  <rect x="0" y="0" width="1200" height="630" fill="url(#dots)"></rect>
+  <ellipse cx="600" cy="315" rx="520" ry="420" fill="url(#lift)"></ellipse>
+
+  <!-- concentric orbit rings around focal cyclone -->
+  <g fill="none" stroke="#cbd5e1" stroke-dasharray="2 9" stroke-linecap="round">
+    <circle cx="600" cy="315" r="205" opacity="0.85"></circle>
+    <circle cx="600" cy="315" r="286" opacity="0.6"></circle>
+    <circle cx="600" cy="315" r="372" opacity="0.42"></circle>
+  </g>
+
+  <!-- motion ghosts behind hero -->
+  <use href="#markcore" transform="translate(370 85) scale(4.6) rotate(-19 50 50)" opacity="0.07"></use>
+  <use href="#markcore" transform="translate(378 93) scale(4.44) rotate(11 50 50)" opacity="0.11"></use>
+
+  <!-- hero cyclone -->
+  <use href="#mark" transform="translate(385 100) scale(4.3)"></use>
+
+  <!-- orbiting composable skill marks -->
+  <use href="#mark" transform="translate(918 74) scale(1.18) rotate(-16 50 50)" opacity="0.92"></use>
+  <use href="#mark" transform="translate(168 70) scale(0.98) rotate(9 50 50)" opacity="0.9"></use>
+  <use href="#mark" transform="translate(980 452) scale(0.9) rotate(28 50 50)" opacity="0.85"></use>
+  <use href="#mark" transform="translate(96 448) scale(1.06) rotate(-7 50 50)" opacity="0.85"></use>
+  <use href="#mark" transform="translate(452 548) scale(0.58) rotate(20 50 50)" opacity="0.72"></use>
+  <use href="#mark" transform="translate(712 20) scale(0.5) rotate(-24 50 50)" opacity="0.6"></use>
+
+  <!-- tiny orbital seed dots -->
+  <g fill="#2563eb">
+    <circle cx="806" cy="140" r="3.5" opacity="0.5"></circle>
+    <circle cx="356" cy="486" r="3" opacity="0.45"></circle>
+    <circle cx="898" cy="470" r="2.6" opacity="0.4"></circle>
+  </g>
+</svg>


### PR DESCRIPTION
## What
Recent blog posts with no `image` in frontmatter rendered a plain gradient box on `/blog`. This adds a branded **placeholder featured image** so every post gets a proper card.

- New self-contained **1200×630 SVG** at `site/public/static/img/blog/default-featured.svg` — PortalJS cyclone mark as hero + orbiting "composable skills" marks, blue gradient, dot texture. Imported from the *PortalJS blog featured images* Claude Design project.
- `DEFAULT_FEATURED_IMAGE` constant; `BlogCard`, `FeaturedBlogPost`, `MiniCard` now fall back to it (`blog.image || DEFAULT_FEATURED_IMAGE`) instead of the gradient.

## Scope
- **og:image unchanged** — still the site-wide default. SVG isn't well-supported as an og/twitter image; a PNG render of this design for imageless-post og is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent default blog image for posts without a custom image.
  * Updated blog cards, featured posts, and mini cards to always display an image instead of a placeholder block.

* **Bug Fixes**
  * Improved visual consistency across blog listings when image data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->