### PR TITLE
feat(core,template): <GeoQuery> — GeoParquet + DuckDB-Wasm spatial query (po-6sr.2)

### DIFF
--- a/examples/portaljs-catalog/README.md
+++ b/examples/portaljs-catalog/README.md
@@ -131,6 +131,48 @@ preview with click-to-inspect feature properties. This manual tippecanoe step is
 the interim ingest path; an automated GeoJSON→PMTiles pipeline is a separate
 roadmap phase.
 
+## Geo query tier — spatial SQL over GeoParquet (no download)
+
+Where PMTiles *renders* geometry, **GeoParquet** lets you *query* it. Add a
+resource with `format: "geoparquet"` and the showcase opens `components/GeoQuery.tsx`:
+DuckDB-Wasm (with the `spatial` extension) reads the remote GeoParquet in place
+over HTTP range requests and runs spatial SQL — the geospatial analog of the
+Parquet SQL editor above. Results render as a live MapLibre overlay, a table, and
+a bar chart; clicking a feature does a DuckDB point-in-polygon lookup for its full
+attributes. A dataset can ship **both** a `pmtiles` and a `geoparquet` resource so
+render + query compose on one page (see `@reference/world-boundaries`).
+
+The queries use a **bbox-first** pattern — a cheap covering-bbox filter prunes
+Parquet row groups, then `ST_Intersects` refines to the exact predicate:
+
+```sql
+SELECT name, ST_AsGeoJSON(geometry) AS geojson   -- `geojson` column drives the overlay
+FROM data
+WHERE bbox.xmin <= 40 AND bbox.xmax >= -25        -- prune row groups (Parquet stats)
+  AND bbox.ymin <= 72 AND bbox.ymax >= 34
+  AND ST_Intersects(geometry, ST_MakeEnvelope(-25, 34, 40, 72))  -- exact predicate
+```
+
+Build a GeoParquet twin from the same source with duckdb — Hilbert-sorted, with a
+GeoParquet 1.1 covering `bbox` column so row-group pruning works:
+
+```bash
+duckdb -c "LOAD spatial;
+  COPY (
+    SELECT * EXCLUDE (geom),
+      {'xmin': ST_XMin(geom), 'ymin': ST_YMin(geom),
+       'xmax': ST_XMax(geom), 'ymax': ST_YMax(geom)} AS bbox,
+      geom AS geometry
+    FROM ST_Read('boundaries.geojson')
+    ORDER BY ST_Hilbert(geom, {'min_x':-180,'min_y':-90,'max_x':180,'max_y':90}::BOX_2D)
+  ) TO 'boundaries.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 25000);"
+```
+
+Keep result sets small (`ST_AsGeoJSON` is the slow path — decode, not query); for
+very large sets project WKB/GeoArrow instead of GeoJSON. `@duckdb/duckdb-wasm`
+loads on demand in the browser only. This manual duckdb step is the interim ingest
+path; an automated pipeline is a separate roadmap phase.
+
 ## Why dataset URLs start with `@`
 
 Dataset showcase URLs are namespaced under `@` (`/@<owner-or-theme>/<dataset>`) so they

--- a/examples/portaljs-catalog/components/GeoQuery.tsx
+++ b/examples/portaljs-catalog/components/GeoQuery.tsx
@@ -1,0 +1,542 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { Map as MapLibreMap, MapMouseEvent, StyleSpecification } from 'maplibre-gl'
+import LoadingSpinner from './ui/LoadingSpinner'
+import { DuckDbQuery } from '../lib/query/duckdb'
+import { resourceUrl, type Resource } from '../lib/datasets'
+
+// <GeoQuery> — spatial SQL over a remote GeoParquet, rendered as a live overlay
+// on a MapLibre map. DuckDB-Wasm (with the `spatial` extension) reads the file IN
+// PLACE over HTTP range requests: a bbox-first WHERE prunes Parquet row groups via
+// the file's column stats, then ST_Intersects refines to the exact predicate, so a
+// query pulls a few MB out of an arbitrarily large file — no server, no download.
+// Results are converted to GeoJSON (ST_AsGeoJSON) and drawn as a MapLibre GeoJSON
+// overlay; the same rows are also available as a table and a quick chart.
+//
+// This is the QUERY tier for geometry — the geospatial analog of the DuckDB SQL
+// editor (components/DataExplorer.tsx) — and composes with <MapPreview> (the
+// render tier, PMTiles) when a dataset ships both artifacts.
+//
+// Import via next/dynamic with { ssr: false }: maplibre-gl and @duckdb/duckdb-wasm
+// both touch browser globals, and the libraries load via dynamic import so the
+// chunk lands in the browser only when a GeoParquet resource actually renders.
+
+// Terracotta accent from tailwind.config.js (matches MapPreview).
+const ACCENT = '#9d4a2c'
+const GEOJSON_COL = 'geojson'
+const MAX_RESULTS = 5000
+
+// Default geometry / covering-bbox column names for the demo GeoParquet. A
+// dataset with different names ships its own `resource.query` (which overrides
+// the generated SQL entirely).
+const GEOM = 'geometry'
+const BBOX = 'bbox'
+
+const BASE_CSS = `
+.maplibregl-map{overflow:hidden;position:relative;-webkit-tap-highlight-color:rgba(0,0,0,0)}
+.maplibregl-canvas-container{height:100%;width:100%}
+.maplibregl-canvas{left:0;position:absolute;top:0}
+.maplibregl-canvas-container.maplibregl-interactive{cursor:grab;user-select:none}
+.maplibregl-canvas-container.maplibregl-interactive:active{cursor:grabbing}
+`
+
+function injectBaseCss() {
+  const id = 'portaljs-geoquery-css'
+  if (document.getElementById(id)) return
+  const style = document.createElement('style')
+  style.id = id
+  style.textContent = BASE_CSS
+  document.head.appendChild(style)
+}
+
+type Bounds = { minX: number; minY: number; maxX: number; maxY: number }
+
+// bbox-first viewport query: prune row groups on the covering bbox (cheap,
+// Parquet stats), THEN refine with the exact ST_Intersects predicate on the
+// survivors, and emit GeoJSON for the overlay.
+function buildViewportSql(b: Bounds): string {
+  const env = `ST_MakeEnvelope(${b.minX}, ${b.minY}, ${b.maxX}, ${b.maxY})`
+  return (
+    `SELECT * EXCLUDE ("${GEOM}", "${BBOX}"), ST_AsGeoJSON("${GEOM}") AS ${GEOJSON_COL}\n` +
+    `FROM data\n` +
+    `WHERE "${BBOX}".xmin <= ${b.maxX} AND "${BBOX}".xmax >= ${b.minX}\n` +
+    `  AND "${BBOX}".ymin <= ${b.maxY} AND "${BBOX}".ymax >= ${b.minY}\n` +
+    `  AND ST_Intersects("${GEOM}", ${env})\n` +
+    `LIMIT ${MAX_RESULTS}`
+  )
+}
+
+type Inspected = { lngLat: [number, number]; properties: Record<string, unknown> }
+type ViewMode = 'map' | 'table' | 'chart'
+type FeatureCollection = { type: 'FeatureCollection'; features: unknown[] }
+type Output = {
+  columns: string[]
+  rows: Record<string, unknown>[]
+  featureCollection: FeatureCollection | null
+}
+
+const WORLD: Bounds = { minX: -180, minY: -85, maxX: 180, maxY: 85 }
+
+export default function GeoQuery({
+  resource,
+  mapAttribution,
+}: {
+  resource: Resource
+  mapAttribution?: string
+}) {
+  const url = resourceUrl(resource)
+  const engine = useMemo(() => new DuckDbQuery(), [url])
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<MapLibreMap | null>(null)
+  // Last FeatureCollection painted; re-applied on every 'styledata' so the overlay
+  // survives a basemap style (re)load (initial + offline fallback).
+  const lastFcRef = useRef<FeatureCollection | null>(null)
+  const openedRef = useRef<Promise<void> | null>(null)
+
+  const initialSql = resource.query ?? buildViewportSql(WORLD)
+  const [draft, setDraft] = useState(initialSql)
+  const [ready, setReady] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [ranged, setRanged] = useState(false)
+  const [view, setView] = useState<ViewMode>('map')
+  const [output, setOutput] = useState<Output>({ columns: [], rows: [], featureCollection: null })
+  const [inspected, setInspected] = useState<Inspected | null>(null)
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null)
+
+  // Normalize a query result into { table rows, FeatureCollection }, pulling the
+  // `geojson` column (when present) out as the overlay geometry.
+  const toOutput = (columns: string[], rows: Record<string, unknown>[]): Output => {
+    const hasGeo = columns.includes(GEOJSON_COL)
+    const tableCols = columns.filter((c) => c !== GEOJSON_COL)
+    const features: unknown[] = []
+    const tableRows: Record<string, unknown>[] = []
+    for (const row of rows) {
+      const rec: Record<string, unknown> = {}
+      for (const c of tableCols) rec[c] = row[c]
+      tableRows.push(rec)
+      if (hasGeo && typeof row[GEOJSON_COL] === 'string') {
+        try {
+          features.push({ type: 'Feature', geometry: JSON.parse(row[GEOJSON_COL] as string), properties: rec })
+        } catch {
+          /* skip an unparseable geometry rather than fail the whole query */
+        }
+      }
+    }
+    return { columns: tableCols, rows: tableRows, featureCollection: hasGeo ? { type: 'FeatureCollection', features } : null }
+  }
+
+  // Paint the query result as a MapLibre GeoJSON overlay (source + fill/line/circle
+  // trio). Idempotent: updates source data on repeat calls, (re)creates layers
+  // after a style (re)load. Remembers the last FeatureCollection so the overlay
+  // survives the offline-basemap fallback swapping the style out.
+  const paintOverlay = (fc: FeatureCollection | null) => {
+    const map = mapRef.current
+    if (!map) return
+    lastFcRef.current = fc
+    const data = fc ?? { type: 'FeatureCollection', features: [] }
+    if (!map.isStyleLoaded()) return // 'styledata' re-runs this once loaded
+    const src = map.getSource('portaljs-geoquery') as any
+    if (src) {
+      src.setData(data as any)
+      return
+    }
+    map.addSource('portaljs-geoquery', { type: 'geojson', data: data as any })
+    map.addLayer({ id: 'gq-fill', type: 'fill', source: 'portaljs-geoquery', filter: ['==', '$type', 'Polygon'], paint: { 'fill-color': ACCENT, 'fill-opacity': 0.22 } })
+    map.addLayer({ id: 'gq-line', type: 'line', source: 'portaljs-geoquery', filter: ['!=', '$type', 'Point'], paint: { 'line-color': ACCENT, 'line-width': 1.1 } })
+    map.addLayer({ id: 'gq-point', type: 'circle', source: 'portaljs-geoquery', filter: ['==', '$type', 'Point'], paint: { 'circle-color': ACCENT, 'circle-radius': 4, 'circle-stroke-color': '#fff', 'circle-stroke-width': 1 } })
+  }
+
+  const run = async (sql: string = draft) => {
+    if (!openedRef.current) return
+    setLoading(true)
+    setError(null)
+    try {
+      await openedRef.current
+      const res = await engine.query(sql)
+      const out = toOutput(res.columns, res.rows)
+      setOutput(out)
+      paintOverlay(out.featureCollection)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const queryViewport = () => {
+    const map = mapRef.current
+    if (!map) return
+    const b = map.getBounds()
+    const sql = buildViewportSql({ minX: b.getWest(), minY: b.getSouth(), maxX: b.getEast(), maxY: b.getNorth() })
+    setDraft(sql)
+    setView('map')
+    void run(sql)
+  }
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    let cancelled = false
+    let map: MapLibreMap | undefined
+
+    // Open the engine once (LOAD spatial + register the remote GeoParquet as `data`).
+    openedRef.current = engine
+      .open({ url, format: 'geoparquet', spatial: true })
+      .then(() => {
+        if (!cancelled) setRanged(engine.ranged)
+      })
+
+    ;(async () => {
+      const maplibre = await import('maplibre-gl')
+      if (cancelled || !containerRef.current) return
+      const maplibregl = maplibre.default
+      injectBaseCss()
+
+      const offlineStyle: StyleSpecification = {
+        version: 8,
+        sources: {},
+        layers: [{ id: 'background', type: 'background', paint: { 'background-color': '#ece7db' } }],
+      }
+
+      try {
+        map = new maplibregl.Map({
+          container: containerRef.current,
+          style: 'https://demotiles.maplibre.org/style.json',
+          center: [0, 20],
+          zoom: 1,
+          attributionControl: false,
+        })
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Could not initialize the map.')
+          setLoading(false)
+        }
+        return
+      }
+      mapRef.current = map
+
+      let degraded = false
+      map.on('error', (e: { error?: Error }) => {
+        const message = e.error?.message ?? ''
+        if (!degraded && !map?.isStyleLoaded() && /fetch|network|ajax/i.test(message)) {
+          degraded = true
+          map?.setStyle(offlineStyle)
+        }
+      })
+
+      // Re-apply the overlay whenever a style finishes loading (initial + the
+      // offline fallback both drop previously-added sources).
+      map.on('styledata', () => {
+        if (lastFcRef.current !== null || map?.getSource('portaljs-geoquery')) {
+          paintOverlay(lastFcRef.current)
+        }
+      })
+
+      // Click-to-inspect: a MapLibre click → DuckDB exact point-in-polygon → the
+      // FULL attribute row (not just the columns the overlay query selected).
+      map.on('click', async (e: MapMouseEvent) => {
+        try {
+          await openedRef.current
+          const sql =
+            `SELECT * EXCLUDE ("${GEOM}", "${BBOX}") FROM data ` +
+            `WHERE ST_Intersects("${GEOM}", ST_Point(${e.lngLat.lng}, ${e.lngLat.lat})) LIMIT 1`
+          const res = await engine.query(sql)
+          if (!res.rows.length) {
+            setInspected(null)
+            return
+          }
+          setInspected({ lngLat: [e.lngLat.lng, e.lngLat.lat], properties: res.rows[0] })
+          setAnchor({ x: e.point.x, y: e.point.y })
+        } catch {
+          /* a failed inspect lookup must not surface as a fatal error */
+        }
+      })
+
+      map.once('load', () => {
+        if (cancelled) return
+        setReady(true)
+        void run(initialSql)
+      })
+    })().catch((e) => {
+      if (!cancelled) {
+        setError(e instanceof Error ? e.message : 'Failed to load the map libraries.')
+        setLoading(false)
+      }
+    })
+
+    return () => {
+      cancelled = true
+      mapRef.current = null
+      lastFcRef.current = null
+      void engine.close()
+      map?.remove()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [engine, url])
+
+  // Keep the inspect popup glued to its geographic anchor while panning/zooming.
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !inspected) return
+    const reproject = () => {
+      const p = map.project(inspected.lngLat)
+      setAnchor({ x: p.x, y: p.y })
+    }
+    reproject()
+    map.on('move', reproject)
+    return () => {
+      map.off('move', reproject)
+    }
+  }, [inspected])
+
+  const zoomBy = (delta: number) => {
+    const map = mapRef.current
+    if (!map) return
+    map.zoomTo(map.getZoom() + delta, { duration: 200 })
+  }
+
+  const inspectEntries = inspected ? Object.entries(inspected.properties) : []
+
+  return (
+    <div>
+      <div className="mb-3.5 flex flex-wrap items-center gap-3">
+        <span className="font-sans text-[11px] font-semibold uppercase tracking-[0.1em] text-ink/45">
+          Spatial query (SQL)
+        </span>
+        {ranged && (
+          <span
+            title="GeoParquet queried in place over HTTP range requests — the bbox pre-filter prunes row groups, so only the bytes a query touches are fetched, never the whole file."
+            className="border border-accent/50 px-1.5 py-0.5 font-sans text-[10px] font-medium uppercase tracking-[0.06em] text-accent"
+          >
+            queried in place · range requests
+          </span>
+        )}
+      </div>
+
+      <div className="border border-ink/[0.18]">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void run()
+          }}
+          rows={5}
+          spellCheck={false}
+          disabled={!ready}
+          className="block w-full resize-y border-0 bg-cream-code px-4 py-4 font-mono text-[13.5px] leading-relaxed text-ink focus:outline-none"
+        />
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-ink/[0.15] px-4 py-2.5">
+          <span className="font-mono text-[11px] text-ink/40">
+            DuckDB-Wasm + spatial · runs in your browser · ⌘/Ctrl + Enter
+          </span>
+          <span className="flex gap-2">
+            <button
+              type="button"
+              onClick={queryViewport}
+              disabled={!ready || loading}
+              title="Rewrite the query to the current map viewport (bbox pre-filter → ST_Intersects)"
+              className="border border-ink/25 px-[14px] py-2.5 font-sans text-xs font-semibold uppercase tracking-[0.06em] text-ink hover:border-accent hover:text-accent disabled:opacity-50"
+            >
+              Query viewport
+            </button>
+            <button
+              type="button"
+              onClick={() => void run()}
+              disabled={!ready || loading}
+              className="bg-accent px-[18px] py-2.5 font-sans text-xs font-semibold uppercase tracking-[0.06em] text-cream hover:opacity-90 disabled:opacity-50"
+            >
+              {loading ? 'Running…' : 'Run ▶'}
+            </button>
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center gap-1.5">
+        {(['map', 'table', 'chart'] as ViewMode[]).map((m) => (
+          <button
+            key={m}
+            type="button"
+            onClick={() => setView(m)}
+            className={`border px-3 py-1 font-sans text-[11px] font-semibold uppercase tracking-[0.06em] ${
+              view === m ? 'border-accent bg-accent text-cream' : 'border-ink/20 bg-cream text-ink/70 hover:text-accent'
+            }`}
+          >
+            {m}
+          </button>
+        ))}
+        <span className="ml-auto font-mono text-[11px] text-ink/40">{output.rows.length} rows</span>
+      </div>
+
+      {error && (
+        <pre className="mt-3 overflow-x-auto whitespace-pre-wrap border border-red-300 bg-red-50 p-3 font-mono text-sm text-red-700">
+          {error}
+        </pre>
+      )}
+
+      {/* Map view — always mounted (the map lives here); hidden when another view is active. */}
+      <div
+        className="relative mt-3 w-full overflow-hidden"
+        style={{ height: 480, background: '#ece7db', display: view === 'map' ? 'block' : 'none' }}
+      >
+        <div ref={containerRef} className="h-full w-full" />
+
+        {loading && (
+          <div className="pointer-events-none absolute left-3 top-3 z-[2] bg-cream/80 px-2 py-1 font-mono text-[11px] text-ink/60">
+            querying…
+          </div>
+        )}
+
+        <div className="absolute right-2.5 top-2.5 z-[2] flex flex-col gap-px">
+          {[
+            { label: '+', title: 'Zoom in', delta: 1 },
+            { label: '−', title: 'Zoom out', delta: -1 },
+          ].map((b) => (
+            <button
+              key={b.label}
+              type="button"
+              aria-label={b.title}
+              title={b.title}
+              onClick={() => zoomBy(b.delta)}
+              className="h-7 w-7 border border-ink/25 bg-white text-base leading-[26px] text-ink"
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+
+        {inspected && anchor && (
+          <div
+            className="absolute z-[3] max-h-[220px] max-w-[280px] overflow-auto border border-ink/20 bg-white px-2.5 py-2 shadow-md"
+            style={{ left: anchor.x, top: anchor.y, transform: 'translate(-50%, calc(-100% - 10px))' }}
+          >
+            <div className="mb-1 flex items-baseline justify-between gap-2">
+              <strong className="font-sans text-[11px] uppercase tracking-[0.05em]">Feature</strong>
+              <button type="button" aria-label="Close" onClick={() => setInspected(null)} className="text-ink/50">
+                ×
+              </button>
+            </div>
+            {inspectEntries.length === 0 ? (
+              <div className="italic text-ink/50">No properties</div>
+            ) : (
+              <table className="w-full border-collapse text-[12px]">
+                <tbody>
+                  {inspectEntries.map(([k, v]) => (
+                    <tr key={k}>
+                      <td className="py-0.5 pr-2 align-top text-ink/50">{k}</td>
+                      <td className="break-words py-0.5">{formatCell(v)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+
+        {mapAttribution && (
+          <div className="absolute bottom-0 right-0 z-[2] bg-white/75 px-1.5 py-0.5 font-sans text-[10px] text-ink/70">
+            {mapAttribution}
+          </div>
+        )}
+      </div>
+
+      {view === 'table' && <ResultTable columns={output.columns} rows={output.rows} loading={loading} />}
+      {view === 'chart' && <ResultChart columns={output.columns} rows={output.rows} />}
+
+      <p className="mt-2 font-sans text-xs text-ink/45">
+        Pan/zoom the map, then “Query viewport” to fetch only the features in view — the bbox pre-filter prunes
+        Parquet row groups before ST_Intersects runs. Click a feature for its full attributes (a DuckDB
+        point-in-polygon lookup).
+      </p>
+    </div>
+  )
+}
+
+function ResultTable({
+  columns,
+  rows,
+  loading,
+}: {
+  columns: string[]
+  rows: Record<string, unknown>[]
+  loading: boolean
+}) {
+  if (loading && rows.length === 0) return <LoadingSpinner />
+  if (!rows.length) return <p className="mt-3 font-serif text-[15px] italic text-ink/55">No rows.</p>
+  return (
+    <div className="mt-3 overflow-x-auto border border-ink/[0.18]">
+      <table className="min-w-full border-collapse text-sm">
+        <thead>
+          <tr>
+            {columns.map((c) => (
+              <th
+                key={c}
+                className="whitespace-nowrap bg-cream-panel px-4 py-3 text-left font-sans text-[11px] font-semibold uppercase tracking-[0.06em] text-ink/60"
+              >
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="border-t border-ink/[0.1] hover:bg-cream-panel/50">
+              {columns.map((c) => (
+                <td key={c} className="whitespace-nowrap px-4 py-3 font-mono text-[13px] text-ink">
+                  {formatCell(row[c])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// Dependency-free horizontal bar chart: first text column = labels, first numeric
+// column = values. Shows a hint when the result has no numeric column.
+function ResultChart({ columns, rows }: { columns: string[]; rows: Record<string, unknown>[] }) {
+  const numericCol = columns.find((c) => rows.some((r) => typeof r[c] === 'number'))
+  const labelCol = columns.find((c) => c !== numericCol && rows.some((r) => typeof r[c] === 'string')) ?? columns[0]
+  if (!numericCol || !rows.length) {
+    return (
+      <p className="mt-3 font-serif text-[15px] italic text-ink/55">
+        Add a numeric column to chart the result (e.g. an aggregate like <code>sum(pop_est)</code>).
+      </p>
+    )
+  }
+  const values = rows.map((r) => Number(r[numericCol]) || 0)
+  const max = Math.max(...values, 1)
+  const shown = rows.slice(0, 30)
+  return (
+    <div className="mt-3 border border-ink/[0.18] p-4">
+      <div className="mb-2.5 font-sans text-[11px] font-semibold uppercase tracking-[0.06em] text-ink/50">
+        {numericCol} by {labelCol}
+      </div>
+      {shown.map((r, i) => {
+        const v = Number(r[numericCol]) || 0
+        return (
+          <div key={i} className="mb-1 flex items-center gap-2.5">
+            <span className="w-32 flex-shrink-0 truncate font-sans text-[12px] text-ink/80">
+              {String(r[labelCol] ?? '')}
+            </span>
+            <span className="relative h-4 flex-1 bg-cream-panel">
+              <span className="absolute inset-y-0 left-0 bg-accent" style={{ width: `${(v / max) * 100}%` }} />
+            </span>
+            <span className="w-24 flex-shrink-0 text-right font-mono text-[12px] text-ink/70">{v.toLocaleString()}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'bigint') return value.toString()
+  if (typeof value === 'object') {
+    const s = String(value)
+    return s === '[object Object]' ? JSON.stringify(value) : s
+  }
+  return String(value)
+}

--- a/examples/portaljs-catalog/datasets.json
+++ b/examples/portaljs-catalog/datasets.json
@@ -129,9 +129,24 @@
     "slug": "world-boundaries",
     "namespace": "reference",
     "name": "World Country Boundaries",
-    "description": "Country boundary polygons for the whole world, tiled as a single PMTiles archive and rendered serverlessly — the map fetches only the tiles in view via HTTP range requests straight from R2.",
-    "file": "https://data.portaljs.com/lfs/datopian/portaljs-catalog/14b9f9c68e58e8c2f3b6fd5f6794e0f8196649b9a63bed57ece80cd1c8c18af4",
-    "format": "pmtiles",
+    "description": "Country boundaries for the whole world in two serverless geo tiers derived from the same Natural Earth source: a PMTiles archive the map renders in place (any size, no tile server), and a GeoParquet twin DuckDB-Wasm runs spatial SQL over in place — bbox pre-filter to prune Parquet row groups, then ST_Intersects, rendered as a live overlay. Render tier + query tier on one dataset.",
+    "resources": [
+      {
+        "name": "tiles",
+        "title": "Boundaries (PMTiles — render tier)",
+        "description": "Vector tiles rendered by MapLibre GL over HTTP range requests; only the tiles in view are fetched, so any dataset size pans and zooms with no tile server.",
+        "path": "https://data.portaljs.com/lfs/datopian/portaljs-catalog/14b9f9c68e58e8c2f3b6fd5f6794e0f8196649b9a63bed57ece80cd1c8c18af4",
+        "format": "pmtiles"
+      },
+      {
+        "name": "geo",
+        "title": "Boundaries (GeoParquet — query tier)",
+        "description": "GeoParquet 1.1 (Hilbert-sorted, covering bbox column) queried in place with DuckDB-Wasm + spatial. Pan the map and “Query viewport” to fetch only the features in view; click a feature for its full attributes via a DuckDB point-in-polygon lookup.",
+        "path": "https://data.portaljs.com/lfs/datopian/portaljs-catalog/437f70dcc2c8d464be9f2181175c37daa21b533351d4873039f78eff0e79f5f5",
+        "format": "geoparquet",
+        "query": "-- bbox-first: the covering bbox prunes Parquet row groups (cheap),\n-- then ST_Intersects refines to the exact predicate (only on survivors).\nSELECT name, continent, pop_est, ST_AsGeoJSON(geometry) AS geojson\nFROM data\nWHERE bbox.xmin <= 40 AND bbox.xmax >= -25\n  AND bbox.ymin <= 72 AND bbox.ymax >= 34\n  AND ST_Intersects(geometry, ST_MakeEnvelope(-25, 34, 40, 72))"
+      }
+    ],
     "licenses": [
       {
         "name": "PDDL-1.0",
@@ -145,7 +160,7 @@
         "path": "https://www.naturalearthdata.com/downloads/110m-cultural-vectors/"
       }
     ],
-    "keywords": ["boundaries", "countries", "geospatial", "pmtiles"],
-    "version": "1.0.0"
+    "keywords": ["boundaries", "countries", "geospatial", "pmtiles", "geoparquet", "duckdb"],
+    "version": "1.1.0"
   }
 ]

--- a/examples/portaljs-catalog/lib/providers/types.ts
+++ b/examples/portaljs-catalog/lib/providers/types.ts
@@ -15,7 +15,12 @@ import type { License, Source, TableSchema } from '../metadata/types'
 // tiles the showcase renders with MapLibre GL over HTTP range requests — any
 // dataset size pans and zooms with no tile server. Made from GeoJSON/Shapefile
 // with tippecanoe; see components/MapPreview.tsx.
-export type DataFormat = 'csv' | 'tsv' | 'json' | 'geojson' | 'parquet' | 'pmtiles'
+// 'geoparquet' is the query tier for geometry: a GeoParquet file DuckDB-Wasm
+// range-reads in place and runs spatial SQL over (bbox pre-filter → ST_Intersects),
+// rendering results as a live map overlay — see components/GeoQuery.tsx. It's the
+// geospatial analog of the 'parquet' query view; a dataset can ship BOTH a pmtiles
+// resource (render) and a geoparquet resource (query) so the two compose.
+export type DataFormat = 'csv' | 'tsv' | 'json' | 'geojson' | 'parquet' | 'pmtiles' | 'geoparquet'
 
 // One line of a version-to-version diff, shown when a resource's history is expanded.
 // Only raw-text resources (CSV/TSV committed in git) produce these; an LFS-pointer

--- a/examples/portaljs-catalog/lib/query/duckdb.ts
+++ b/examples/portaljs-catalog/lib/query/duckdb.ts
@@ -65,7 +65,16 @@ export class DuckDbQuery implements DataQuery {
       await this.db.instantiate(bundle.mainModule, bundle.pthreadWorker)
       this.conn = await this.db.connect()
 
-      const isParquet = source.format === 'parquet'
+      // GeoParquet spatial queries need the `spatial` extension: it provides the
+      // ST_* functions AND makes read_parquet auto-decode the GeoParquet geometry
+      // column to the GEOMETRY type. The extension loads in WASM from the DuckDB
+      // extension repository on demand.
+      if (source.spatial) {
+        await this.conn.query('INSTALL spatial; LOAD spatial;')
+      }
+
+      // 'geoparquet' is Parquet on the wire, so it takes the same range-read path.
+      const isParquet = source.format === 'parquet' || source.format === 'geoparquet'
       const isRemote = /^https?:\/\//i.test(source.url)
       this._ranged = isParquet && isRemote
 

--- a/examples/portaljs-catalog/lib/query/types.ts
+++ b/examples/portaljs-catalog/lib/query/types.ts
@@ -18,7 +18,11 @@ export type QueryResult = {
 export type QuerySource = {
   // URL to the dataset file (e.g. /data/foo.csv, or a remote URL).
   url: string
-  format: 'csv' | 'tsv' | 'json' | 'parquet' | string
+  format: 'csv' | 'tsv' | 'json' | 'parquet' | 'geoparquet' | string
+  // Load the DuckDB `spatial` extension after connecting, so ST_* functions and
+  // GeoParquet geometry decoding are available. Set for GeoParquet sources
+  // (the <GeoQuery> spatial view); left off for plain tabular queries.
+  spatial?: boolean
 }
 
 export interface DataQuery {

--- a/examples/portaljs-catalog/pages/[owner]/[slug].tsx
+++ b/examples/portaljs-catalog/pages/[owner]/[slug].tsx
@@ -31,6 +31,13 @@ const MapPreview = dynamic(() => import('../../components/MapPreview'), {
   ssr: false,
 })
 
+// DuckDB-Wasm + spatial + MapLibre are browser-only, so the GeoParquet query
+// view is client-side too. The chunk loads only when a dataset has a geoparquet
+// resource.
+const GeoQuery = dynamic(() => import('../../components/GeoQuery'), {
+  ssr: false,
+})
+
 type PageProps = {
   dataset: Dataset
   resources: Resource[]
@@ -449,6 +456,11 @@ function ResourceSection({
         // Tiled geo data: MapLibre renders the archive in place over HTTP
         // range requests — any dataset size, no tile server.
         <MapPreview url={url} attribution={mapAttribution} />
+      ) : resource.format === 'geoparquet' ? (
+        // Geometry query tier: DuckDB-Wasm runs spatial SQL over the remote
+        // GeoParquet in place (bbox pre-filter → ST_Intersects) and renders the
+        // result as a live map overlay — the geospatial analog of the SQL editor.
+        <GeoQuery resource={resource} mapAttribution={mapAttribution} />
       ) : useQueryView ? (
         <DataExplorer resource={resource} />
       ) : tabular ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1239,6 +1239,16 @@
         }
       }
     },
+    "node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz",
+      "integrity": "sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "apache-arrow": "^17.0.0"
+      }
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
       "license": "MIT",
@@ -2752,13 +2762,13 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.0",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -2870,6 +2880,20 @@
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3389,6 +3413,44 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.cjs"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "dev": true,
@@ -3410,6 +3472,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-union": {
@@ -3866,6 +3938,98 @@
         "node": ">=4"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/chalk-template/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chalk-template/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk-template/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "license": "MIT",
@@ -4037,6 +4201,58 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/command-score": {
@@ -5522,6 +5738,19 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "dev": true,
@@ -5553,6 +5782,13 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.2.7",
@@ -6454,6 +6690,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -6698,6 +6943,13 @@
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.get": {
@@ -9485,6 +9737,30 @@
       "version": "6.1.2",
       "license": "MIT"
     },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.3.2",
       "dev": true,
@@ -10025,6 +10301,16 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
@@ -10481,6 +10767,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/wrap-ansi": {
@@ -11932,6 +12228,7 @@
         "prop-types": "^15.8.1"
       },
       "devDependencies": {
+        "@duckdb/duckdb-wasm": "^1.28.0",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.6",
@@ -11944,11 +12241,17 @@
         "node": ">=22"
       },
       "peerDependencies": {
+        "@duckdb/duckdb-wasm": "^1.28.0",
         "mdx-mermaid": "^2.0.4",
         "next": ">=13.2.1",
         "next-themes": "^0.2.1",
         "react": "^18.2.0 || ^19.0.0",
         "react-dom": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@duckdb/duckdb-wasm": {
+          "optional": true
+        }
       }
     },
     "packages/core/node_modules/@rollup/plugin-commonjs": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,3 +32,73 @@ Make PMTiles from GeoJSON/Shapefile with
 ```bash
 tippecanoe -zg --drop-densest-as-needed -o out.pmtiles in.geojson
 ```
+
+## `<GeoQuery>` — serverless spatial SQL over GeoParquet (DuckDB-Wasm)
+
+The query counterpart to `<MapPreview>`: point DuckDB-Wasm (with the `spatial`
+extension) at a remote **GeoParquet** file and run spatial SQL over it entirely
+in the browser — no server, no download. The file is read IN PLACE over HTTP
+range requests, results are drawn as a live MapLibre overlay, and the same rows
+are available as a table and a quick bar chart. Click a feature for a DuckDB
+point-in-polygon lookup of its full attributes. Composes with `<MapPreview>` on
+the same dataset (PMTiles = render tier, GeoParquet = query tier).
+
+```tsx
+import { GeoQuery } from "@portaljs/core";
+
+<GeoQuery
+  url="https://example.com/data/countries.parquet" // remote GeoParquet on R2/S3
+  geometryColumn="geometry"   // GEOMETRY once `spatial` is loaded (default)
+  bboxColumn="bbox"           // GeoParquet 1.1 covering bbox STRUCT (default; "" to disable)
+  // query="SELECT name, ST_AsGeoJSON(geometry) AS geojson FROM data WHERE …"
+  // color="#2f6f4f" height={480} attribution="Natural Earth"
+/>
+```
+
+`@duckdb/duckdb-wasm` is an **optional peer dependency** — install it in the app
+that uses `<GeoQuery>` (`npm i @duckdb/duckdb-wasm`). Load the component with
+`next/dynamic({ ssr: false })`.
+
+### The bbox-first query pattern (why it's cheap)
+
+Structure spatial queries as a **cheap filter first, exact predicate second**:
+
+```sql
+SELECT name, ST_AsGeoJSON(geometry) AS geojson
+FROM data
+WHERE bbox.xmin <= :maxx AND bbox.xmax >= :minx      -- 1. prune row groups (Parquet stats)
+  AND bbox.ymin <= :maxy AND bbox.ymax >= :miny
+  AND ST_Intersects(geometry, ST_MakeEnvelope(:minx,:miny,:maxx,:maxy))  -- 2. exact
+LIMIT 5000
+```
+
+The bbox comparison hits the GeoParquet 1.1 **covering** column, whose per-row-group
+min/max stats let DuckDB skip row groups that can't match — so a viewport query
+fetches only a few MB out of an arbitrarily large file. `ST_Intersects` then runs
+the exact (expensive) predicate only on the survivors. Build the file
+Hilbert-sorted with a bbox covering column so spatially-near rows share row groups
+and pruning is effective:
+
+```sql
+-- duckdb: CSV/Shapefile/GeoJSON → GeoParquet with a covering bbox + Hilbert order
+LOAD spatial;
+COPY (
+  SELECT * EXCLUDE (geom),
+    {'xmin': ST_XMin(geom), 'ymin': ST_YMin(geom),
+     'xmax': ST_XMax(geom), 'ymax': ST_YMax(geom)} AS bbox,
+    geom AS geometry
+  FROM ST_Read('in.geojson')
+  ORDER BY ST_Hilbert(geom, {'min_x':-180,'min_y':-90,'max_x':180,'max_y':90}::BOX_2D)
+) TO 'out.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 25000);
+```
+
+### Overlay decode: GeoJSON vs WKB (the slow path)
+
+Geometry decode, not the query, is the bottleneck. `ST_AsGeoJSON` is convenient
+and fine for small result sets (keep a `LIMIT` / a WHERE), and `<GeoQuery>` reads
+a `geojson` column to build the MapLibre overlay. **Do not `ST_AsGeoJSON` a huge
+result set.** For large sets, project the geometry to WKB / GeoArrow and decode it
+with a GPU layer (e.g. deck.gl's `GeoJsonLayer` fed from parsed WKB) instead of
+serializing megabytes of GeoJSON text — or pre-aggregate / cap the result at
+publish time. The range path means weak clients only process the bytes a query
+touches, so lean on the bbox pre-filter and a tight `LIMIT`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,13 +53,18 @@
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {
+    "@duckdb/duckdb-wasm": "^1.28.0",
     "mdx-mermaid": "^2.0.4",
     "next": ">=13.2.1",
     "next-themes": "^0.2.1",
     "react": "^18.2.0 || ^19.0.0",
     "react-dom": "^18.2.0 || ^19.0.0"
   },
+  "peerDependenciesMeta": {
+    "@duckdb/duckdb-wasm": { "optional": true }
+  },
   "devDependencies": {
+    "@duckdb/duckdb-wasm": "^1.28.0",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/packages/core/src/ui/GeoQuery/GeoQuery.tsx
+++ b/packages/core/src/ui/GeoQuery/GeoQuery.tsx
@@ -1,0 +1,810 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type {
+  Map as MapLibreMap,
+  MapMouseEvent,
+  StyleSpecification,
+} from "maplibre-gl";
+
+// <GeoQuery> — serverless spatial SQL over a remote GeoParquet, rendered as a
+// live overlay on a MapLibre map. DuckDB-Wasm reads the GeoParquet IN PLACE over
+// HTTP range requests (no server, no download): a bbox-first WHERE prunes Parquet
+// row groups via the file's column statistics, then ST_Intersects refines to the
+// exact predicate, so a query pulls a few MB out of an arbitrarily large file.
+// Results are converted to GeoJSON (ST_AsGeoJSON) and drawn as a MapLibre GeoJSON
+// overlay on top of the basemap; the same rows are also shown as a table and a
+// quick bar chart. This is the QUERY tier of the GIS story — the analog of the
+// CSV→Parquet + DuckDB-Wasm query view, for geometry — and composes with
+// <MapPreview> (the render tier, PMTiles) on the same dataset.
+//
+// Overlay decode note: keep result sets small and let ST_AsGeoJSON run in DuckDB
+// (the geometry decode is the slow path). For very large result sets, project to
+// WKB / GeoArrow and decode with a GPU layer (e.g. deck.gl) instead of
+// ST_AsGeoJSON-ing the whole set — see the README.
+//
+// SSR-safe by construction: maplibre-gl and @duckdb/duckdb-wasm both touch
+// `window`/`Worker` at module scope, so both are loaded with dynamic import()
+// inside useEffect — the component renders an empty shell on the server and
+// hydrates the map + engine in the browser. Consumers may still wrap it in
+// next/dynamic({ ssr: false }) to keep the chunk out of the server bundle.
+
+export interface GeoQueryProps {
+  /** URL of the GeoParquet file (absolute, or relative to the page origin). Must
+   * be served with HTTP range requests + CORS (e.g. R2) for the no-download path. */
+  url: string;
+  /** Geometry column name in the file. DuckDB-spatial auto-decodes a GeoParquet
+   * geometry column to the GEOMETRY type once `spatial` is loaded. */
+  geometryColumn?: string;
+  /** GeoParquet 1.1 "covering" bbox column — a STRUCT with xmin/ymin/xmax/ymax.
+   * Used for the cheap row-group-pruning pre-filter before ST_Intersects. Pass
+   * an empty string to disable the bbox pre-filter (ST_Intersects only). */
+  bboxColumn?: string;
+  /** A few attribute columns to select alongside the geometry (table + tooltip).
+   * When omitted, every non-geometry / non-bbox column is selected. */
+  columns?: string[];
+  /** Starter SQL over the table `data`. When omitted a bbox-first viewport query
+   * is generated. A query whose result includes a text column named `geojson`
+   * (e.g. `ST_AsGeoJSON(geometry) AS geojson`) drives the map overlay; any other
+   * result is shown as a table/chart only. */
+  query?: string;
+  /** Basemap style URL, or `false` for a plain background (fully offline). */
+  basemap?: string | false;
+  /** Accent color for the rendered features + chart bars. */
+  color?: string;
+  /** CSS height of the map container. */
+  height?: string | number;
+  center?: [number, number];
+  zoom?: number;
+  /** Attribution line rendered bottom-right. */
+  attribution?: string;
+  /** LIMIT applied to generated viewport queries (guards huge ST_AsGeoJSON). */
+  maxResults?: number;
+}
+
+const DEFAULT_BASEMAP = "https://demotiles.maplibre.org/style.json";
+const DEFAULT_COLOR = "#2f6f4f";
+const DEFAULT_GEOM = "geometry";
+const DEFAULT_BBOX = "bbox";
+const DEFAULT_MAX = 5000;
+const GEOJSON_COL = "geojson";
+
+const BASE_CSS = `
+.maplibregl-map{overflow:hidden;position:relative;-webkit-tap-highlight-color:rgba(0,0,0,0)}
+.maplibregl-canvas-container{height:100%;width:100%}
+.maplibregl-canvas{left:0;position:absolute;top:0}
+.maplibregl-map:fullscreen{height:100%;width:100%}
+.maplibregl-canvas-container.maplibregl-interactive{cursor:grab;user-select:none}
+.maplibregl-canvas-container.maplibregl-interactive:active{cursor:grabbing}
+`;
+
+function injectBaseCss() {
+  const id = "portaljs-geoquery-css";
+  if (document.getElementById(id)) return;
+  const style = document.createElement("style");
+  style.id = id;
+  style.textContent = BASE_CSS;
+  document.head.appendChild(style);
+}
+
+// SQL string literal (single-quote escaped). URLs/identifiers passed to DuckDB.
+function sqlStr(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+// The generated bbox-first viewport query: prune row groups on the covering bbox
+// (cheap, uses Parquet stats), THEN refine with the exact ST_Intersects predicate
+// (expensive, only on survivors), and emit GeoJSON for the overlay.
+function buildViewportSql(
+  b: Bounds,
+  opts: { geom: string; bbox: string; columns: string[]; limit: number }
+): string {
+  const { geom, bbox, columns, limit } = opts;
+  const select = columns.length ? columns.map((c) => `"${c}"`).join(", ") : "* EXCLUDE (" + `"${geom}"` + ")";
+  const env = `ST_MakeEnvelope(${b.minX}, ${b.minY}, ${b.maxX}, ${b.maxY})`;
+  const bboxFilter = bbox
+    ? `"${bbox}".xmin <= ${b.maxX} AND "${bbox}".xmax >= ${b.minX} ` +
+      `AND "${bbox}".ymin <= ${b.maxY} AND "${bbox}".ymax >= ${b.minY} AND `
+    : "";
+  return (
+    `SELECT ${select}, ST_AsGeoJSON("${geom}") AS ${GEOJSON_COL}\n` +
+    `FROM data\n` +
+    `WHERE ${bboxFilter}ST_Intersects("${geom}", ${env})\n` +
+    `LIMIT ${limit}`
+  );
+}
+
+interface Inspected {
+  lngLat: [number, number];
+  properties: Record<string, unknown>;
+}
+
+type ViewMode = "map" | "table" | "chart";
+
+// Rows returned from a query: the raw attribute records (geojson stripped) plus
+// the parsed GeoJSON FeatureCollection for the overlay (null when the result has
+// no `geojson` column).
+interface QueryOutput {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  featureCollection: {
+    type: "FeatureCollection";
+    features: unknown[];
+  } | null;
+}
+
+export const GeoQuery: React.FC<GeoQueryProps> = ({
+  url,
+  geometryColumn = DEFAULT_GEOM,
+  bboxColumn = DEFAULT_BBOX,
+  columns,
+  query,
+  basemap = DEFAULT_BASEMAP,
+  color = DEFAULT_COLOR,
+  height = 480,
+  center,
+  zoom,
+  attribution,
+  maxResults = DEFAULT_MAX,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  // The last FeatureCollection painted, re-applied whenever a style finishes
+  // (re)loading — covers the offline-basemap fallback dropping the overlay source.
+  const lastFcRef = useRef<QueryOutput["featureCollection"]>(null);
+  // The DuckDB connection + a flag that the spatial view is ready to query.
+  const connRef = useRef<any>(null);
+  const dbRef = useRef<any>(null);
+  const workerRef = useRef<Worker | null>(null);
+
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<ViewMode>("map");
+  const [output, setOutput] = useState<QueryOutput>({
+    columns: [],
+    rows: [],
+    featureCollection: null,
+  });
+  const [inspected, setInspected] = useState<Inspected | null>(null);
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
+
+  // The SQL currently in the editor. Seeded from `query`, or a whole-world
+  // bbox-first query once we know the column defaults.
+  const initialSql = useMemo(
+    () =>
+      query ??
+      buildViewportSql(
+        { minX: -180, minY: -85, maxX: 180, maxY: 85 },
+        {
+          geom: geometryColumn,
+          bbox: bboxColumn,
+          columns: columns ?? [],
+          limit: maxResults,
+        }
+      ),
+    [query, geometryColumn, bboxColumn, columns, maxResults]
+  );
+  const [draft, setDraft] = useState(initialSql);
+  useEffect(() => setDraft(initialSql), [initialSql]);
+
+  // Turn a query result into { table rows, FeatureCollection } — pulling out the
+  // `geojson` column (if present) as the overlay geometry and coercing BigInt.
+  const toOutput = (columnsOut: string[], rowsOut: Record<string, unknown>[]): QueryOutput => {
+    const hasGeo = columnsOut.includes(GEOJSON_COL);
+    const tableCols = columnsOut.filter((c) => c !== GEOJSON_COL);
+    const features: unknown[] = [];
+    const tableRows: Record<string, unknown>[] = [];
+    for (const row of rowsOut) {
+      const rec: Record<string, unknown> = {};
+      for (const c of tableCols) {
+        const v = row[c];
+        rec[c] = typeof v === "bigint" ? Number(v) : v;
+      }
+      tableRows.push(rec);
+      if (hasGeo && typeof row[GEOJSON_COL] === "string") {
+        try {
+          features.push({
+            type: "Feature",
+            geometry: JSON.parse(row[GEOJSON_COL] as string),
+            properties: rec,
+          });
+        } catch {
+          /* skip an unparseable geometry rather than fail the whole query */
+        }
+      }
+    }
+    return {
+      columns: tableCols,
+      rows: tableRows,
+      featureCollection: hasGeo ? { type: "FeatureCollection", features } : null,
+    };
+  };
+
+  // Run one query row-set through DuckDB and normalize it.
+  const runQuery = async (sql: string): Promise<QueryOutput> => {
+    const conn = connRef.current;
+    if (!conn) throw new Error("Query engine is not ready");
+    const table = await conn.query(sql);
+    const cols: string[] = table.schema.fields.map((f: any) => f.name);
+    const rows = table.toArray().map((r: any) => r.toJSON() as Record<string, unknown>);
+    return toOutput(cols, rows);
+  };
+
+  // Paint the query result as a MapLibre GeoJSON overlay (a source + a
+  // fill/line/circle layer trio, one filter per geometry type). Idempotent:
+  // updates the source data on repeat calls, and (re)creates the layers after a
+  // style (re)load. Remembers the last FeatureCollection so the overlay survives
+  // the offline-basemap fallback swapping the style out from under it.
+  const paintOverlay = (fc: QueryOutput["featureCollection"]) => {
+    const map = mapRef.current;
+    if (!map) return;
+    lastFcRef.current = fc;
+    const data = fc ?? { type: "FeatureCollection", features: [] };
+    if (!map.isStyleLoaded()) return; // 'styledata' will re-run this once loaded
+    const src = map.getSource("portaljs-geoquery") as any;
+    if (src) {
+      src.setData(data as any);
+      return;
+    }
+    map.addSource("portaljs-geoquery", { type: "geojson", data: data as any });
+    map.addLayer({
+      id: "portaljs-geoquery-fill",
+      type: "fill",
+      source: "portaljs-geoquery",
+      filter: ["==", "$type", "Polygon"],
+      paint: { "fill-color": color, "fill-opacity": 0.24 },
+    });
+    map.addLayer({
+      id: "portaljs-geoquery-line",
+      type: "line",
+      source: "portaljs-geoquery",
+      filter: ["!=", "$type", "Point"],
+      paint: { "line-color": color, "line-width": 1.1 },
+    });
+    map.addLayer({
+      id: "portaljs-geoquery-point",
+      type: "circle",
+      source: "portaljs-geoquery",
+      filter: ["==", "$type", "Point"],
+      paint: {
+        "circle-color": color,
+        "circle-radius": 4,
+        "circle-opacity": 0.85,
+        "circle-stroke-color": "#fff",
+        "circle-stroke-width": 1,
+      },
+    });
+  };
+
+  // Run the editor's SQL, update the table/chart, and (when the result carries a
+  // `geojson` column) repaint the overlay.
+  const run = async (sql: string = draft) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const out = await runQuery(sql);
+      setOutput(out);
+      paintOverlay(out.featureCollection);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Rewrite the editor query to the map's CURRENT viewport bounds and run it —
+  // the headline "query only what you're looking at" interaction.
+  const queryViewport = () => {
+    const map = mapRef.current;
+    if (!map) return;
+    const b = map.getBounds();
+    const sql = buildViewportSql(
+      { minX: b.getWest(), minY: b.getSouth(), maxX: b.getEast(), maxY: b.getNorth() },
+      { geom: geometryColumn, bbox: bboxColumn, columns: columns ?? [], limit: maxResults }
+    );
+    setDraft(sql);
+    setView("map");
+    void run(sql);
+  };
+
+  // --- init: map + DuckDB-spatial engine (both client-only) -----------------
+  useEffect(() => {
+    if (!containerRef.current) return;
+    let cancelled = false;
+    let map: MapLibreMap | undefined;
+
+    (async () => {
+      const [maplibre, duckdbMod] = await Promise.all([
+        import("maplibre-gl"),
+        import("@duckdb/duckdb-wasm"),
+      ]);
+      if (cancelled || !containerRef.current) return;
+      const maplibregl = maplibre.default;
+      injectBaseCss();
+
+      const offlineStyle: StyleSpecification = {
+        version: 8,
+        sources: {},
+        layers: [
+          { id: "background", type: "background", paint: { "background-color": "#e6e2d8" } },
+        ],
+      };
+
+      // --- map ---
+      try {
+        map = new maplibregl.Map({
+          container: containerRef.current,
+          style: basemap === false ? offlineStyle : basemap,
+          center: center ?? [0, 20],
+          zoom: zoom ?? 1,
+          attributionControl: false,
+        });
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not initialize the map.");
+        return;
+      }
+      mapRef.current = map;
+
+      // A missing basemap must never take the overlay down: swap to the offline
+      // background on network-shaped style errors before the style is up.
+      let degraded = false;
+      map.on("error", (e: { error?: Error }) => {
+        const message = e.error?.message ?? "";
+        if (!degraded && basemap !== false && !map?.isStyleLoaded() && /fetch|network|ajax/i.test(message)) {
+          degraded = true;
+          map?.setStyle(offlineStyle);
+        }
+      });
+
+      // Re-apply the overlay whenever a style finishes loading (initial load and
+      // the offline-fallback setStyle both drop any previously-added sources).
+      map.on("styledata", () => {
+        if (lastFcRef.current !== null || map?.getSource("portaljs-geoquery")) {
+          paintOverlay(lastFcRef.current);
+        }
+      });
+
+      // --- DuckDB-Wasm + spatial ---
+      let workerUrl: string | null = null;
+      try {
+        const bundles = duckdbMod.getJsDelivrBundles();
+        const bundle = await duckdbMod.selectBundle(bundles);
+        workerUrl = URL.createObjectURL(
+          new Blob([`importScripts("${bundle.mainWorker}");`], { type: "text/javascript" })
+        );
+        const worker = new Worker(workerUrl);
+        const logger = new duckdbMod.ConsoleLogger(duckdbMod.LogLevel.WARNING);
+        const db = new duckdbMod.AsyncDuckDB(logger, worker);
+        await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+        const conn = await db.connect();
+        workerRef.current = worker;
+        dbRef.current = db;
+        connRef.current = conn;
+
+        // The spatial extension gives ST_*; it loads in WASM from the extension
+        // repository. Once loaded, read_parquet auto-decodes the GeoParquet
+        // geometry column to the GEOMETRY type.
+        await conn.query("INSTALL spatial; LOAD spatial;");
+
+        // Register the remote file over HTTP and expose it as the VIEW `data` so
+        // projection + predicate pushdown reach the file over range requests —
+        // directIO=true reads it in place (footer + touched row groups only),
+        // never downloading the whole file.
+        const absoluteUrl = new URL(url, window.location.href).toString();
+        await db.registerFileURL(
+          "geo.parquet",
+          absoluteUrl,
+          duckdbMod.DuckDBDataProtocol.HTTP,
+          true
+        );
+        await conn.query(
+          `CREATE OR REPLACE VIEW data AS SELECT * FROM read_parquet(${sqlStr("geo.parquet")})`
+        );
+      } catch (e) {
+        if (workerUrl) URL.revokeObjectURL(workerUrl);
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not open the query engine.");
+        return;
+      } finally {
+        if (workerUrl) URL.revokeObjectURL(workerUrl);
+      }
+      if (cancelled) return;
+
+      // Click-to-inspect: a MapLibre click gives a lng/lat; DuckDB does the exact
+      // point-in-polygon and returns the FULL attribute row (not just the columns
+      // the overlay query selected).
+      map.on("click", async (e: MapMouseEvent) => {
+        const conn = connRef.current;
+        if (!conn) return;
+        try {
+          const sql =
+            `SELECT * EXCLUDE ("${geometryColumn}"${bboxColumn ? `, "${bboxColumn}"` : ""}) ` +
+            `FROM data WHERE ST_Intersects("${geometryColumn}", ST_Point(${e.lngLat.lng}, ${e.lngLat.lat})) LIMIT 1`;
+          const table = await conn.query(sql);
+          const arr = table.toArray();
+          if (!arr.length) {
+            setInspected(null);
+            return;
+          }
+          const props = arr[0].toJSON() as Record<string, unknown>;
+          for (const k of Object.keys(props)) {
+            if (typeof props[k] === "bigint") props[k] = Number(props[k]);
+          }
+          setInspected({ lngLat: [e.lngLat.lng, e.lngLat.lat], properties: props });
+          setAnchor({ x: e.point.x, y: e.point.y });
+        } catch {
+          /* a failed inspect lookup shouldn't surface as a fatal error */
+        }
+      });
+
+      map.once("load", () => {
+        if (cancelled) return;
+        setReady(true);
+        void run(query ?? initialSql);
+      });
+    })().catch((e) => {
+      if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load the map libraries.");
+    });
+
+    return () => {
+      cancelled = true;
+      mapRef.current = null;
+      lastFcRef.current = null;
+      void connRef.current?.close?.();
+      void dbRef.current?.terminate?.();
+      workerRef.current?.terminate();
+      connRef.current = null;
+      dbRef.current = null;
+      workerRef.current = null;
+      map?.remove();
+    };
+    // Rebuild everything when the source or view config changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, basemap, center?.[0], center?.[1], zoom]);
+
+  // Keep the inspect popup glued to its geographic anchor while panning/zooming.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !inspected) return;
+    const reproject = () => {
+      const p = map.project(inspected.lngLat);
+      setAnchor({ x: p.x, y: p.y });
+    };
+    reproject();
+    map.on("move", reproject);
+    return () => {
+      map.off("move", reproject);
+    };
+  }, [inspected]);
+
+  const zoomBy = (delta: number) => {
+    const map = mapRef.current;
+    if (!map) return;
+    map.zoomTo(map.getZoom() + delta, { duration: 200 });
+  };
+
+  const inspectEntries = inspected ? Object.entries(inspected.properties) : [];
+
+  return (
+    <div style={{ fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif" }}>
+      {/* SQL panel. */}
+      <div style={{ border: "1px solid rgba(0,0,0,0.18)", marginBottom: 10 }}>
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") void run();
+          }}
+          rows={5}
+          spellCheck={false}
+          disabled={!ready}
+          style={{
+            display: "block",
+            width: "100%",
+            resize: "vertical",
+            border: 0,
+            boxSizing: "border-box",
+            padding: "12px 14px",
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            fontSize: 13,
+            lineHeight: 1.5,
+            color: "#1c1c1c",
+            background: "#f6f4ee",
+            outline: "none",
+          }}
+        />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 8,
+            borderTop: "1px solid rgba(0,0,0,0.15)",
+            padding: "8px 12px",
+            flexWrap: "wrap",
+          }}
+        >
+          <span style={{ fontSize: 11, color: "rgba(0,0,0,0.45)", fontFamily: "ui-monospace, monospace" }}>
+            DuckDB-Wasm + spatial · queried in place over HTTP range requests · ⌘/Ctrl+Enter
+          </span>
+          <span style={{ display: "flex", gap: 8 }}>
+            <button
+              type="button"
+              onClick={queryViewport}
+              disabled={!ready || loading}
+              style={btnStyle(false, color)}
+              title="Rewrite the query to the current map viewport (bbox pre-filter → ST_Intersects)"
+            >
+              Query viewport
+            </button>
+            <button type="button" onClick={() => void run()} disabled={!ready || loading} style={btnStyle(true, color)}>
+              {loading ? "Running…" : "Run ▶"}
+            </button>
+          </span>
+        </div>
+      </div>
+
+      {/* View switcher. */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 8 }}>
+        {(["map", "table", "chart"] as ViewMode[]).map((m) => (
+          <button
+            key={m}
+            type="button"
+            onClick={() => setView(m)}
+            style={{
+              border: "1px solid rgba(0,0,0,0.2)",
+              background: view === m ? color : "#fff",
+              color: view === m ? "#fff" : "#333",
+              padding: "4px 12px",
+              fontSize: 11,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              cursor: "pointer",
+            }}
+          >
+            {m}
+          </button>
+        ))}
+        <span style={{ marginLeft: "auto", alignSelf: "center", fontSize: 11, color: "rgba(0,0,0,0.4)", fontFamily: "ui-monospace, monospace" }}>
+          {output.rows.length} rows
+        </span>
+      </div>
+
+      {error && (
+        <pre
+          style={{
+            overflowX: "auto",
+            border: "1px solid #f0b4b4",
+            background: "#fdf1f1",
+            color: "#a33",
+            padding: 12,
+            fontSize: 12,
+            fontFamily: "ui-monospace, monospace",
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {error}
+        </pre>
+      )}
+
+      {/* Map view. */}
+      <div
+        style={{
+          position: "relative",
+          height,
+          width: "100%",
+          overflow: "hidden",
+          background: "#e6e2d8",
+          display: view === "map" ? "block" : "none",
+        }}
+      >
+        <div ref={containerRef} style={{ position: "absolute", inset: 0 }} />
+
+        <div style={{ position: "absolute", top: 10, right: 10, display: "flex", flexDirection: "column", gap: 1, zIndex: 2 }}>
+          {[
+            { label: "+", title: "Zoom in", delta: 1 },
+            { label: "−", title: "Zoom out", delta: -1 },
+          ].map((b) => (
+            <button
+              key={b.label}
+              type="button"
+              aria-label={b.title}
+              title={b.title}
+              onClick={() => zoomBy(b.delta)}
+              style={{
+                width: 28,
+                height: 28,
+                border: "1px solid rgba(0,0,0,0.25)",
+                background: "#fff",
+                color: "#222",
+                fontSize: 16,
+                lineHeight: "26px",
+                cursor: "pointer",
+                padding: 0,
+              }}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+
+        {inspected && anchor && (
+          <div
+            style={{
+              position: "absolute",
+              left: anchor.x,
+              top: anchor.y,
+              transform: "translate(-50%, calc(-100% - 10px))",
+              zIndex: 3,
+              maxWidth: 280,
+              maxHeight: 220,
+              overflow: "auto",
+              background: "#fff",
+              border: "1px solid rgba(0,0,0,0.2)",
+              boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+              padding: "8px 10px",
+              fontSize: 12,
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8, marginBottom: 4 }}>
+              <strong style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.05em" }}>Feature</strong>
+              <button
+                type="button"
+                aria-label="Close"
+                onClick={() => setInspected(null)}
+                style={{ border: "none", background: "none", cursor: "pointer", fontSize: 14, lineHeight: 1, padding: 0, color: "#666" }}
+              >
+                ×
+              </button>
+            </div>
+            {inspectEntries.length === 0 ? (
+              <div style={{ color: "#666", fontStyle: "italic" }}>No properties</div>
+            ) : (
+              <table style={{ borderCollapse: "collapse", width: "100%" }}>
+                <tbody>
+                  {inspectEntries.map(([k, v]) => (
+                    <tr key={k}>
+                      <td style={{ padding: "2px 8px 2px 0", color: "#666", verticalAlign: "top", whiteSpace: "nowrap" }}>{k}</td>
+                      <td style={{ padding: "2px 0", wordBreak: "break-word" }}>{String(v)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+
+        {attribution && (
+          <div
+            style={{
+              position: "absolute",
+              right: 0,
+              bottom: 0,
+              zIndex: 2,
+              background: "rgba(255,255,255,0.75)",
+              padding: "2px 6px",
+              fontSize: 10,
+              color: "#333",
+            }}
+          >
+            {attribution}
+          </div>
+        )}
+      </div>
+
+      {/* Table view. */}
+      {view === "table" && <ResultTable columns={output.columns} rows={output.rows} />}
+
+      {/* Chart view. */}
+      {view === "chart" && <ResultChart columns={output.columns} rows={output.rows} color={color} />}
+    </div>
+  );
+};
+
+function btnStyle(primary: boolean, color: string): React.CSSProperties {
+  return {
+    border: primary ? "none" : "1px solid rgba(0,0,0,0.25)",
+    background: primary ? color : "#fff",
+    color: primary ? "#fff" : "#333",
+    padding: "6px 14px",
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    cursor: "pointer",
+  };
+}
+
+function ResultTable({ columns, rows }: { columns: string[]; rows: Record<string, unknown>[] }) {
+  if (!rows.length) return <p style={{ fontStyle: "italic", color: "rgba(0,0,0,0.55)" }}>No rows.</p>;
+  return (
+    <div style={{ overflowX: "auto", border: "1px solid rgba(0,0,0,0.18)" }}>
+      <table style={{ minWidth: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+        <thead>
+          <tr>
+            {columns.map((c) => (
+              <th
+                key={c}
+                style={{
+                  whiteSpace: "nowrap",
+                  background: "#f0ede5",
+                  padding: "10px 14px",
+                  textAlign: "left",
+                  fontSize: 11,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                  color: "rgba(0,0,0,0.6)",
+                }}
+              >
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} style={{ borderTop: "1px solid rgba(0,0,0,0.1)" }}>
+              {columns.map((c) => (
+                <td key={c} style={{ whiteSpace: "nowrap", padding: "8px 14px", fontFamily: "ui-monospace, monospace", fontSize: 12.5 }}>
+                  {formatCell(row[c])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// A dependency-free horizontal bar chart: first text column = labels, first
+// numeric column = values. Renders nothing useful when the result has no numeric
+// column (a hint is shown instead).
+function ResultChart({ columns, rows, color }: { columns: string[]; rows: Record<string, unknown>[]; color: string }) {
+  const numericCol = columns.find((c) => rows.some((r) => typeof r[c] === "number"));
+  const labelCol = columns.find((c) => c !== numericCol && rows.some((r) => typeof r[c] === "string")) ?? columns[0];
+  if (!numericCol || !rows.length) {
+    return <p style={{ fontStyle: "italic", color: "rgba(0,0,0,0.55)" }}>Add a numeric column to chart the result (e.g. an aggregate).</p>;
+  }
+  const values = rows.map((r) => Number(r[numericCol]) || 0);
+  const max = Math.max(...values, 1);
+  const shown = rows.slice(0, 30);
+  return (
+    <div style={{ border: "1px solid rgba(0,0,0,0.18)", padding: 14 }}>
+      <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.05em", color: "rgba(0,0,0,0.5)", marginBottom: 10 }}>
+        {numericCol} by {labelCol}
+      </div>
+      {shown.map((r, i) => {
+        const v = Number(r[numericCol]) || 0;
+        return (
+          <div key={i} style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 4 }}>
+            <span style={{ width: 130, flexShrink: 0, fontSize: 12, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+              {String(r[labelCol] ?? "")}
+            </span>
+            <span style={{ flex: 1, background: "#eee", height: 16, position: "relative" }}>
+              <span style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: `${(v / max) * 100}%`, background: color }} />
+            </span>
+            <span style={{ width: 90, flexShrink: 0, textAlign: "right", fontSize: 12, fontFamily: "ui-monospace, monospace" }}>
+              {v.toLocaleString()}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "object") {
+    const s = String(value);
+    return s === "[object Object]" ? JSON.stringify(value) : s;
+  }
+  return String(value);
+}

--- a/packages/core/src/ui/GeoQuery/index.ts
+++ b/packages/core/src/ui/GeoQuery/index.ts
@@ -1,0 +1,1 @@
+export { GeoQuery, GeoQueryProps } from "./GeoQuery";

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -18,6 +18,7 @@ export { UnstyledLayout } from "./UnstyledLayout";
 export { BlogLayout } from "./BlogLayout";
 export { Mermaid } from "./Mermaid";
 export { MapPreview, MapPreviewProps } from "./MapPreview";
+export { GeoQuery, GeoQueryProps } from "./GeoQuery";
 export { SiteToc, NavItem, NavGroup } from "./SiteToc";
 export { Comments, CommentsConfig } from "./Comments";
 export { AuthorConfig } from "./types";


### PR DESCRIPTION
Phase 2 of the GIS epic (po-6sr §6) — the **query tier for geometry**. Phase 1 (`<MapPreview>`, PMTiles rendering) shipped in #1644; this adds spatial SQL over a remote **GeoParquet** entirely in the browser (DuckDB-Wasm + `spatial`), rendered as a live map overlay. Pure frontend, no infra dependency — same shippable-slice pattern as Phase 1.

## What's in it
- **`@portaljs/core` `<GeoQuery>`** (exported): reads a remote GeoParquet **in place** over HTTP range requests; `INSTALL/LOAD spatial`; a **bbox-first** query (covering-bbox `WHERE` prunes Parquet row groups via column stats, then `ST_Intersects` refines the exact predicate); results → `ST_AsGeoJSON` → MapLibre GeoJSON overlay + table + bar chart; a **Query viewport** button rewrites the `WHERE` to the current map bounds; **click-to-inspect** does a DuckDB point-in-polygon lookup for full attributes. `@duckdb/duckdb-wasm` is an optional peer dep; SSR-safe (dynamic `import()`).
- **Catalog template**: `geoparquet` DataFormat + local `components/GeoQuery.tsx` wired into the showcase (`next/dynamic` `ssr:false`). `lib/query/duckdb.ts` gains a `spatial` flag. The `@reference/world-boundaries` demo is now **dual-tier** — a PMTiles resource (render) + a GeoParquet twin (query) from the same Natural Earth source (Hilbert-sorted, GeoParquet 1.1 covering bbox column), hosted on R2 via Giftless — so `<MapPreview>` + `<GeoQuery>` compose on one page.
- **Docs**: `<GeoQuery>` usage + bbox-first pattern + GeoJSON-vs-WKB decode guidance (core README); "Geo query tier" duckdb build recipe (template README).

## Design note
Chose a **MapLibre-native GeoJSON overlay** over deck.gl: deck.gl's `MapboxOverlay` broke the maplibre render (collapsed the map canvas) and added a heavy dependency. The native overlay is proven by `<MapPreview>`, keeps `@portaljs/core` lean, and the README documents WKB/GeoArrow + a GPU layer as the path for very large result sets.

## Verification (real browser, headed/WebGL)
- ✅ GeoParquet fetched from `data.portaljs.com` via **206 range reads**
- ✅ bbox-first spatial query returns correct rows (49 European countries) and renders as a **map overlay**
- ✅ **table** + **chart** views work (pop_est bars)
- ✅ **click-to-inspect** → DuckDB point-in-polygon → full attributes (Czechia: pop 10,669,709 / gdp 250,680)
- ✅ no console errors; both `@portaljs/core` and the catalog template build clean

**Do not merge** — leave on the feature branch; mayor lands after CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for browsing and querying geospatial datasets directly in the browser.
  * Introduced a new map/table/chart geospatial query view with live map overlays and click-to-inspect details.
  * Expanded dataset previews to distinguish between render and query tiers for spatial data.

* **Documentation**
  * Updated docs with guidance for querying remote GeoParquet data, including example SQL and recommended query patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->